### PR TITLE
[SERVICES-1520] fix farms v1.2 and v1.3 abi services

### DIFF
--- a/src/modules/farm/v1.2/services/farm.v1.2.abi.service.ts
+++ b/src/modules/farm/v1.2/services/farm.v1.2.abi.service.ts
@@ -2,9 +2,18 @@ import { Interaction } from '@multiversx/sdk-core';
 import { Injectable } from '@nestjs/common';
 import { FarmMigrationConfig } from '../../models/farm.model';
 import { AbiFarmService } from '../../base-module/services/farm.abi.service';
+import { MXProxyService } from 'src/services/multiversx-communication/mx.proxy.service';
+import { MXGatewayService } from 'src/services/multiversx-communication/mx.gateway.service';
 
 @Injectable()
 export class FarmAbiServiceV1_2 extends AbiFarmService {
+    constructor(
+        protected readonly mxProxy: MXProxyService,
+        protected readonly gatewayService: MXGatewayService,
+    ) {
+        super(mxProxy, gatewayService);
+    }
+
     async getFarmingTokenReserve(farmAddress: string): Promise<string> {
         const contract = await this.mxProxy.getFarmSmartContract(farmAddress);
 

--- a/src/modules/farm/v1.3/services/farm.v1.3.abi.service.ts
+++ b/src/modules/farm/v1.3/services/farm.v1.3.abi.service.ts
@@ -2,9 +2,18 @@ import { Interaction } from '@multiversx/sdk-core';
 import { Injectable } from '@nestjs/common';
 import { FarmMigrationConfig } from '../../models/farm.model';
 import { AbiFarmService } from '../../base-module/services/farm.abi.service';
+import { MXProxyService } from 'src/services/multiversx-communication/mx.proxy.service';
+import { MXGatewayService } from 'src/services/multiversx-communication/mx.gateway.service';
 
 @Injectable()
 export class FarmAbiServiceV1_3 extends AbiFarmService {
+    constructor(
+        protected readonly mxProxy: MXProxyService,
+        protected readonly gatewayService: MXGatewayService,
+    ) {
+        super(mxProxy, gatewayService);
+    }
+
     async getFarmMigrationConfiguration(
         farmAddress: string,
     ): Promise<FarmMigrationConfig | undefined> {


### PR DESCRIPTION
## Reasoning
- base farm abi service did not had mxProxy instance passed from child
  
## Proposed Changes
- add mxProxy in child constructors for farms versioned abi services

## How to test
`
farms {
  ... on FarmModelV1_2 {
	address
	farmedToken {
		identifier
	}
  }
}
`
query should return values