### PR TITLE
[SERVICES-1535] user fees collector APR

### DIFF
--- a/src/modules/energy/energy.module.ts
+++ b/src/modules/energy/energy.module.ts
@@ -27,6 +27,11 @@ import { EnergyTransactionService } from './services/energy.transaction.service'
         EnergyTransactionService,
         EnergyResolver,
     ],
-    exports: [EnergyAbiService, EnergySetterService, EnergyComputeService],
+    exports: [
+        EnergyAbiService,
+        EnergySetterService,
+        EnergyComputeService,
+        EnergyService,
+    ],
 })
 export class EnergyModule {}

--- a/src/modules/fees-collector/fees-collector.module.ts
+++ b/src/modules/fees-collector/fees-collector.module.ts
@@ -13,6 +13,8 @@ import { FeesCollectorSetterService } from './services/fees-collector.setter.ser
 import { FeesCollectorComputeService } from './services/fees-collector.compute.service';
 import { ContextModule } from '../../services/context/context.module';
 import { FeesCollectorTransactionService } from './services/fees-collector.transaction.service';
+import { EnergyModule } from '../energy/energy.module';
+import { TokenModule } from '../tokens/token.module';
 
 @Module({
     imports: [
@@ -21,6 +23,8 @@ import { FeesCollectorTransactionService } from './services/fees-collector.trans
         forwardRef(() => WeekTimekeepingModule),
         forwardRef(() => WeeklyRewardsSplittingModule),
         ContextModule,
+        EnergyModule,
+        TokenModule,
     ],
     providers: [
         FeesCollectorService,

--- a/src/modules/fees-collector/specs/fees-collector.service.spec.ts
+++ b/src/modules/fees-collector/specs/fees-collector.service.spec.ts
@@ -22,6 +22,8 @@ import { PairComputeServiceProvider } from 'src/modules/pair/mocks/pair.compute.
 import { PairService } from 'src/modules/pair/services/pair.service';
 import { TokenGetterServiceProvider } from 'src/modules/tokens/mocks/token.getter.service.mock';
 import { WrapAbiServiceProvider } from 'src/modules/wrapping/mocks/wrap.abi.service.mock';
+import { EnergyService } from 'src/modules/energy/services/energy.service';
+import { EnergyComputeService } from 'src/modules/energy/services/energy.compute.service';
 
 describe('FeesCollectorService', () => {
     let module: TestingModule;
@@ -37,6 +39,8 @@ describe('FeesCollectorService', () => {
                 WeekTimekeepingComputeService,
                 WeeklyRewardsSplittingAbiServiceProvider,
                 WeeklyRewardsSplittingComputeService,
+                EnergyService,
+                EnergyComputeService,
                 EnergyAbiServiceProvider,
                 TokenComputeService,
                 TokenGetterServiceProvider,

--- a/src/modules/pair/mocks/pair.constants.ts
+++ b/src/modules/pair/mocks/pair.constants.ts
@@ -109,6 +109,41 @@ export const Tokens = (tokenID: string): EsdtToken => {
                 price: '1',
                 roles: new RolesModel(),
             });
+        case 'MEX-27f4cd':
+            return new EsdtToken({
+                identifier: 'MEX-27f4cd',
+                name: 'MEX',
+                ticker: 'MEX',
+                owner: 'owner_address',
+                supply: '2000000000000000000',
+                decimals: 18,
+                isPaused: false,
+                canUpgrade: true,
+                canMint: true,
+                canBurn: true,
+                canChangeOwner: true,
+                canPause: true,
+                canFreeze: true,
+                canWipe: true,
+                type: '',
+                minted: '1',
+                burnt: '1',
+                circulatingSupply: '1',
+                accounts: 1,
+                transactions: 1,
+                assets: new AssetsModel({
+                    description: '',
+                    extraTokens: [],
+                    lockedAccounts: [],
+                    pngUrl: '',
+                    status: '',
+                    svgUrl: '',
+                    website: '',
+                }),
+                initialMinted: '1',
+                price: '1',
+                roles: new RolesModel(),
+            });
         case 'TOK1USDCLP':
             return new EsdtToken({
                 identifier: 'TOK1USDCLP',

--- a/src/modules/pair/services/pair.setter.service.ts
+++ b/src/modules/pair/services/pair.setter.service.ts
@@ -172,7 +172,7 @@ export class PairSetterService extends GenericSetterService {
 
     async setTokenPriceUSD(tokenID: string, value: string): Promise<string> {
         return await this.setData(
-            this.getCacheKey('priceUSD', tokenID),
+            this.getCacheKey('tokenPriceUSD', tokenID),
             value,
             CacheTtlInfo.Price.remoteTtl,
             CacheTtlInfo.Price.localTtl,

--- a/src/submodules/weekly-rewards-splitting/mocks/weekly.rewards.splitting.abi.mock.ts
+++ b/src/submodules/weekly-rewards-splitting/mocks/weekly.rewards.splitting.abi.mock.ts
@@ -37,16 +37,16 @@ export class WeeklyRewardsSplittingAbiServiceMock
     ): Promise<EsdtTokenPayment[]> {
         return [
             new EsdtTokenPayment({
-                amount: '100',
-                tokenID: 'firstToken',
+                amount: '100000000000000000000',
+                tokenID: 'TOK1-1111',
             }),
             new EsdtTokenPayment({
-                amount: '150',
-                tokenID: 'secondToken',
+                amount: '150000000000000000000',
+                tokenID: 'TOK2-2222',
             }),
             new EsdtTokenPayment({
-                amount: '200',
-                tokenID: 'thirdToken',
+                amount: '200000000000000000000',
+                tokenID: 'TOK4-4444',
             }),
         ];
     }

--- a/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
+++ b/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
@@ -53,54 +53,69 @@ describe('WeeklyRewardsSplittingComputeService', () => {
         const service = module.get<WeeklyRewardsSplittingComputeService>(
             WeeklyRewardsSplittingComputeService,
         );
-        const usdValue = await service.computeTotalRewardsForWeekUSD([]);
+        const weeklyRewardsSplittingAbi =
+            module.get<WeeklyRewardsSplittingAbiService>(
+                WeeklyRewardsSplittingAbiService,
+            );
+        jest.spyOn(
+            weeklyRewardsSplittingAbi,
+            'totalRewardsForWeek',
+        ).mockReturnValueOnce(Promise.resolve([]));
+
+        const usdValue = await service.computeTotalRewardsForWeekUSD(
+            Address.Zero().bech32(),
+            1,
+        );
         expect(usdValue).toEqual('0');
     });
 
     it('computeTotalRewardsForWeekPriceUSD' + ' should work', async () => {
         const priceMap = new Map<string, string>();
-        priceMap.set('firstToken', '10');
-        priceMap.set('secondToken', '20');
-        priceMap.set('thirdToken', '30');
+        priceMap.set('TOK1-1111', '10');
+        priceMap.set('TOK2-2222', '20');
+        priceMap.set('TOK4-4444', '30');
 
         const service = module.get<WeeklyRewardsSplittingComputeService>(
             WeeklyRewardsSplittingComputeService,
         );
         const tokenCompute =
             module.get<TokenComputeService>(TokenComputeService);
+        const weeklyRewardsSplittingAbi =
+            module.get<WeeklyRewardsSplittingAbiService>(
+                WeeklyRewardsSplittingAbiService,
+            );
+
         jest.spyOn(
             tokenCompute,
             'computeTokenPriceDerivedUSD',
         ).mockImplementation((tokenID) => {
             return Promise.resolve(priceMap.get(tokenID));
         });
-
-        let usdValue = await service.computeTotalRewardsForWeekUSD([
-            new EsdtTokenPayment({
-                amount: '100',
-                tokenID: 'firstToken',
-            }),
-            new EsdtTokenPayment({
-                amount: '200',
-                tokenID: 'thirdToken',
-            }),
-        ]);
+        jest.spyOn(
+            weeklyRewardsSplittingAbi,
+            'totalRewardsForWeek',
+        ).mockReturnValueOnce(
+            Promise.resolve([
+                new EsdtTokenPayment({
+                    amount: '100000000000000000000',
+                    tokenID: 'TOK1-1111',
+                }),
+                new EsdtTokenPayment({
+                    amount: '200000000000000000000',
+                    tokenID: 'TOK4-4444',
+                }),
+            ]),
+        );
+        let usdValue = await service.computeTotalRewardsForWeekUSD(
+            Address.Zero().bech32(),
+            1,
+        );
         expect(usdValue).toEqual('7000'); // 100 * 10 + 200 * 30
 
-        usdValue = await service.computeTotalRewardsForWeekUSD([
-            new EsdtTokenPayment({
-                amount: '100',
-                tokenID: 'firstToken',
-            }),
-            new EsdtTokenPayment({
-                amount: '150',
-                tokenID: 'secondToken',
-            }),
-            new EsdtTokenPayment({
-                amount: '200',
-                tokenID: 'thirdToken',
-            }),
-        ]);
+        usdValue = await service.computeTotalRewardsForWeekUSD(
+            Address.Zero().bech32(),
+            1,
+        );
         expect(usdValue).toEqual('10000');
     });
 
@@ -137,9 +152,9 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             const mex = 'MEX-27f4cd';
 
             const priceMap = new Map<string, string>();
-            priceMap.set('firstToken', '10');
-            priceMap.set('secondToken', '20');
-            priceMap.set('thirdToken', '30');
+            priceMap.set('TOK1-1111', '10');
+            priceMap.set('TOK2-2222', '20');
+            priceMap.set('TOK4-4444', '30');
             priceMap.set(mex, '1');
 
             const service = module.get<WeeklyRewardsSplittingComputeService>(
@@ -163,12 +178,12 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             ).mockReturnValueOnce(
                 Promise.resolve([
                     new EsdtTokenPayment({
-                        amount: '100',
-                        tokenID: 'firstToken',
+                        amount: '100000000000000000000',
+                        tokenID: 'TOK1-1111',
                     }),
                     new EsdtTokenPayment({
-                        amount: '200',
-                        tokenID: 'thirdToken',
+                        amount: '200000000000000000000',
+                        tokenID: 'TOK4-4444',
                     }),
                 ]),
             );
@@ -184,9 +199,9 @@ describe('WeeklyRewardsSplittingComputeService', () => {
         const mex = 'MEX-27f4cd';
 
         const priceMap = new Map<string, string>();
-        priceMap.set('firstToken', '10');
-        priceMap.set('secondToken', '20');
-        priceMap.set('thirdToken', '30');
+        priceMap.set('TOK1-1111', '10');
+        priceMap.set('TOK2-2222', '20');
+        priceMap.set('TOK4-4444', '30');
         priceMap.set(mex, '1');
 
         const service = module.get<WeeklyRewardsSplittingComputeService>(
@@ -210,9 +225,9 @@ describe('WeeklyRewardsSplittingComputeService', () => {
         const mex = 'MEX-27f4cd';
 
         const priceMap = new Map<string, string>();
-        priceMap.set('firstToken', '10');
-        priceMap.set('secondToken', '20');
-        priceMap.set('thirdToken', '30');
+        priceMap.set('TOK1-1111', '10');
+        priceMap.set('TOK2-2222', '20');
+        priceMap.set('TOK4-4444', '30');
         priceMap.set(mex, '1');
 
         const totalEnergyForWeek = '1000';
@@ -260,9 +275,9 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             const mex = 'MEX-27f4cd';
 
             const priceMap = new Map<string, string>();
-            priceMap.set('firstToken', '10');
-            priceMap.set('secondToken', '20');
-            priceMap.set('thirdToken', '30');
+            priceMap.set('TOK1-1111', '10');
+            priceMap.set('TOK2-2222', '20');
+            priceMap.set('TOK4-4444', '30');
             priceMap.set(mex, '1');
             const totalEnergyForWeek = '1000';
             const totalLockedTokensForWeek = '1000';
@@ -319,9 +334,9 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             const user2 = 'erd2';
             const mex = 'MEX-27f4cd';
             const priceMap = new Map<string, string>();
-            priceMap.set('firstToken', '10');
-            priceMap.set('secondToken', '20');
-            priceMap.set('thirdToken', '30');
+            priceMap.set('TOK1-1111', '10');
+            priceMap.set('TOK2-2222', '20');
+            priceMap.set('TOK4-4444', '30');
             priceMap.set(mex, '1');
 
             const totalEnergyForWeek = '3000';
@@ -395,9 +410,9 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             const user2 = 'erd2';
             const mex = 'MEX-27f4cd';
             const priceMap = new Map<string, string>();
-            priceMap.set('firstToken', '10');
-            priceMap.set('secondToken', '20');
-            priceMap.set('thirdToken', '30');
+            priceMap.set('TOK1-1111', '10');
+            priceMap.set('TOK2-2222', '20');
+            priceMap.set('TOK4-4444', '30');
             priceMap.set(mex, '1');
 
             const totalEnergyForWeek = '3000';

--- a/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
+++ b/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
@@ -53,7 +53,7 @@ describe('WeeklyRewardsSplittingComputeService', () => {
         const service = module.get<WeeklyRewardsSplittingComputeService>(
             WeeklyRewardsSplittingComputeService,
         );
-        const usdValue = await service.computeTotalRewardsForWeekPriceUSD([]);
+        const usdValue = await service.computeTotalRewardsForWeekUSD([]);
         expect(usdValue).toEqual('0');
     });
 
@@ -75,7 +75,7 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             return Promise.resolve(priceMap.get(tokenID));
         });
 
-        let usdValue = await service.computeTotalRewardsForWeekPriceUSD([
+        let usdValue = await service.computeTotalRewardsForWeekUSD([
             new EsdtTokenPayment({
                 amount: '100',
                 tokenID: 'firstToken',
@@ -87,7 +87,7 @@ describe('WeeklyRewardsSplittingComputeService', () => {
         ]);
         expect(usdValue).toEqual('7000'); // 100 * 10 + 200 * 30
 
-        usdValue = await service.computeTotalRewardsForWeekPriceUSD([
+        usdValue = await service.computeTotalRewardsForWeekUSD([
             new EsdtTokenPayment({
                 amount: '100',
                 tokenID: 'firstToken',


### PR DESCRIPTION
## Reasoning
- compute user fees collector APR based on last week distributed rewards
  
## Proposed Changes
- fixed total rewards usd compute method from weekly module
- added method to compute user APR for fees collector
- added endpoint to get actual user APR or use new values for energy or locked tokens to simulate new APR values

## How to test
- query `userLastWeekRewards` should return an APR expressed in percentages with and without the optional arguments
