### PR TITLE
[SERVICES-1657] improve pair reserves caching update

### DIFF
--- a/src/modules/pair/services/pair.abi.service.ts
+++ b/src/modules/pair/services/pair.abi.service.ts
@@ -124,14 +124,32 @@ export class PairAbiService
         return await this.getTokenReserveRaw(pairAddress, tokenID);
     }
 
+    @ErrorLoggerAsync({
+        className: PairAbiService.name,
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'pair',
+        remoteTtl: CacheTtlInfo.ContractBalance.remoteTtl,
+        localTtl: CacheTtlInfo.ContractBalance.localTtl,
+    })
     async firstTokenReserve(pairAddress: string): Promise<string> {
         const firstTokenID = await this.firstTokenID(pairAddress);
-        return await this.tokenReserve(pairAddress, firstTokenID);
+        return await this.getTokenReserveRaw(pairAddress, firstTokenID);
     }
 
+    @ErrorLoggerAsync({
+        className: PairAbiService.name,
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'pair',
+        remoteTtl: CacheTtlInfo.ContractBalance.remoteTtl,
+        localTtl: CacheTtlInfo.ContractBalance.localTtl,
+    })
     async secondTokenReserve(pairAddress: string): Promise<string> {
         const secondTokenID = await this.secondTokenID(pairAddress);
-        return await this.tokenReserve(pairAddress, secondTokenID);
+        return await this.getTokenReserveRaw(pairAddress, secondTokenID);
     }
 
     async getTokenReserveRaw(

--- a/src/modules/pair/services/pair.setter.service.ts
+++ b/src/modules/pair/services/pair.setter.service.ts
@@ -6,6 +6,7 @@ import { GenericSetterService } from 'src/services/generics/generic.setter.servi
 import { FeeDestination } from '../models/pair.model';
 import { Logger } from 'winston';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
+import { PairInfoModel } from '../models/pair-info.model';
 
 @Injectable()
 export class PairSetterService extends GenericSetterService {
@@ -116,6 +117,18 @@ export class PairSetterService extends GenericSetterService {
     async setTotalSupply(pairAddress: string, value: string): Promise<string> {
         return await this.setData(
             this.getCacheKey('totalSupply', pairAddress),
+            value,
+            CacheTtlInfo.ContractBalance.remoteTtl,
+            CacheTtlInfo.ContractBalance.localTtl,
+        );
+    }
+
+    async setPairInfoMetadata(
+        pairAddress: string,
+        value: PairInfoModel,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('pairInfoMetadata', pairAddress),
             value,
             CacheTtlInfo.ContractBalance.remoteTtl,
             CacheTtlInfo.ContractBalance.localTtl,

--- a/src/modules/rabbitmq/handlers/pair.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/pair.handler.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { PairInfoModel } from 'src/modules/pair/models/pair-info.model';
 import { PairAbiService } from 'src/modules/pair/services/pair.abi.service';
 import { PairSetterService } from 'src/modules/pair/services/pair.setter.service';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
@@ -36,6 +37,19 @@ export class PairHandler {
                 this.pairSetter.setTotalSupply(pairAddress, totalSupply),
             );
         }
+        totalSupply = totalSupply
+            ? totalSupply
+            : await this.pairAbi.totalSupply(pairAddress);
+        promises.push(
+            this.pairSetter.setPairInfoMetadata(
+                pairAddress,
+                new PairInfoModel({
+                    reserves0: firstTokenReserves,
+                    reserves1: secondTokenReserves,
+                    totalSupply,
+                }),
+            ),
+        );
         const cachedKeys = await Promise.all(promises);
         await this.deleteCacheKeys(cachedKeys);
     }

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -226,6 +226,10 @@ export class PairCacheWarmerService {
                     pairAddress.address,
                     pairInfo.totalSupply,
                 ),
+                this.pairSetterService.setPairInfoMetadata(
+                    pairAddress.address,
+                    pairInfo,
+                ),
             ]);
             invalidatedKeys.push(cachedKeys);
         }
@@ -275,6 +279,14 @@ export class PairCacheWarmerService {
                 this.pairSetterService.setLpTokenPriceUSD(
                     pairMetadata.address,
                     lpTokenPriceUSD,
+                ),
+                this.pairSetterService.setTokenPriceUSD(
+                    pairMetadata.firstTokenID,
+                    firstTokenPriceUSD,
+                ),
+                this.pairSetterService.setTokenPriceUSD(
+                    pairMetadata.secondTokenID,
+                    secondTokenPriceUSD,
                 ),
             ]);
             invalidatedKeys.push(cachedKeys);


### PR DESCRIPTION
## Reasoning
- real time updates on pair info with fall back to cron job
  
## Proposed Changes
- added correct cache for token reserves
- added token price usd and pair info refresh in cachewarmer
- added token price usd and pair info refresh in rabbitmq events

## How to test
- with `ENABLE_CACHE_WARMER=true` pair reserves should be updated every 12 seconds(cron job interval);
- with `ENABLE_EVENTS_NOTIFIER=true` pair reserves should be updated after each event generated by pair(liquidity event or swap)
