### PR TITLE
[SERVICES-1602] add native admin guard

### DIFF
--- a/src/modules/auth/gql.admin.guard.ts
+++ b/src/modules/auth/gql.admin.guard.ts
@@ -3,10 +3,10 @@ import {
     ExecutionContext,
     Inject,
     Injectable,
+    Logger,
 } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { Logger } from 'winston';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import { JwtPayload, verify } from 'jsonwebtoken';
 import { ForbiddenError } from 'apollo-server-express';
@@ -14,16 +14,19 @@ import { ForbiddenError } from 'apollo-server-express';
 @Injectable()
 export class GqlAdminGuard implements CanActivate {
     constructor(
-        @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
+        @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: Logger,
         private readonly apiConfigService: ApiConfigService,
     ) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const ctx = GqlExecutionContext.create(context);
         const { req } = ctx.getContext();
-        this.logger.error('request header', [
-            { requestIP: req.ip, request: req.headers },
-        ]);
+        this.logger.log(
+            `request header: requestIP: ${req.ip}, request: ${JSON.stringify(
+                req.headers,
+            )}`,
+            GqlAdminGuard.name,
+        );
 
         const authorization: string = req.headers['authorization'];
         if (!authorization) {
@@ -61,11 +64,7 @@ export class GqlAdminGuard implements CanActivate {
                 });
             });
         } catch (error) {
-            if (error.extensions.code === 'FORBIDDEN') {
-                this.logger.error(error.message, error.extensions);
-            } else {
-                this.logger.error(error);
-            }
+            this.logger.warn(error.message, GqlAdminGuard.name);
             return false;
         }
 

--- a/src/modules/auth/jwt.or.native.admin.guard.ts
+++ b/src/modules/auth/jwt.or.native.admin.guard.ts
@@ -1,0 +1,49 @@
+import {
+    Injectable,
+    CanActivate,
+    ExecutionContext,
+    Inject,
+    Logger,
+} from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { ApiConfigService } from 'src/helpers/api.config.service';
+import { CachingService } from 'src/services/caching/cache.service';
+import { GqlAdminGuard } from './gql.admin.guard';
+import { NativeAdminGuard } from './native.admin.guard';
+
+@Injectable()
+export class JwtOrNativeAdminGuard implements CanActivate {
+    constructor(
+        private readonly apiConfigService: ApiConfigService,
+        private readonly cachingService: CachingService,
+        @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: Logger,
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const jwtGuard = new GqlAdminGuard(this.logger, this.apiConfigService);
+        const nativeAuthGuard = new NativeAdminGuard(
+            this.apiConfigService,
+            this.cachingService,
+            this.logger,
+        );
+
+        const guards = [jwtGuard, nativeAuthGuard];
+
+        const canActivateResponses = await Promise.all(
+            guards.map((guard) => {
+                try {
+                    return guard.canActivate(context);
+                } catch (error) {
+                    this.logger.error(`${JwtOrNativeAdminGuard.name}: `, error);
+                    return false;
+                }
+            }),
+        );
+
+        const canActivate = canActivateResponses.reduce(
+            (result, value) => result || value,
+            false,
+        );
+        return canActivate;
+    }
+}

--- a/src/modules/energy/energy.resolver.ts
+++ b/src/modules/energy/energy.resolver.ts
@@ -6,7 +6,6 @@ import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { InputTokenModel } from 'src/models/inputToken.model';
 import { TransactionModel } from 'src/models/transaction.model';
-import { GqlAdminGuard } from '../auth/gql.admin.guard';
 import { JwtOrNativeAuthGuard } from '../auth/jwt.or.native.auth.guard';
 import { EsdtToken } from '../tokens/models/esdtToken.model';
 import { NftCollection } from '../tokens/models/nftCollection.model';
