### PR TITLE
Add type filter for user NFTs request

### DIFF
--- a/src/services/elrond-communication/elrond-api.service.ts
+++ b/src/services/elrond-communication/elrond-api.service.ts
@@ -125,10 +125,11 @@ export class ElrondApiService {
         address: string,
         from = 0,
         size = 100,
+        type = 'MetaESDT',
     ): Promise<NftToken[]> {
         return this.doGetGeneric(
             this.getNftsForUser.name,
-            `accounts/${address}/nfts?from=${from}&size=${size}`,
+            `accounts/${address}/nfts?from=${from}&size=${size}&type=${type}`,
             response => response,
         );
     }


### PR DESCRIPTION
- Default NFT Type for dex service: MetaESDT

Signed-off-by: Claudiu Ion Lataretu <claudiu.lataretu@gmail.com>