### PR TITLE
[SERVICES-1573] price discovery new charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "build": "nest build",
         "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
         "start": "nest start",
-        "start:dev": "npm run copy-env && nest start --watch",
+        "start:dev": "npm run copy-env && TZ=UTC nest start --watch",
         "start:debug": "nest start --debug --watch",
         "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
         "copy-env": "cp .env.example .env",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
         "test:e2e": "jest --config ./test/jest-e2e.json",
         "typeorm": "ts-node ./node_modules/typeorm/cli",
-        "typeorm:run-migrations": "npm run typeorm migration:run -- -d ./src/services/analytics/data-api/migration/typeOrm.config.ts",
-        "typeorm:generate-migration": "npm run typeorm -- -d ./src/services/analytics/data-api/migration/typeOrm.config.ts migration:generate ./src/services/analytics/data-api/migration/xExchange",
-        "typeorm:create-migration": "npm run typeorm -- migration:create ./src/services/analytics/data-api/migration/xExchange",
-        "typeorm:revert-migration": "npm run typeorm -- -d ./src/services/analytics/data-api/migration/typeOrm.config.ts migration:revert"
+        "typeorm:run-migrations": "npm run typeorm migration:run -- -d ./src/services/analytics/timescaledb/migration/typeOrm.config.ts",
+        "typeorm:generate-migration": "npm run typeorm -- -d ./src/services/analytics/timescaledb/migration/typeOrm.config.ts migration:generate ./src/services/analytics/timescaledb/migration/xExchange",
+        "typeorm:create-migration": "npm run typeorm -- migration:create ./src/services/analytics/timescaledb/migration/xExchange",
+        "typeorm:revert-migration": "npm run typeorm -- -d ./src/services/analytics/timescaledb/migration/typeOrm.config.ts migration:revert"
     },
     "dependencies": {
         "@apollo/gateway": "^2.0.5",

--- a/src/config/devnet.json
+++ b/src/config/devnet.json
@@ -29,7 +29,8 @@
             "erd1qqqqqqqqqqqqqpgqpzlhg54w5upaeweyc6kugqspunpywwvx0n4sa9spnk",
             "erd1qqqqqqqqqqqqqpgq5daxqzyl8hxug8zyplweugxsh62vyqaw0n4sc69ndf",
             "erd1qqqqqqqqqqqqqpgqzczn45apvnacfl6qhqnydz4gwxmtxj8k0n4synvktu",
-            "erd1qqqqqqqqqqqqqpgq7ycg0y45frcxupcpyvqlpvnuclkuscj30n4sgla0tf"
+            "erd1qqqqqqqqqqqqqpgq7ycg0y45frcxupcpyvqlpvnuclkuscj30n4sgla0tf",
+            "erd1qqqqqqqqqqqqqpgq6dszt34rl3zffwvfce8meq8e63zss5v70n4srreusz"
         ],
         "staking": [
             "erd1qqqqqqqqqqqqqpgq8w0s682m88xae2ne3qkq7w2h26u5a5c00n4stt02d7",

--- a/src/helpers/validators/metric.validator.ts
+++ b/src/helpers/validators/metric.validator.ts
@@ -28,6 +28,7 @@ const metrics = [
     'launchedTokenPrice',
     'acceptedTokenPrice',
     'launchedTokenPriceUSD',
+    'acceptedTokenPriceUSD',
     'feeBurned',
     'penaltyBurned',
 ];

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -2,7 +2,7 @@ import { UsePipes, ValidationPipe } from '@nestjs/common';
 import { Int, Query } from '@nestjs/graphql';
 import { Args, Resolver } from '@nestjs/graphql';
 import { HistoricDataModel } from 'src/modules/analytics/models/analytics.model';
-import { AWSQueryArgs } from './models/query.args';
+import { AnalyticsQueryArgs } from './models/query.args';
 import { AnalyticsAWSGetterService } from './services/analytics.aws.getter.service';
 import { TokenGetterService } from '../tokens/services/token.getter.service';
 import { AnalyticsComputeService } from './services/analytics.compute.service';
@@ -79,7 +79,7 @@ export class AnalyticsResolver {
         }),
     )
     async latestCompleteValues(
-        @Args() args: AWSQueryArgs,
+        @Args() args: AnalyticsQueryArgs,
     ): Promise<HistoricDataModel[]> {
         return this.analyticsAWSGetter.getLatestCompleteValues(
             args.series,
@@ -98,7 +98,7 @@ export class AnalyticsResolver {
         }),
     )
     async sumCompleteValues(
-        @Args() args: AWSQueryArgs,
+        @Args() args: AnalyticsQueryArgs,
     ): Promise<HistoricDataModel[]> {
         return this.analyticsAWSGetter.getSumCompleteValues(
             args.series,
@@ -114,7 +114,9 @@ export class AnalyticsResolver {
             skipUndefinedProperties: true,
         }),
     )