@@ -19,6 +18,7 @@ import { EnergyService } from './services/energy.service';
 import { EnergyTransactionService } from './services/energy.transaction.service';
 import { LockedEnergyTokensValidationPipe } from './validators/locked.tokens.validator';
 import { EnergyAbiService } from './services/energy.abi.service';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 
 @Resolver(() => SimpleLockEnergyModel)
 export class EnergyResolver {
@@ -142,7 +142,7 @@ export class EnergyResolver {
         return this.energyTransaction.migrateOldTokens(user.address, args);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async updateLockOptions(
         @Args('lockOptions', { type: () => [Int] }) lockOptions: number[],
@@ -157,7 +157,7 @@ export class EnergyResolver {
         return this.energyTransaction.updateLockOptions(lockOptions, remove);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPenaltyPercentage(
         @Args('minPenaltyPercentage') minPenaltyPercentage: number,
@@ -175,7 +175,7 @@ export class EnergyResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setFeesBurnPercentage(
         @Args('percentage') percentage: number,
@@ -189,7 +189,7 @@ export class EnergyResolver {
         return this.energyTransaction.setFeesBurnPercentage(percentage);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setFeesCollectorAddress(
         @Args('collectorAddress') collectorAddress: string,
@@ -203,7 +203,7 @@ export class EnergyResolver {
         return this.energyTransaction.setFeesCollectorAddress(collectorAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setOldLockedAssetFactoryAddress(
         @Args('oldLockedAssetFactoryAddress')

--- a/src/modules/farm/farm.transaction.resolver.ts
+++ b/src/modules/farm/farm.transaction.resolver.ts
@@ -3,7 +3,6 @@ import { Args, Query, Resolver } from '@nestjs/graphql';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { TransactionModel } from 'src/models/transaction.model';
-import { GqlAdminGuard } from 'src/modules/auth/gql.admin.guard';
 import { JwtOrNativeAuthGuard } from '../auth/jwt.or.native.auth.guard';
 import {
     ClaimRewardsArgs,
@@ -18,6 +17,7 @@ import { FarmTransactionServiceV1_2 } from './v1.2/services/farm.v1.2.transactio
 import { farmVersion } from 'src/utils/farm.utils';
 import { FarmVersion } from './models/farm.model';
 import { FarmTransactionFactory } from './farm.transaction.factory';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 
 @Resolver()
 export class FarmTransactionResolver {
@@ -38,7 +38,7 @@ export class FarmTransactionResolver {
             .mergeFarmTokens(user.address, args.farmAddress, args.payments);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async endProduceRewards(
         @Args('farmAddress') farmAddress: string,
@@ -52,7 +52,7 @@ export class FarmTransactionResolver {
             .endProduceRewards(farmAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPerBlockRewardAmount(
         @Args('farmAddress') farmAddress: string,
@@ -67,7 +67,7 @@ export class FarmTransactionResolver {
             .setPerBlockRewardAmount(farmAddress, amount);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async startProduceRewards(
         @Args('farmAddress') farmAddress: string,
@@ -81,7 +81,7 @@ export class FarmTransactionResolver {
             .startProduceRewards(farmAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPenaltyPercent(
         @Args('farmAddress') farmAddress: string,
@@ -96,7 +96,7 @@ export class FarmTransactionResolver {
             .setPenaltyPercent(farmAddress, percent);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setMinimumFarmingEpochs(
         @Args('farmAddress') farmAddress: string,
@@ -111,7 +111,7 @@ export class FarmTransactionResolver {
             .setMinimumFarmingEpochs(farmAddress, epochs);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setTransferExecGasLimit(
         @Args('farmAddress') farmAddress: string,
@@ -126,7 +126,7 @@ export class FarmTransactionResolver {
             .setTransferExecGasLimit(farmAddress, gasLimit);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setBurnGasLimit(
         @Args('farmAddress') farmAddress: string,
@@ -141,7 +141,7 @@ export class FarmTransactionResolver {
             .setBurnGasLimit(farmAddress, gasLimit);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async pause(
         @Args('farmAddress') farmAddress: string,
@@ -155,7 +155,7 @@ export class FarmTransactionResolver {
             .pause(farmAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async resume(
         @Args('farmAddress') farmAddress: string,
@@ -169,7 +169,7 @@ export class FarmTransactionResolver {
             .resume(farmAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async registerFarmToken(
         @Args('farmAddress') farmAddress: string,
@@ -191,7 +191,7 @@ export class FarmTransactionResolver {
             );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setLocalRolesFarmToken(
         @Args('farmAddress') farmAddress: string,
@@ -261,7 +261,7 @@ export class FarmTransactionResolver {
         return this.farmTransactionV1_2.migrateToNewFarm(user.address, args);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setFarmMigrationConfig(
         @Args() args: FarmMigrationConfigArgs,
@@ -276,7 +276,7 @@ export class FarmTransactionResolver {
         return this.farmTransactionV1_2.setFarmMigrationConfig(args);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async stopRewardsAndMigrateRps(
         @Args('farmAddress') farmAddress: string,

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -21,11 +21,11 @@ import { JwtOrNativeAuthGuard } from '../auth/jwt.or.native.auth.guard';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { PairInfoModel } from './models/pair-info.model';
-import { GqlAdminGuard } from '../auth/gql.admin.guard';
 import { EsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
 import { EsdtToken } from '../tokens/models/esdtToken.model';
 import { PairAbiService } from './services/pair.abi.service';
 import { PairComputeService } from './services/pair.compute.service';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 
 @Resolver(() => PairModel)
 export class PairResolver {
@@ -349,7 +349,7 @@ export class PairResolver {
         return this.pairAbi.numAddsByAddress(pairAddress, user.address);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async whitelist(
         @Args() args: WhitelistArgs,
@@ -359,7 +359,7 @@ export class PairResolver {
         return this.transactionService.whitelist(args);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async removeWhitelist(
         @Args() args: WhitelistArgs,
@@ -369,7 +369,7 @@ export class PairResolver {
         return this.transactionService.removeWhitelist(args);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async addTrustedSwapPair(
         @Args('pairAddress') pairAddress: string,
@@ -387,7 +387,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async removeTrustedSwapPair(
         @Args('pairAddress') pairAddress: string,
@@ -403,7 +403,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setTransferExecGasLimit(
         @Args('pairAddress') pairAddress: string,
@@ -417,7 +417,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setExternSwapGasLimit(
         @Args('pairAddress') pairAddress: string,
@@ -431,7 +431,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async pause(
         @Args('pairAddress') pairAddress: string,
@@ -441,7 +441,7 @@ export class PairResolver {
         return this.transactionService.pause(pairAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async resume(
         @Args('pairAddress') pairAddress: string,
@@ -451,7 +451,7 @@ export class PairResolver {
         return this.transactionService.resume(pairAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setStateActiveNoSwaps(
         @Args('pairAddress') pairAddress: string,
@@ -461,7 +461,7 @@ export class PairResolver {
         return this.transactionService.setStateActiveNoSwaps(pairAddress);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setFeePercents(
         @Args('pairAddress') pairAddress: string,
@@ -477,7 +477,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setMaxObservationsPerRecord(
         @Args('pairAddress') pairAddress: string,
@@ -491,7 +491,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setBPSwapConfig(
         @Args('pairAddress') pairAddress: string,
@@ -502,7 +502,7 @@ export class PairResolver {
         return this.transactionService.setBPSwapConfig(pairAddress, config);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setBPRemoveConfig(
         @Args('pairAddress') pairAddress: string,
@@ -513,7 +513,7 @@ export class PairResolver {
         return this.transactionService.setBPRemoveConfig(pairAddress, config);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setBPAddConfig(
         @Args('pairAddress') pairAddress: string,
@@ -524,7 +524,7 @@ export class PairResolver {
         return this.transactionService.setBPAddConfig(pairAddress, config);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setLockingDeadlineEpoch(
         @Args('pairAddress') pairAddress: string,
@@ -538,7 +538,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setLockingScAddress(
         @Args('pairAddress') pairAddress: string,
@@ -552,7 +552,7 @@ export class PairResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setUnlockEpoch(
         @Args('pairAddress') pairAddress: string,

--- a/src/modules/remote-config/remote-config.controller.ts
+++ b/src/modules/remote-config/remote-config.controller.ts
@@ -12,7 +12,6 @@ import {
 } from '@nestjs/common';
 import { FlagRepositoryService } from 'src/services/database/repositories/flag.repository';
 import { SCAddressRepositoryService } from 'src/services/database/repositories/scAddress.repository';
-import { JwtAdminGuard } from '../auth/jwt.admin.guard';
 import { FlagArgs } from './args/flag.args';
 import { FlagModel } from './models/flag.model';
 import { SCAddressModel, SCAddressType } from './models/sc-address.model';
@@ -26,6 +25,7 @@ import { CachingService } from 'src/services/caching/cache.service';
 import { AnalyticsRepositoryService } from 'src/services/database/repositories/analytics.repository';
 import { AnalyticsModel } from './models/analytics.model';
 import { AnalyticsArgs } from './args/analytics.args';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 
 @Controller('remote-config')
 export class RemoteConfigController {
@@ -36,9 +36,9 @@ export class RemoteConfigController {
         private readonly remoteConfigSetterService: RemoteConfigSetterService,
         private readonly cacheService: CachingService,
         @Inject(PUB_SUB) private pubSub: RedisPubSub,
-    ) { }
+    ) {}
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Post('/flags')
     async addRemoteConfigFlag(
         @Body() flag: FlagArgs,
@@ -64,7 +64,7 @@ export class RemoteConfigController {
         }
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Put('/flags')
     async updateRemoteConfigFlag(
         @Body() flag: FlagArgs,
@@ -72,10 +72,11 @@ export class RemoteConfigController {
     ): Promise<FlagModel | Response> {
         try {
             if (flag.name && flag.value != null) {
-                const result = await this.flagRepositoryService.findOneAndUpdate(
-                    { name: flag.name },
-                    flag,
-                );
+                const result =
+                    await this.flagRepositoryService.findOneAndUpdate(
+                        { name: flag.name },
+                        flag,
+                    );
 
                 if (result) {
                     await this.remoteConfigSetterService.setFlag(
@@ -98,13 +99,13 @@ export class RemoteConfigController {
         }
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Get('/flags')
     async getRemoteConfigFlags(): Promise<FlagModel[]> {
         return await this.flagRepositoryService.find({});
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Get('/flags/:nameOrID')
     async getRemoteConfigFlag(
         @Param('nameOrID') nameOrID: string,
@@ -116,13 +117,13 @@ export class RemoteConfigController {
                     ? { _id: nameOrID }
                     : { name: nameOrID },
             )
-            .then(result => {
+            .then((result) => {
                 if (result) return res.status(200).send(result);
                 return res.status(404).send();
             });
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Delete('/flags/:nameOrID')
     async deleteRemoteConfigFlag(
         @Param('nameOrID') nameOrID: string,
@@ -141,7 +142,7 @@ export class RemoteConfigController {
         return false;
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Post('/sc-address')
     async addRemoteConfigSCAddress(
         @Body() scAddress: SCAddressModel,
@@ -153,9 +154,8 @@ export class RemoteConfigController {
                 scAddress.category &&
                 scAddress.category in SCAddressType
             ) {
-                const newSCAddress = await this.scAddressRepositoryService.create(
-                    scAddress,
-                );
+                const newSCAddress =
+                    await this.scAddressRepositoryService.create(scAddress);
                 if (newSCAddress) {
                     await this.remoteConfigSetterService.setSCAddressesFromDB(
                         scAddress.category,
@@ -174,13 +174,13 @@ export class RemoteConfigController {
         }
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Get('/sc-address')
     async getRemoteConfigSCAddresses(): Promise<SCAddressModel[]> {
         return await this.scAddressRepositoryService.find({});
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Get('/sc-address/:addressOrID')
     async getRemoteConfigSCAddress(
         @Param('addressOrID') addressOrID: string,
@@ -192,13 +192,13 @@ export class RemoteConfigController {
                     ? { _id: addressOrID }
                     : { address: addressOrID },
             )
-            .then(result => {
+            .then((result) => {
                 if (result) return res.status(200).send(result);
                 return res.status(404).send();
             });
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Delete('/sc-address/:addressOrID')
     async deleteRemoteConfigSCAddress(
         @Param('addressOrID') addressOrID: string,
@@ -219,13 +219,13 @@ export class RemoteConfigController {
         return false;
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Get('/analytics')
     async getAnalyticsRemoteConfigs(): Promise<AnalyticsModel[]> {
         return await this.analyticsRepositoryService.find({});
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Post('/analytics')
     async upsertAnalyticsRemoteConfig(
         @Body() analytics: AnalyticsArgs,
@@ -233,12 +233,13 @@ export class RemoteConfigController {
     ): Promise<AnalyticsModel | Response> {
         try {
             if (analytics.name && analytics.value != null) {
-                const result = await this.analyticsRepositoryService.findOneAndUpdate(
-                    { name: analytics.name },
-                    analytics,
-                    undefined,
-                    true
-                )
+                const result =
+                    await this.analyticsRepositoryService.findOneAndUpdate(
+                        { name: analytics.name },
+                        analytics,
+                        undefined,
+                        true,
+                    );
                 this.remoteConfigSetterService.setAnalytics(
                     result.name,
                     result.value,
@@ -256,7 +257,7 @@ export class RemoteConfigController {
         }
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Post('/cache/delete-keys')
     async deleteCacheKeys(
         @Body() cacheKeys: CacheKeysArgs,

--- a/src/modules/router/router.resolver.ts
+++ b/src/modules/router/router.resolver.ts
@@ -18,11 +18,11 @@ import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { RemoteConfigGetterService } from '../remote-config/remote-config.getter.service';
 import { InputTokenModel } from 'src/models/inputToken.model';
-import { GqlAdminGuard } from '../auth/gql.admin.guard';
 import { SetLocalRoleOwnerArgs } from './models/router.args';
 import { PairFilterArgs } from './models/filter.args';
 import { RouterAbiService } from './services/router.abi.service';
 import { RouterComputeService } from './services/router.compute.service';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 
 @Resolver(() => FactoryModel)
 export class RouterResolver {
@@ -166,7 +166,7 @@ export class RouterResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async upgradePair(
         @Args('firstTokenID') firstTokenID: string,
@@ -204,7 +204,7 @@ export class RouterResolver {
         return this.routerTransaction.setLocalRoles(address);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setState(
         @Args('address') address: string,
@@ -215,7 +215,7 @@ export class RouterResolver {
         return this.routerTransaction.setState(address, enable);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setFee(
         @Args('pairAddress') pairAddress: string,
@@ -233,7 +233,7 @@ export class RouterResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPairCreationEnabled(
         @Args('enabled') enabled: boolean,
@@ -248,7 +248,7 @@ export class RouterResolver {
         return await this.routerabi.lastErrorMessage();
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async clearPairTemporaryOwnerStorage(
         @AuthUser() user: UserAuthResult,
@@ -257,7 +257,7 @@ export class RouterResolver {
         return this.routerTransaction.clearPairTemporaryOwnerStorage();
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setTemporaryOwnerPeriod(
         @Args('periodBlocks') periodBlocks: string,
@@ -267,7 +267,7 @@ export class RouterResolver {
         return this.routerTransaction.setTemporaryOwnerPeriod(periodBlocks);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPairTemplateAddress(
         @Args('address') address: string,
@@ -277,7 +277,7 @@ export class RouterResolver {
         return this.routerTransaction.setPairTemplateAddress(address);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setLocalRolesOwner(
         @Args({ name: 'args', type: () => SetLocalRoleOwnerArgs })
@@ -288,7 +288,7 @@ export class RouterResolver {
         return this.routerTransaction.setLocalRolesOwner(args);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async removePair(
         @Args('firstTokenID') firstTokenID: string,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -3,7 +3,6 @@ import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { TransactionModel } from 'src/models/transaction.model';
-import { GqlAdminGuard } from '../auth/gql.admin.guard';
 import { JwtOrNativeAuthGuard } from '../auth/jwt.or.native.auth.guard';
 import { BatchFarmRewardsComputeArgs } from '../farm/models/farm.args';
 import { DecodeAttributesArgs } from '../proxy/models/proxy.args';
@@ -21,6 +20,7 @@ import { StakingService } from './services/staking.service';
 import { StakingTransactionService } from './services/staking.transactions.service';
 import { StakingAbiService } from './services/staking.abi.service';
 import { StakingComputeService } from './services/staking.compute.service';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 
 @Resolver(() => StakingModel)
 export class StakingResolver {
@@ -190,7 +190,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPenaltyPercent(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -204,7 +204,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setMinimumFarmingEpochs(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -218,7 +218,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPerBlockRewardAmount(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -232,7 +232,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setMaxApr(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -246,7 +246,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setMinUnbondEpochs(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -260,7 +260,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async startProduceRewards(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -273,7 +273,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async endProduceRewards(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -286,7 +286,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setBurnGasLimit(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -300,7 +300,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setTransferExecGasLimit(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -314,7 +314,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async addAddressToWhitelist(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -329,7 +329,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async removeAddressFromWhitelist(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -344,7 +344,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async registerFarmToken(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -362,7 +362,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async pause(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -375,7 +375,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async resume(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -385,7 +385,7 @@ export class StakingResolver {
         return this.stakingTransactionService.setState(farmStakeAddress, true);
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setLocalRolesFarmToken(
         @Args('farmStakeAddress') farmStakeAddress: string,
@@ -450,7 +450,7 @@ export class StakingResolver {
         );
     }
 
-    @UseGuards(GqlAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async topUpRewards(
         @Args() args: GenericStakeFarmArgs,

--- a/src/modules/tokens/token.controller.ts
+++ b/src/modules/tokens/token.controller.ts
@@ -1,8 +1,8 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
-import { JwtAdminGuard } from '../auth/jwt.admin.guard';
 import { CreateTokenDto } from './dto/create.token.dto';
 import { TokenRepositoryService } from './services/token.repository.service';
 import { TokenSetterService } from './services/token.setter.service';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 
 @Controller()
 export class TokenController {
@@ -11,7 +11,7 @@ export class TokenController {
         private readonly tokenSetter: TokenSetterService,
     ) {}
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Post('/token/create')
     async createToken(@Body() createTokenDto: CreateTokenDto) {
         await this.tokenRepositoryService.create(createTokenDto);
@@ -21,7 +21,7 @@ export class TokenController {
         );
     }
 
-    @UseGuards(JwtAdminGuard)
+    @UseGuards(JwtOrNativeAdminGuard)
     @Post('/token/update')
     async updateToken(@Body() updateTokenDto: CreateTokenDto) {
         await this.tokenRepositoryService.updateToken(updateTokenDto);


### PR DESCRIPTION
## Reasoning
- Native auth for admins missing
  
## Proposed Changes
- added native auth guard for admin
- added jwt or native auth guard for admins

## How to test
- with admin address set, query any endpoint guarded with `JwtOrNativeAdminGuard`. Should work for whitelisted admins and fail for other addresses
