### PR TITLE
[SERVICES-1672] fees collector user apr

### DIFF
--- a/src/modules/fees-collector/services/fees-collector.compute.service.ts
+++ b/src/modules/fees-collector/services/fees-collector.compute.service.ts
@@ -175,6 +175,13 @@ export class FeesCollectorComputeService {
         customEnergyAmount?: string,
         customLockedTokens?: string,
     ): Promise<BigNumber> {
+        if (
+            new BigNumber(customEnergyAmount).isZero() ||
+            new BigNumber(customLockedTokens).isZero()
+        ) {
+            return new BigNumber(0);
+        }
+
         const [currentWeek, baseAssetTokenID] = await Promise.all([
             this.weekTimekeepingAbi.currentWeek(scAddress),
             this.energyAbi.baseAssetTokenID(),

--- a/src/modules/fees-collector/specs/fees.collector.compute.service.spec.ts
+++ b/src/modules/fees-collector/specs/fees.collector.compute.service.spec.ts
@@ -372,4 +372,50 @@ describe('FeesCollectorComputeService', () => {
             expect(apr.toFixed()).toEqual('41.6');
         },
     );
+
+    it(
+        'computeUserApr' +
+            ' last week' +
+            ' with 0 user energy and locked tokens',
+        async () => {
+            const user1 = 'erd1';
+            const mex = 'MEX-27f4cd';
+            const priceMap = new Map<string, string>();
+            priceMap.set('TOK1-1111', '10');
+            priceMap.set('TOK2-2222', '20');
+            priceMap.set('TOK4-4444', '30');
+            priceMap.set(mex, '1');
+
+            const service = module.get<FeesCollectorComputeService>(
+                FeesCollectorComputeService,
+            );
+
+            let apr = await service.computeUserRewardsAPR(
+                Address.Zero().bech32(),
+                user1,
+                new BigNumber(0).toFixed(),
+                new BigNumber(0).toFixed(),
+            );
+
+            expect(apr.toFixed()).toEqual('0');
+
+            apr = await service.computeUserRewardsAPR(
+                Address.Zero().bech32(),
+                user1,
+                new BigNumber('1440000000000000000000').toFixed(),
+                new BigNumber(0).toFixed(),
+            );
+
+            expect(apr.toFixed()).toEqual('0');
+
+            apr = await service.computeUserRewardsAPR(
+                Address.Zero().bech32(),
+                user1,
+                new BigNumber(0).toFixed(),
+                new BigNumber('1000000000000000000').toFixed(),
+            );
+
+            expect(apr.toFixed()).toEqual('0');
+        },
+    );
 });


### PR DESCRIPTION
## Reasoning
- computeUserRewardsAPR returned `NaN` for `customEnergyAmount = 0` or `customLockedTokens = 0` 

## Proposed Changes
- return 0 APR for `customEnergyAmount = 0` or `customLockedTokens = 0` 

## How to test
```
query UserLastWeekRewards {
	userLastWeekRewards(
		energyAmount: "0",
		lockedTokens: "0"
	)
}
```
- query should return `0`
