### PR TITLE
SERVICES-1227: fix native auth impersonate

### DIFF
--- a/src/modules/auth/native.auth.guard.ts
+++ b/src/modules/auth/native.auth.guard.ts
@@ -49,6 +49,7 @@ export class NativeAuthGuard implements CanActivate {
                 'X-Native-Auth-Timestamp',
                 Math.round(new Date().getTime() / 1000),
             );
+            req.auth = userInfo;
 
             if (this.impersonateAddress) {
                 const admins = process.env.SECURITY_ADMINS.split(',');
@@ -60,8 +61,6 @@ export class NativeAuthGuard implements CanActivate {
                     req.auth.address = this.impersonateAddress;
                 }
             }
-
-            req.auth = userInfo;
 
             return true;
         } catch (error: any) {

--- a/src/modules/auth/native.auth.guard.ts
+++ b/src/modules/auth/native.auth.guard.ts
@@ -57,6 +57,7 @@ export class NativeAuthGuard implements CanActivate {
                         'X-Native-Auth-Address',
                         this.impersonateAddress,
                     );
+                    req.auth.address = this.impersonateAddress;
                 }
             }
 


### PR DESCRIPTION
## Reasoning
-  the auth.addres was not set to the impersonate address in case of native auth guardian.
- 
  
## Proposed Changes
- set the auth.addres to the impersonate address 

## How to test
- query a request guarded by JwtOrNativeAuthGuard. It should now behave as the impersonated address made the request.
