### PR TITLE
Allow to only retrieve X last values

### DIFF
--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -108,7 +108,8 @@ export class AnalyticsResolver {
             this.analyticsAWSGetter.getLatestCompleteValues(
                 args.series,
                 args.metric,
-                args.last,
+                args.start,
+                args.time,
             ),
         );
     }

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -108,6 +108,7 @@ export class AnalyticsResolver {
             this.analyticsAWSGetter.getLatestCompleteValues(
                 args.series,
                 args.metric,
+                args.last,
             ),
         );
     }

--- a/src/modules/analytics/models/query.args.ts
+++ b/src/modules/analytics/models/query.args.ts
@@ -1,4 +1,4 @@
-import { ArgsType, Field } from '@nestjs/graphql';
+import { ArgsType, Field, Int } from '@nestjs/graphql';
 import { Matches } from 'class-validator';
 import { IsValidMetric } from 'src/helpers/validators/metric.validator';
 import { IsValidSeries } from 'src/helpers/validators/series.validator';
@@ -19,6 +19,8 @@ export class AWSQueryArgs {
     @IsValidUnixTime()
     start: string;
     @Field({ nullable: true })
+    last?: number;
+    @Field(() => Int, { nullable: true })
     @Matches(new RegExp('[1-60][s,m,h,d]'))
     bin: string;
 }

--- a/src/modules/analytics/models/query.args.ts
+++ b/src/modules/analytics/models/query.args.ts
@@ -18,8 +18,6 @@ export class AWSQueryArgs {
     @Field({ nullable: true })
     @IsValidUnixTime()
     start: string;
-    @Field({ nullable: true })
-    last?: number;
     @Field(() => Int, { nullable: true })
     @Matches(new RegExp('[1-60][s,m,h,d]'))
     bin: string;

--- a/src/modules/analytics/services/analytics.aws.getter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.getter.service.ts
@@ -46,16 +46,21 @@ export class AnalyticsAWSGetterService extends GenericGetterService {
     async getLatestCompleteValues(
         series: string,
         metric: string,
+        last?: number,
     ): Promise<HistoricDataModel[]> {
         const cacheKey = this.getAnalyticsCacheKey(
             'latestCompleteValues',
             series,
             metric,
         );
-        return await this.getCachedData(
+        let data = await this.getCachedData<HistoricDataModel[]>(
             cacheKey,
             this.getLatestCompleteValues.name,
         );
+        if (last !== undefined) {
+            data = data.slice(-last);
+        }
+        return data;
     }
 
     async getSumCompleteValues(


### PR DESCRIPTION
## Reasoning

`latestCompleteValues` returns all the values since the beginning of xExchange. However, we might only want the last week data or last month data. Actually, we would download way more data than needed.
  
## Proposed Changes

Allow to only retrieve the last X values.

## How to test

```
{
  latestCompleteValues(metric: "priceUSD", series: "WEGLD-bd4d79", last: 5) {
    timestamp
    value
  }
}
```
