### PR TITLE
[SERVICES-1454] fix tokens decimals

### DIFF
--- a/src/services/multiversx-communication/mx.api.service.ts
+++ b/src/services/multiversx-communication/mx.api.service.ts
@@ -199,10 +199,21 @@ export class MXApiService {
         from = 0,
         size = 100,
     ): Promise<EsdtToken[]> {
-        return this.doGetGeneric<EsdtToken[]>(
+        const userTokens = await this.doGetGeneric<EsdtToken[]>(
             this.getTokensForUser.name,
             `accounts/${address}/tokens?from=${from}&size=${size}`,
         );
+
+        for (const token of userTokens) {
+            if (!checkEsdtToken(token) || token.decimals === 0) {
+                const gatewayToken = await this.mxProxy
+                    .getService()
+                    .getDefinitionOfFungibleToken(token.identifier);
+                token.decimals = gatewayToken.decimals;
+            }
+        }
+
+        return userTokens;
     }
 
     async getTokenForUser(

--- a/src/utils/token.type.compare.ts
+++ b/src/utils/token.type.compare.ts
@@ -101,3 +101,16 @@ export function checkEsdtToken(token: EsdtToken): boolean {
     }
     return true;
 }
+
+export function checkNftCollection(
+    collection: NftCollection | NftToken,
+): boolean {
+    if (
+        !collection.decimals ||
+        collection.decimals === undefined ||
+        collection.decimals === 0
+    ) {
+        return false;
+    }
+    return true;
+}


### PR DESCRIPTION
## Reasoning
- MVX API can provide token information with missing fields
  
## Proposed Changes
- fetch token information from MVX gateway if token object misses fields

## How to test
- `userTokens` and `userNfts` queries should always return decimals for tokens