### PR TITLE
[SERVICES-1233] add missing injectable service

### DIFF
--- a/src/submodules/week-timekeeping/services/week-timekeeping.abi.service.ts
+++ b/src/submodules/week-timekeeping/services/week-timekeeping.abi.service.ts
@@ -1,5 +1,5 @@
 import { Interaction, SmartContract } from '@multiversx/sdk-core';
-import { Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { scAddress } from 'src/config';
 import { MXProxyService } from 'src/services/multiversx-communication/mx.proxy.service';
@@ -7,6 +7,7 @@ import { Logger } from 'winston';
 import { GenericAbiService } from '../../../services/generics/generic.abi.service';
 import { IWeekTimekeepingAbiService } from '../interfaces';
 
+@Injectable()
 export class WeekTimekeepingAbiService
     extends GenericAbiService
     implements IWeekTimekeepingAbiService


### PR DESCRIPTION
## Reasoning
- weektimekeeping abi service is not injected
  
## Proposed Changes
- add injectable decorator for abi service

## How to test
`
farms {...on FarmModelV2 {time {currentWeek}}}
`
query should return value