### PR TITLE
[SERVICES-1553] fix cached values for pair fees percents

### DIFF
--- a/src/modules/pair/services/pair.abi.service.ts
+++ b/src/modules/pair/services/pair.abi.service.ts
@@ -21,7 +21,7 @@ import {
     U64Value,
 } from '@multiversx/sdk-core';
 import { GenericAbiService } from 'src/services/generics/generic.abi.service';
-import { mxConfig } from 'src/config';
+import { constantsConfig, mxConfig } from 'src/config';
 import { VmQueryError } from 'src/utils/errors.constants';
 import { ErrorLoggerAsync } from 'src/helpers/decorators/error.logger';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
@@ -204,7 +204,10 @@ export class PairAbiService
         localTtl: CacheTtlInfo.ContractState.localTtl,
     })
     async totalFeePercent(pairAddress: string): Promise<number> {
-        return await this.getTotalFeePercentRaw(pairAddress);
+        const totalFeePercent = await this.getTotalFeePercentRaw(pairAddress);
+        return new BigNumber(totalFeePercent)
+            .dividedBy(constantsConfig.SWAP_FEE_PERCENT_BASE_POINTS)
+            .toNumber();
     }
 
     async getTotalFeePercentRaw(pairAddress: string): Promise<number> {
@@ -226,7 +229,12 @@ export class PairAbiService
         localTtl: CacheTtlInfo.ContractState.localTtl,
     })
     async specialFeePercent(pairAddress: string): Promise<number> {
-        return await this.getSpecialFeePercentRaw(pairAddress);
+        const specialFeePercent = await this.getSpecialFeePercentRaw(
+            pairAddress,
+        );
+        return new BigNumber(specialFeePercent)
+            .dividedBy(constantsConfig.SWAP_FEE_PERCENT_BASE_POINTS)
+            .toNumber();
     }
 
     async getSpecialFeePercentRaw(pairAddress: string): Promise<number> {

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -14,6 +14,8 @@ import { Locker } from 'src/utils/locker';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
+import BigNumber from 'bignumber.js';
+import { constantsConfig } from 'src/config';
 
 @Injectable()
 export class PairCacheWarmerService {
@@ -187,11 +189,15 @@ export class PairCacheWarmerService {
                 this.pairSetterService.setFeeState(pairAddress, feeState),
                 this.pairSetterService.setTotalFeePercent(
                     pairAddress,
-                    totalFeePercent,
+                    new BigNumber(totalFeePercent)
+                        .dividedBy(constantsConfig.SWAP_FEE_PERCENT_BASE_POINTS)
+                        .toNumber(),
                 ),
                 this.pairSetterService.setSpecialFeePercent(
                     pairAddress,
-                    specialFeePercent,
+                    new BigNumber(specialFeePercent)
+                        .dividedBy(constantsConfig.SWAP_FEE_PERCENT_BASE_POINTS)
+                        .toNumber(),
                 ),
             ]);
             await this.deleteCacheKeys(cachedKeys);


### PR DESCRIPTION
## Reasoning
- pairs fee percents were cached without denomination
  
## Proposed Changes
- added denomination for pair fees percents

## How to test
- `totalFeePercent` and `specialFeePercent` fields from pairs should return values in decimals: `0.003` / `0.0005` / `0.001`