### PR TITLE
[SERVICES-854] fix locked asset token attributes

### DIFF
--- a/src/modules/proxy/wrappedFarm.token.v2.resolver.ts
+++ b/src/modules/proxy/wrappedFarm.token.v2.resolver.ts
@@ -66,6 +66,17 @@ export class WrappedFarmTokenResolverV2 {
                         attributes: wrappedLpToken.attributes,
                         identifier: wrappedLpToken.identifier,
                     });
+                if (
+                    wrappedLpTokenDecodedAttributes.lockedTokens
+                        .tokenIdentifier === oldLockedAssetID
+                ) {
+                    return this.proxyService.getLockedAssetsAttributes(
+                        proxyAddress,
+                        wrappedLpTokenDecodedAttributes.lockedTokens
+                            .tokenIdentifier,
+                        wrappedLpTokenDecodedAttributes.lockedTokens.tokenNonce,
+                    );
+                }
                 return this.proxyService.getLockedTokenAttributes(
                     proxyAddress,
                     wrappedLpTokenDecodedAttributes.lockedTokens


### PR DESCRIPTION
- wrapped farm token attributes v2 can hold lkmex v1 and lkmex v2 tokens

Signed-off-by: Claudiu Lataretu <claudiu.lataretu@gmail.com>