-    async values24h(@Args() args: AWSQueryArgs): Promise<HistoricDataModel[]> {
+    async values24h(
+        @Args() args: AnalyticsQueryArgs,
+    ): Promise<HistoricDataModel[]> {
         return this.analyticsAWSGetter.getValues24h(args.series, args.metric);
     }
 
@@ -127,7 +129,7 @@ export class AnalyticsResolver {
         }),
     )
     async values24hSum(
-        @Args() args: AWSQueryArgs,
+        @Args() args: AnalyticsQueryArgs,
     ): Promise<HistoricDataModel[]> {
         return this.analyticsAWSGetter.getValues24hSum(
             args.series,
@@ -146,7 +148,7 @@ export class AnalyticsResolver {
         }),
     )
     async latestHistoricData(
-        @Args() args: AWSQueryArgs,
+        @Args() args: AnalyticsQueryArgs,
     ): Promise<HistoricDataModel[]> {
         return [];
     }
@@ -162,7 +164,7 @@ export class AnalyticsResolver {
         }),
     )
     async latestBinnedHistoricData(
-        @Args() args: AWSQueryArgs,
+        @Args() args: AnalyticsQueryArgs,
     ): Promise<HistoricDataModel[]> {
         return [];
     }

--- a/src/modules/analytics/models/query.args.ts
+++ b/src/modules/analytics/models/query.args.ts
@@ -5,7 +5,7 @@ import { IsValidSeries } from 'src/helpers/validators/series.validator';
 import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
 
 @ArgsType()
-export class AWSQueryArgs {
+export class AnalyticsQueryArgs {
     @Field()
     @IsValidSeries()
     series: string;

--- a/src/modules/farm/models/farm.model.ts
+++ b/src/modules/farm/models/farm.model.ts
@@ -1,5 +1,4 @@
 import { Field, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
-import { LockedAssetModel } from 'src/modules/locked-asset-factory/models/locked-asset.model';
 import { PairModel } from 'src/modules/pair/models/pair.model';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';

--- a/src/modules/price-discovery/models/price.discovery.args.ts
+++ b/src/modules/price-discovery/models/price.discovery.args.ts
@@ -1,0 +1,26 @@
+import { ArgsType, Field, registerEnumType } from '@nestjs/graphql';
+import {
+    IsValidPDBucket,
+    IsValidPDMetric,
+} from '../validators/pd.args.validator';
+
+export enum PDMetricsBuckets {
+    MINUTE_1 = '1 minute',
+    MINUTES_5 = '5 minutes',
+    MINUTES_30 = '30 minutes',
+    HOUR_1 = '1 hour',
+}
+
+registerEnumType(PDMetricsBuckets, { name: 'PDMetricsBuckets' });
+
+@ArgsType()
+export class PDAnalyticsArgs {
+    @Field()
+    priceDiscoveryAddress: string;
+    @Field()
+    @IsValidPDMetric()
+    metric: string;
+    @Field(() => PDMetricsBuckets)
+    @IsValidPDBucket()
+    bucket: PDMetricsBuckets;
+}

--- a/src/modules/price-discovery/price.discovery.resolver.ts
+++ b/src/modules/price-discovery/price.discovery.resolver.ts
@@ -1,4 +1,4 @@
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, UsePipes, ValidationPipe } from '@nestjs/common';
 import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
@@ -16,6 +16,8 @@ import { PriceDiscoveryTransactionService } from './services/price.discovery.tra
 import { SimpleLockModel } from '../simple-lock/models/simple.lock.model';
 import { PriceDiscoveryAbiService } from './services/price.discovery.abi.service';
 import { PriceDiscoveryComputeService } from './services/price.discovery.compute.service';
+import { HistoricDataModel } from '../analytics/models/analytics.model';
+import { PDAnalyticsArgs } from './models/price.discovery.args';
 
 @Resolver(() => PriceDiscoveryModel)
 export class PriceDiscoveryResolver {
@@ -282,6 +284,24 @@ export class PriceDiscoveryResolver {
             user.address,
             inputTokens,
             'redeem',
+        );
+    }
+
+    @Query(() => [HistoricDataModel])
+    @UsePipes(
+        new ValidationPipe({
+            skipNullProperties: true,
+            skipMissingProperties: true,
+            skipUndefinedProperties: true,
+        }),
+    )
+    async closingValues(
+        @Args() args: PDAnalyticsArgs,
+    ): Promise<HistoricDataModel[]> {
+        return this.priceDiscoveryCompute.closingValues(
+            args.priceDiscoveryAddress,
+            args.metric,
+            args.bucket,
         );
     }
 }

--- a/src/modules/price-discovery/services/price.discovery.compute.service.ts
+++ b/src/modules/price-discovery/services/price.discovery.compute.service.ts
@@ -93,13 +93,13 @@ export class PriceDiscoveryComputeService
             priceDiscoveryAddress,
         );
 
