### PR TITLE
[SERVICES-1289] Filtering for latestCompleteValues

### DIFF
--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -108,6 +108,8 @@ export class AnalyticsResolver {
             this.analyticsAWSGetter.getLatestCompleteValues(
                 args.series,
                 args.metric,
+                args.start,
+                args.time,
             ),
         );
     }

--- a/src/modules/analytics/services/analytics.aws.getter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.getter.service.ts
@@ -9,6 +9,7 @@ import { GenericGetterService } from 'src/services/generics/generic.getter.servi
 import { oneMinute } from 'src/helpers/helpers';
 import { AWSTimestreamQueryService } from 'src/services/aws/aws.timestream.query';
 import { ApiConfigService } from 'src/helpers/api.config.service';
+import moment from 'moment';
 
 @Injectable()
 export class AnalyticsAWSGetterService extends GenericGetterService {
@@ -46,16 +47,42 @@ export class AnalyticsAWSGetterService extends GenericGetterService {
     async getLatestCompleteValues(
         series: string,
         metric: string,
+        start?: string,
+        time?: string,
     ): Promise<HistoricDataModel[]> {
         const cacheKey = this.getAnalyticsCacheKey(
             'latestCompleteValues',
             series,
             metric,
         );
-        return await this.getCachedData(
+        let data = await this.getCachedData<HistoricDataModel[]>(
             cacheKey,
             this.getLatestCompleteValues.name,
         );
+        if (start) {
+            const formattedStart = moment.unix(parseInt(start)).utc();
+
+            data = data.filter((historicData) =>
+                moment
+                    .utc(historicData.timestamp)
+                    .isSameOrAfter(formattedStart),
+            );
+
+            if (time) {
+                const [timeAmount, timeUnit] = time.match(/[a-zA-Z]+|[0-9]+/g);
+                const endDate = formattedStart.add(
+                    moment.duration(
+                        timeAmount,
+                        timeUnit as moment.unitOfTime.Base,
+                    ),
+                );
+                data = data.filter((historicData) =>
+                    moment.utc(historicData.timestamp).isSameOrBefore(endDate),
+                );
+            }
+        }
+
+        return data;
     }
 
     async getSumCompleteValues(


### PR DESCRIPTION
Signed-off-by: Claudiu Lataretu <claudiu.lataretu@gmail.com>

## Reasoning
- latestCompleteValues always returns all the data points
  
## Proposed Changes
- add a filtering that uses the `start` in UTC unix time and `time` to create a filtering window

## How to test
`query LatestCompleteValues {
  latestCompleteValues(metric: "priceUSD", series: "MEX-455c57", start: "1675382400", time: "2d") {
    timestamp
    value
  }
}`