### PR TITLE
[SERVICES-1355] skip fees collector from outdated contracts

### DIFF
--- a/src/modules/user/services/userEnergy/user.energy.getter.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.getter.service.ts
@@ -41,6 +41,7 @@ export class UserEnergyGetterService extends GenericGetterService {
 
     async getUserOutdatedContracts(
         userAddress: string,
+        skipFeesCollector = false,
     ): Promise<OutdatedContract[]> {
         const activeFarms = await this.getUserActiveFarmsV2(userAddress);
         const userEnergy = await this.energyGetter.getEnergyEntryForUser(
@@ -50,13 +51,15 @@ export class UserEnergyGetterService extends GenericGetterService {
         const promises = activeFarms.map((farm) =>
             this.getUserOutdatedContract(userAddress, userEnergy, farm),
         );
-        promises.push(
-            this.getUserOutdatedContract(
-                userAddress,
-                userEnergy,
-                scAddress.feesCollector,
-            ),
-        );
+        if (!skipFeesCollector) {
+            promises.push(
+                this.getUserOutdatedContract(
+                    userAddress,
+                    userEnergy,
+                    scAddress.feesCollector,
+                ),
+            );
+        }
 
         const outdatedContracts = await Promise.all(promises);
         return outdatedContracts.filter(

--- a/src/modules/user/services/userEnergy/user.energy.transaction.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.transaction.service.ts
@@ -15,6 +15,7 @@ export class UserEnergyTransactionService {
     async updateFarmsEnergyForUser(
         userAddress: string,
         includeAllContracts = false,
+        skipFeesCollector = false,
     ): Promise<TransactionModel | null> {
         const endpointArgs: TypedValue[] = [
             new AddressValue(Address.fromString(userAddress)),
@@ -27,13 +28,18 @@ export class UserEnergyTransactionService {
             farms.forEach((farm) => {
                 endpointArgs.push(new AddressValue(Address.fromString(farm)));
             });
-            endpointArgs.push(
-                new AddressValue(Address.fromString(scAddress.feesCollector)),
-            );
+            if (!skipFeesCollector) {
+                endpointArgs.push(
+                    new AddressValue(
+                        Address.fromString(scAddress.feesCollector),
+                    ),
+                );
+            }
         } else {
             const contracts =
                 await this.userEnergyGetter.getUserOutdatedContracts(
                     userAddress,
+                    skipFeesCollector,
                 );
             contracts.forEach((contract) => {
                 if (contract !== undefined && !contract.claimProgressOutdated) {

--- a/src/modules/user/user.resolver.ts
+++ b/src/modules/user/user.resolver.ts
@@ -50,10 +50,13 @@ export class UserResolver {
     @UseGuards(JwtOrNativeAuthGuard)
     @Query(() => [OutdatedContract])
     async userOutdatedContracts(
+        @Args('skipFeesCollector', { nullable: true })
+        skipFeesCollector: boolean,
         @AuthUser() user: UserAuthResult,
     ): Promise<OutdatedContract[]> {
         return await this.userEnergyGetter.getUserOutdatedContracts(
             user.address,
+            skipFeesCollector,
         );
     }
 
@@ -63,10 +66,13 @@ export class UserResolver {
         @AuthUser() user: UserAuthResult,
         @Args('includeAllContracts', { nullable: true })
         includeAllContracts: boolean,
+        @Args('skipFeesCollector', { nullable: true })
+        skipFeesCollector: boolean,
     ): Promise<TransactionModel | null> {
         return await this.userEnergyTransaction.updateFarmsEnergyForUser(
             user.address,
             includeAllContracts,
+            skipFeesCollector,
         );
     }
 


### PR DESCRIPTION
## Reasoning
- users can't opt out from fees collector rewards
  
## Proposed Changes
- add option to skip checks for outdated energy on fees collector

## How to test
- `updateEnergy` transaction should not provide fees collector address if `skipFeesCollector` is true
