### PR TITLE
config: increase gas limit for enter farm with proxy and lock rewards

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -65,7 +65,7 @@
         "claimRewards": 40500000,
         "compoundRewards": 16500000,
         "enterFarmProxy": 36000000,
-        "enterFarmProxyMerge": 80500000,
+        "enterFarmProxyMerge": 83500000,
         "exitFarmProxy": 61500000,
         "compoundRewardsProxy": 38000000,
         "claimRewardsProxy": 55000000,


### PR DESCRIPTION
Signed-off-by: Claudiu Ion Lataretu <claudiu.lataretu@gmail.com>