### PR TITLE
Add batch transactions for pair flows

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -6,6 +6,7 @@
         "gateway": "https://devnet-gateway.elrond.com",
         "explorer": "https://devnet-explorer.elrond.com",
         "chainID": "D",
+        "EGLDIdentifier": "EGLD",
         "version": 1,
         "proxyTimeout": 60000,
         "timeoutLimit": 10000,

--- a/src/modules/pair/dto/pair.args.ts
+++ b/src/modules/pair/dto/pair.args.ts
@@ -35,6 +35,8 @@ export class RemoveLiquidityArgs {
     @Field()
     pairAddress: string;
     @Field()
+    sender: string;
+    @Field()
     liquidity: string;
     @Field()
     liquidityTokenID: string;
@@ -46,6 +48,8 @@ export class RemoveLiquidityArgs {
 export class SwapTokensFixedInputArgs {
     @Field()
     pairAddress: string;
+    @Field()
+    sender: string;
     @Field()
     tokenInID: string;
     @Field()
@@ -62,6 +66,8 @@ export class SwapTokensFixedInputArgs {
 export class SwapTokensFixedOutputArgs {
     @Field()
     pairAddress: string;
+    @Field()
+    sender: string;
     @Field()
     tokenInID: string;
     @Field()

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -152,24 +152,24 @@ export class PairResolver {
         return await this.transactionService.reclaimTemporaryFunds(pairAddress);
     }
 
-    @Query(returns => TransactionModel)
+    @Query(returns => [TransactionModel])
     async removeLiquidity(
         @Args() args: RemoveLiquidityArgs,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         return await this.transactionService.removeLiquidity(args);
     }
 
-    @Query(returns => TransactionModel)
+    @Query(returns => [TransactionModel])
     async swapTokensFixedInput(
         @Args() args: SwapTokensFixedInputArgs,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         return await this.transactionService.swapTokensFixedInput(args);
     }
 
-    @Query(returns => TransactionModel)
+    @Query(returns => [TransactionModel])
     async swapTokensFixedOutput(
         @Args() args: SwapTokensFixedOutputArgs,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         return await this.transactionService.swapTokensFixedOutput(args);
     }
 

--- a/src/modules/pair/transactions-pair.service.ts
+++ b/src/modules/pair/transactions-pair.service.ts
@@ -39,7 +39,7 @@ export class TransactionPairService {
 
         const wrappedTokenID = await this.wrapService.getWrappedEgldTokenID();
 
-        switch ('eGLD') {
+        switch (elrondConfig.EGLDIdentifier) {
             case args.firstTokenID:
                 eGLDwrapTransaction = this.wrapTransaction.wrapEgld(
                     args.sender,
@@ -168,11 +168,24 @@ export class TransactionPairService {
 
     async removeLiquidity(
         args: RemoveLiquidityArgs,
-    ): Promise<TransactionModel> {
-        const liquidityPosition = await this.pairService.getLiquidityPosition(
-            args.pairAddress,
-            args.liquidity,
-        );
+    ): Promise<TransactionModel[]> {
+        const transactions = [];
+        const [
+            wrappedTokenID,
+            firstTokenID,
+            secondTokenID,
+            liquidityPosition,
+            contract,
+        ] = await Promise.all([
+            this.wrapService.getWrappedEgldTokenID(),
+            this.pairService.getFirstTokenID(args.pairAddress),
+            this.pairService.getSecondTokenID(args.pairAddress),
+            this.pairService.getLiquidityPosition(
+                args.pairAddress,
+                args.liquidity,
+            ),
+            this.elrondProxy.getPairSmartContract(args.pairAddress),
+        ]);
 
         const amount0Min = new BigNumber(liquidityPosition.firstTokenAmount)
             .multipliedBy(1 - args.tolerance)
@@ -181,9 +194,6 @@ export class TransactionPairService {
             .multipliedBy(1 - args.tolerance)
             .integerValue();
 
-        const contract = await this.elrondProxy.getPairSmartContract(
-            args.pairAddress,
-        );
         const transactionArgs = [
             BytesValue.fromUTF8(args.liquidityTokenID),
             new BigUIntValue(new BigNumber(args.liquidity)),
@@ -191,17 +201,39 @@ export class TransactionPairService {
             new BigUIntValue(amount0Min),
             new BigUIntValue(amount1Min),
         ];
-
-        return this.context.esdtTransfer(
-            contract,
-            transactionArgs,
-            new GasLimit(gasConfig.removeLiquidity),
+        transactions.push(
+            this.context.esdtTransfer(
+                contract,
+                transactionArgs,
+                new GasLimit(gasConfig.removeLiquidity),
+            ),
         );
+
+        switch (wrappedTokenID) {
+            case firstTokenID:
+                transactions.push(
+                    await this.wrapTransaction.unwrapEgld(
+                        args.sender,
+                        amount0Min.toString(),
+                    ),
+                );
+                break;
+            case secondTokenID:
+                transactions.push(
+                    await this.wrapTransaction.unwrapEgld(
+                        args.sender,
+                        amount1Min.toString(),
+                    ),
+                );
+        }
+
+        return transactions;
     }
 
     async swapTokensFixedInput(
         args: SwapTokensFixedInputArgs,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
+        const transactions = [];
         const contract = await this.elrondProxy.getPairSmartContract(
             args.pairAddress,
         );
@@ -220,16 +252,55 @@ export class TransactionPairService {
             new BigUIntValue(amountOutMin),
         ];
 
-        return this.context.esdtTransfer(
-            contract,
-            transactionArgs,
-            new GasLimit(gasConfig.swapTokens),
-        );
+        switch (elrondConfig.EGLDIdentifier) {
+            case args.tokenInID:
+                transactions.push(
+                    await this.wrapTransaction.wrapEgld(
+                        args.sender,
+                        args.amountIn,
+                    ),
+                );
+                transactions.push(
+                    this.context.esdtTransfer(
+                        contract,
+                        transactionArgs,
+                        new GasLimit(gasConfig.swapTokens),
+                    ),
+                );
+                break;
+            case args.tokenOutID:
+                transactions.push(
+                    this.context.esdtTransfer(
+                        contract,
+                        transactionArgs,
+                        new GasLimit(gasConfig.swapTokens),
+                    ),
+                );
+                transactions.push(
+                    await this.wrapTransaction.unwrapEgld(
+                        args.sender,
+                        amountOutMin.toString(),
+                    ),
+                );
+                break;
+            default:
+                transactions.push(
+                    this.context.esdtTransfer(
+                        contract,
+                        transactionArgs,
+                        new GasLimit(gasConfig.swapTokens),
+                    ),
+                );
+                break;
+        }
+
+        return transactions;
     }
 
     async swapTokensFixedOutput(
         args: SwapTokensFixedOutputArgs,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
+        const transactions = [];
         const contract = await this.elrondProxy.getPairSmartContract(
             args.pairAddress,
         );
@@ -247,11 +318,49 @@ export class TransactionPairService {
             new BigUIntValue(amountOut),
         ];
 
-        return this.context.esdtTransfer(
-            contract,
-            transactionArgs,
-            new GasLimit(gasConfig.swapTokens),
-        );
+        switch (elrondConfig.EGLDIdentifier) {
+            case args.tokenInID:
+                transactions.push(
+                    await this.wrapTransaction.wrapEgld(
+                        args.sender,
+                        amountInMax.toString(),
+                    ),
+                );
+                transactions.push(
+                    this.context.esdtTransfer(
+                        contract,
+                        transactionArgs,
+                        new GasLimit(gasConfig.swapTokens),
+                    ),
+                );
+                break;
+            case args.tokenOutID:
+                transactions.push(
+                    this.context.esdtTransfer(
+                        contract,
+                        transactionArgs,
+                        new GasLimit(gasConfig.swapTokens),
+                    ),
+                );
+                transactions.push(
+                    await this.wrapTransaction.unwrapEgld(
+                        args.sender,
+                        args.amountOut,
+                    ),
+                );
+                break;
+            default:
+                transactions.push(
+                    this.context.esdtTransfer(
+                        contract,
+                        transactionArgs,
+                        new GasLimit(gasConfig.swapTokens),
+                    ),
+                );
+                break;
+        }
+
+        return transactions;
     }
 
     esdtTransferBatch(


### PR DESCRIPTION
- Remove liquidity can now unwrap EGLD
- Swap transactions can now wrap or unwrap EGLD based on input and
  output tokens

Signed-off-by: Claudiu Ion Lataretu <claudiu.lataretu@gmail.com>