-        // if (phase.name === 'Redeem') {
-        //     const latestPrice = await this.analyticsQuery.latestValue({
-        //         series: priceDiscoveryAddress,
-        //         metric: 'acceptedTokenPrice',
-        //     });
-        //     return latestPrice?.value ?? '0';
-        // }
+        if (phase.name === 'Redeem') {
+            const latestPrice = await this.analyticsQuery.getPDlatestValue({
+                series: priceDiscoveryAddress,
+                metric: 'acceptedTokenPrice',
+            });
+            return latestPrice?.value ?? '0';
+        }
 
         const [
             launchedToken,

--- a/src/modules/price-discovery/services/price.discovery.compute.service.ts
+++ b/src/modules/price-discovery/services/price.discovery.compute.service.ts
@@ -229,7 +229,6 @@ export class PriceDiscoveryComputeService
         metric: string,
         interval: string,
     ): Promise<HistoricDataModel[]> {
-        console.log('Get from timescale');
         return await this.analyticsQuery.getPDCloseValues({
             series: priceDiscoveryAddress,
             metric,

--- a/src/modules/price-discovery/validators/pd.args.validator.ts
+++ b/src/modules/price-discovery/validators/pd.args.validator.ts
@@ -1,0 +1,65 @@
+import {
+    registerDecorator,
+    ValidationOptions,
+    ValidatorConstraint,
+    ValidatorConstraintInterface,
+} from 'class-validator';
+import { PDMetricsBuckets } from '../models/price.discovery.args';
+
+const metrics = [
+    'launchedTokenAmount',
+    'acceptedTokenAmount',
+    'launchedTokenPrice',
+    'acceptedTokenPrice',
+    'launchedTokenPriceUSD',
+    'acceptedTokenPriceUSD',
+];
+
+@ValidatorConstraint()
+export class IsValidMetricConstraint implements ValidatorConstraintInterface {
+    validate(metric: string): boolean {
+        return metrics.includes(metric);
+    }
+
+    defaultMessage() {
+        // here you can provide default error message if validation failed
+        return 'Invalid price discovery metric';
+    }
+}
+
+export function IsValidPDMetric(validationOptions?: ValidationOptions) {
+    return (object: any, propertyName: string) => {
+        registerDecorator({
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: IsValidMetricConstraint,
+        });
+    };
+}
+
+@ValidatorConstraint()
+export class IsValidBucketConstraint implements ValidatorConstraintInterface {
+    validate(bucket: PDMetricsBuckets): boolean {
+        console.log(Object.values(PDMetricsBuckets).includes(bucket));
+        return Object.values(PDMetricsBuckets).includes(bucket);
+    }
+
+    defaultMessage() {
+        // here you can provide default error message if validation failed
+        return 'Invalid price discovery bucket';
+    }
+}
+
+export function IsValidPDBucket(validationOptions?: ValidationOptions) {
+    return (object: any, propertyName: string) => {
+        registerDecorator({
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: IsValidBucketConstraint,
+        });
+    };
+}

--- a/src/modules/price-discovery/validators/pd.args.validator.ts
+++ b/src/modules/price-discovery/validators/pd.args.validator.ts
@@ -42,7 +42,6 @@ export function IsValidPDMetric(validationOptions?: ValidationOptions) {
 @ValidatorConstraint()
 export class IsValidBucketConstraint implements ValidatorConstraintInterface {
     validate(bucket: PDMetricsBuckets): boolean {
-        console.log(Object.values(PDMetricsBuckets).includes(bucket));
         return Object.values(PDMetricsBuckets).includes(bucket);
     }
 

--- a/src/modules/rabbitmq/handlers/price.discovery.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/price.discovery.handler.service.ts
@@ -61,11 +61,18 @@ export class PriceDiscoveryEventHandler {
 
         await this.deleteCacheKeys(cacheKeys);
 
-        const [acceptedTokenPrice, launchedTokenPriceUSD] = await Promise.all([
+        const [
+            acceptedTokenPrice,
+            launchedTokenPriceUSD,
+            acceptedTokenPriceUSD,
+        ] = await Promise.all([
             this.priceDiscoveryCompute.computeAcceptedTokenPrice(
                 priceDiscoveryAddress,
             ),
             this.priceDiscoveryCompute.computeLaunchedTokenPriceUSD(
+                priceDiscoveryAddress,
+            ),
+            this.priceDiscoveryCompute.computeAcceptedTokenPriceUSD(
                 priceDiscoveryAddress,
             ),
         ]);
@@ -99,6 +106,7 @@ export class PriceDiscoveryEventHandler {
             launchedTokenPrice,
             acceptedTokenPrice,
             launchedTokenPriceUSD,
+            acceptedTokenPriceUSD,
         };
 
         return [data, timestamp];

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -53,7 +53,6 @@ import { FeesCollectorHandlerService } from './handlers/feesCollector.handler.se
 import { WeeklyRewardsSplittingHandlerService } from './handlers/weeklyRewardsSplitting.handler.service';
 import { TokenUnstakeHandlerService } from './handlers/token.unstake.handler.service';
 import { AnalyticsWriteService } from 'src/services/analytics/services/analytics.write.service';
-import { ApiConfigService } from 'src/helpers/api.config.service';
 import { RouterAbiService } from '../router/services/router.abi.service';
 
 @Injectable()
@@ -62,7 +61,6 @@ export class RabbitMqConsumer {
     private data: any[];
 
     constructor(
-        private readonly apiConfig: ApiConfigService,
         private readonly routerAbi: RouterAbiService,
         private readonly liquidityHandler: LiquidityHandler,
         private readonly swapHandler: SwapEventHandler,

--- a/src/services/analytics/interfaces/analytics.query.interface.ts
+++ b/src/services/analytics/interfaces/analytics.query.interface.ts
@@ -15,4 +15,15 @@ export interface AnalyticsQueryInterface {
     getValues24h(args: AnalyticsQueryArgs): Promise<HistoricDataModel[]>;
 
     getValues24hSum(args: AnalyticsQueryArgs): Promise<HistoricDataModel[]>;
+
+    getPDlatestValue({
+        series,
+        metric,
+    }: AnalyticsQueryArgs): Promise<HistoricDataModel>;
+
+    getPDCloseValues({
+        series,
+        metric,
+        timeBucket,
+    }): Promise<HistoricDataModel[]>;
 }

--- a/src/services/analytics/mocks/analytics.query.service.mock.ts
+++ b/src/services/analytics/mocks/analytics.query.service.mock.ts
@@ -4,6 +4,23 @@ import { AnalyticsQueryInterface } from '../interfaces/analytics.query.interface
 import { AnalyticsQueryService } from '../services/analytics.query.service';
 
 export class AnalyticsQueryServiceMock implements AnalyticsQueryInterface {
+    getPDlatestValue({
+        series,
+        metric,
+    }: AnalyticsQueryArgs): Promise<HistoricDataModel> {
+        throw new Error('Method not implemented.');
+    }
+    getPDCloseValues({
+        series,
+        metric,
+        timeBucket,
+    }: {
+        series: any;
+        metric: any;
+        timeBucket: any;
+    }): Promise<HistoricDataModel[]> {
+        throw new Error('Method not implemented.');
+    }
     getAggregatedValue(args: AnalyticsQueryArgs): Promise<string> {
         throw new Error('Method not implemented.');
     }

--- a/src/services/analytics/services/analytics.query.service.ts
+++ b/src/services/analytics/services/analytics.query.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { HistoricDataModel } from 'src/modules/analytics/models/analytics.model';
 import { TimescaleDBQueryService } from '../timescaledb/timescaledb.query.service';
 import { AnalyticsQueryInterface } from '../interfaces/analytics.query.interface';
+import { AnalyticsQueryArgs } from '../entities/analytics.query.args';
 
 @Injectable()
 export class AnalyticsQueryService implements AnalyticsQueryInterface {
@@ -46,6 +47,27 @@ export class AnalyticsQueryService implements AnalyticsQueryInterface {
     }): Promise<HistoricDataModel[]> {
         const service = await this.getService();
         return await service.getValues24hSum(args);
+    }
+
+    async getPDlatestValue({
+        series,
+        metric,
+    }: AnalyticsQueryArgs): Promise<HistoricDataModel> {
+        const service = await this.getService();
+        return await service.getPDlatestValue({ series, metric });
+    }
+
+    async getPDCloseValues({
+        series,
+        metric,
+        timeBucket,
+    }): Promise<HistoricDataModel[]> {
+        const service = await this.getService();
+        return await service.getPDCloseValues({
+            series,
+            metric,
+            timeBucket,
+        });
     }
 
     private async getService(): Promise<AnalyticsQueryInterface> {

--- a/src/services/analytics/timescaledb/migration/1684167998347-xExchange.ts
+++ b/src/services/analytics/timescaledb/migration/1684167998347-xExchange.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class xExchange1684167998347 implements MigrationInterface {
+    name = 'xExchange1684167998347';
+    transaction = false;
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE MATERIALIZED VIEW "pd_close_minute" WITH (timescaledb.continuous) AS 
+    SELECT 
+      time_bucket('1 minute', timestamp) as time,
+      series,
+      key,
+      last(value, timestamp) as last
+    FROM "hyper_dex_analytics"
+    WHERE key IN ('launchedTokenAmount',
+        'acceptedTokenAmount',
+        'launchedTokenPrice',
+        'acceptedTokenPrice',
+        'launchedTokenPriceUSD',
+        'acceptedTokenPriceUSD')
+    AND timestamp >= NOW() - INTERVAL '1 day'
+    GROUP BY time, series, key;
+  `);
+        await queryRunner.query(
+            `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+            [
+                'public',
+                'MATERIALIZED_VIEW',
+                'pd_close_minute',
+                "SELECT \n      time_bucket('1 minute', timestamp) as time,\n      series,\n      key,\n      last(value, timestamp) as last\n    FROM \"hyper_dex_analytics\"\n    WHERE key IN ('launchedTokenAmount',\n        'acceptedTokenAmount',\n        'launchedTokenPrice',\n        'acceptedTokenPrice',\n        'launchedTokenPriceUSD',\n        'acceptedTokenPriceUSD')\n    AND timestamp >= NOW() - INTERVAL '1 day'\n    GROUP BY time, series, key;",
+            ],
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+            ['MATERIALIZED_VIEW', 'pd_close_minute', 'public'],
+        );
+        await queryRunner.query(`DROP MATERIALIZED VIEW "pd_close_minute"`);
+    }
+}

--- a/src/services/analytics/timescaledb/migration/typeOrm.config.ts
+++ b/src/services/analytics/timescaledb/migration/typeOrm.config.ts
@@ -27,5 +27,5 @@ export default new DataSource({
         CloseDaily,
         CloseHourly,
     ],
-    migrations: ['src/services/analytics/data-api/migration/*-xExchange.ts'],
+    migrations: ['src/services/analytics/timescaledb/migration/*-xExchange.ts'],
 });

--- a/src/services/analytics/timescaledb/timescaledb.module.ts
+++ b/src/services/analytics/timescaledb/timescaledb.module.ts
@@ -8,6 +8,7 @@ import { TimescaleDBWriteService } from './timescaledb.write.service';
 import {
     CloseDaily,
     CloseHourly,
+    PDCloseMinute,
     SumDaily,
     SumHourly,
     TokenBurnedWeekly,
@@ -27,12 +28,12 @@ import {
                 database: apiConfig.getTimescaleDbDatabase(),
                 username: apiConfig.getTimescaleDbUsername(),
                 password: apiConfig.getTimescaleDbPassword(),
-                // ssl: true,
-                // extra: {
-                //     ssl: {
-                //         rejectUnauthorized: false,
-                //     },
-                // },
+                ssl: true,
+                extra: {
+                    ssl: {
+                        rejectUnauthorized: false,
+                    },
+                },
                 entities: ['dist/**/*.entities.{ts,js}'],
             }),
             inject: [ApiConfigService],
@@ -44,6 +45,7 @@ import {
             CloseDaily,
             CloseHourly,
             TokenBurnedWeekly,
+            PDCloseMinute,
         ]),
     ],
     providers: [TimescaleDBQueryService, TimescaleDBWriteService],

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -1,17 +1,13 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import moment from 'moment';
-import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { HistoricDataModel } from 'src/modules/analytics/models/analytics.model';
-import {
-    computeTimeInterval,
-    convertBinToTimeResolution,
-} from 'src/utils/analytics.utils';
-import { Logger } from 'winston';
+import { computeTimeInterval } from 'src/utils/analytics.utils';
 import { AnalyticsQueryArgs } from '../entities/analytics.query.args';
 import { AnalyticsQueryInterface } from '../interfaces/analytics.query.interface';
 import {
     CloseDaily,
     CloseHourly,
+    PDCloseMinute,
     SumDaily,
     SumHourly,
     TokenBurnedWeekly,
@@ -24,7 +20,6 @@ import { TimescaleDBQuery } from 'src/helpers/decorators/timescaledb.query.decor
 @Injectable()
 export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     constructor(
-        @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
         @InjectRepository(XExchangeAnalyticsEntity)
         private readonly dexAnalytics: Repository<XExchangeAnalyticsEntity>,
         @InjectRepository(SumDaily)
@@ -37,6 +32,8 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
         private readonly closeHourly: Repository<CloseHourly>,
         @InjectRepository(TokenBurnedWeekly)
         private readonly tokenBurnedWeekly: Repository<TokenBurnedWeekly>,
+        @InjectRepository(PDCloseMinute)
+        private readonly pdCloseMinute: Repository<PDCloseMinute>,
     ) {}
 
     @TimescaleDBQuery()
@@ -254,6 +251,55 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
                         value: row.sum ?? '0',
                     }),
             ) ?? []
+        );
+    }
+
+    @TimescaleDBQuery()
+    async getPDlatestValue({
+        series,
+        metric,
+    }: AnalyticsQueryArgs): Promise<HistoricDataModel> {
+        const query = await this.pdCloseMinute
+            .createQueryBuilder()
+            .select('time')
+            .addSelect('last')
+            .where('series = :series', { series })
+            .andWhere('key = :metric', { metric })
+            .orderBy('time', 'DESC')
+            .limit(1)
+            .getRawOne();
+
+        return query
+            ? new HistoricDataModel({
+                  value: query.last,
+                  timestamp: query.time,
+              })
+            : undefined;
+    }
+
+    @TimescaleDBQuery()
+    async getPDCloseValues({
+        series,
+        metric,
+        timeBucket,
+    }): Promise<HistoricDataModel[]> {
+        const query = await this.pdCloseMinute
+            .createQueryBuilder()
+            .select(`time_bucket_gapfill('${timeBucket}', time) as bucket`)
+            .addSelect('locf(last(last, time)) as last')
+            .where('series = :series', { series })
+            .andWhere('key = :metric', { metric })
+            .andWhere("time between now() - INTERVAL '1 day' and now()")
+            .groupBy('bucket')
+            .getRawMany();
+
+        const rows = query?.filter((row) => row.last !== null);
+        return rows.map(
+            (row) =>
+                new HistoricDataModel({
+                    timestamp: row.bucket,
+                    value: row.last,
+                }),
         );
     }
 }

--- a/src/services/crons/price.discovery.cache.warmer.service.ts
+++ b/src/services/crons/price.discovery.cache.warmer.service.ts
@@ -167,7 +167,7 @@ export class PriceDiscoveryCacheWarmerService {
                 this.priceDiscoveryAbi.getAcceptedTokenRedeemBalanceRaw(
                     address,
                 ),
-                this.priceDiscoveryAbi.currentPhase(address),
+                this.priceDiscoveryAbi.getCurrentPhaseRaw(address),
             ]);
 
             const invalidatedKeys: string[] = await Promise.all([


### PR DESCRIPTION
## Reasoning
- transition from AWS timestream to timescaleDB only
- use optimised queries for price discovery charts
  
## Proposed Changes
- added new continuous aggregate for price discovery chart values
- use last registered values for price discovery launched and accepted tokens
- code cleanup

## How to test
- last tokens price: `acceptedTokenPriceUSD` and `launchedTokenPriceUSD` should remain the same even after price change on swaps
```
query PriceDiscovery {
	priceDiscoveryContracts {
		address
		acceptedTokenPrice
		acceptedTokenPriceUSD
		launchedTokenPrice
		launchedTokenPriceUSD
	}
}
```
- closing values:
```
query ClosedValues {
	closingValues(
		priceDiscoveryAddress: "erd1qqqqqqqqqqqqqpgq6dszt34rl3zffwvfce8meq8e63zss5v70n4srreusz",
		metric: "launchedTokenPrice",
		bucket: MINUTES_30
	) {
		timestamp
		value
	}
}
```