### PR TITLE
[SERVICES-1354] xmex no penalty amount

### DIFF
--- a/src/modules/energy/services/energy.service.ts
+++ b/src/modules/energy/services/energy.service.ts
@@ -72,7 +72,7 @@ export class EnergyService {
 
         const prevLockEpochs = decodedAttributes.unlockEpoch - currentEpoch;
         if (prevLockEpochs <= 0) {
-            throw new Error('Token can be unlocked already');
+            return '0';
         }
 
         if (newLockPeriod > prevLockEpochs) {


### PR DESCRIPTION
## Reasoning
- xmex with no penalty amount returns error on query
  
## Proposed Changes
- return `0` penalty amount if xmex can be unlocked with no penalty

## How to test
- `penaltyAmount` query should not throw error if xmex is unlockable
