### PR TITLE
[SERVICES-1411] add cache warm for USDC price from CMC

### DIFF
--- a/src/services/cache.warmer.module.ts
+++ b/src/services/cache.warmer.module.ts
@@ -33,6 +33,7 @@ import { FarmModuleV1_2 } from 'src/modules/farm/v1.2/farm.v1.2.module';
 import { FarmModuleV1_3 } from 'src/modules/farm/v1.3/farm.v1.3.module';
 import { FarmModule } from 'src/modules/farm/farm.module';
 import { AnalyticsModule as AnalyticsServicesModule } from 'src/services/analytics/analytics.module';
+import { ExternalCommunication } from './external-communication/external.communication.module';
 
 @Module({
     imports: [
@@ -42,6 +43,7 @@ import { AnalyticsModule as AnalyticsServicesModule } from 'src/services/analyti
         PairModule,
         RouterModule,
         MXCommunicationModule,
+        ExternalCommunication,
         ContextModule,
         FarmModule,
         FarmModuleV1_2,

--- a/src/services/external-communication/api.cmc.setter.service.ts
+++ b/src/services/external-communication/api.cmc.setter.service.ts
@@ -3,24 +3,23 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { oneMinute } from 'src/helpers/helpers';
 import { Logger } from 'winston';
 import { CachingService } from '../caching/cache.service';
-import { GenericGetterService } from '../generics/generic.getter.service';
-import { CMCApiService } from './api.cmc.service';
+import { GenericSetterService } from '../generics/generic.setter.service';
 
 @Injectable()
-export class CMCApiGetterService extends GenericGetterService {
+export class CMCApiSetterService extends GenericSetterService {
     constructor(
         protected readonly cachingService: CachingService,
         @Inject(WINSTON_MODULE_PROVIDER) protected readonly logger: Logger,
-        private readonly cmcApi: CMCApiService,
     ) {
         super(cachingService, logger);
+
         this.baseKey = 'cmc';
     }
 
-    async getUSDCPrice(): Promise<number> {
-        return await this.getData(
+    async setUSDCPrice(value: number): Promise<string> {
+        return await this.setData(
             this.getCacheKey('price', 'usdc'),
-            () => this.cmcApi.getUSDCPrice(),
+            value,
             oneMinute() * 5,
             oneMinute() * 3,
         );

--- a/src/services/external-communication/external.communication.module.ts
+++ b/src/services/external-communication/external.communication.module.ts
@@ -3,10 +3,11 @@ import { CommonAppModule } from 'src/common.app.module';
 import { CachingModule } from '../caching/cache.module';
 import { CMCApiGetterService } from './api.cmc.getter.service';
 import { CMCApiService } from './api.cmc.service';
+import { CMCApiSetterService } from './api.cmc.setter.service';
 
 @Module({
     imports: [CommonAppModule, CachingModule],
-    providers: [CMCApiService, CMCApiGetterService],
-    exports: [CMCApiGetterService],
+    providers: [CMCApiService, CMCApiGetterService, CMCApiSetterService],
+    exports: [CMCApiService, CMCApiGetterService, CMCApiSetterService],
 })
 export class ExternalCommunication {}


### PR DESCRIPTION
## Reasoning
- external calls to CMC from all API instances
  
## Proposed Changes
- use cache warmer to pre-warm USDC value in cache

## How to test
- only 1 request / 2 minutes should be performed to CMC
