### PR TITLE
[SERVICES-1670] router swap enable map

### DIFF
--- a/src/abis/router.abi.json
+++ b/src/abis/router.abi.json
@@ -1,20 +1,20 @@
 {
     "buildInfo": {
         "rustc": {
-            "version": "1.62.0-nightly",
-            "commitHash": "a5ad0d29a401007b51715852cc702e441ac2248c",
-            "commitDate": "2022-05-12",
+            "version": "1.66.0-nightly",
+            "commitHash": "b8c35ca26b191bb9a9ac669a4b3f4d3d52d97fb1",
+            "commitDate": "2022-10-15",
             "channel": "Nightly",
-            "short": "rustc 1.62.0-nightly (a5ad0d29a 2022-05-12)"
+            "short": "rustc 1.66.0-nightly (b8c35ca26 2022-10-15)"
         },
         "contractCrate": {
             "name": "router",
             "version": "0.0.0",
-            "git_version": "v1.6.0-101-g7d0cbf11"
+            "gitVersion": "v1.6.0-1269-g68748a06"
         },
         "framework": {
-            "name": "elrond-wasm",
-            "version": "0.33.1"
+            "name": "multiversx-sc",
+            "version": "0.39.4"
         }
     },
     "name": "Router",
@@ -73,6 +73,11 @@
                     "name": "opt_fee_percents",
                     "type": "optional<multi<u64,u64>>",
                     "multi_arg": true
+                },
+                {
+                    "name": "admins",
+                    "type": "variadic<Address>",
+                    "multi_arg": true
                 }
             ],
             "outputs": [
@@ -93,6 +98,10 @@
                 {
                     "name": "second_token_id",
                     "type": "TokenIdentifier"
+                },
+                {
+                    "name": "initial_liquidity_adder",
+                    "type": "Address"
                 },
                 {
                     "name": "total_fee_percent_requested",
@@ -389,6 +398,10 @@
             "mutability": "mutable",
             "inputs": [
                 {
+                    "name": "common_token_id",
+                    "type": "TokenIdentifier"
+                },
+                {
                     "name": "locked_token_id",
                     "type": "TokenIdentifier"
                 },
@@ -399,11 +412,6 @@
                 {
                     "name": "min_lock_period_epochs",
                     "type": "u64"
-                },
-                {
-                    "name": "common_tokens_for_user_pairs",
-                    "type": "variadic<TokenIdentifier>",
-                    "multi_arg": true
                 }
             ],
             "outputs": []
@@ -451,7 +459,12 @@
         {
             "name": "getEnableSwapByUserConfig",
             "mutability": "readonly",
-            "inputs": [],
+            "inputs": [
+                {
+                    "name": "token_id",
+                    "type": "TokenIdentifier"
+                }
+            ],
             "outputs": [
                 {
                     "type": "EnableSwapByUserConfig"
@@ -470,7 +483,66 @@
             ]
         }
     ],
-    "events": [],
+    "events": [
+        {
+            "identifier": "create_pair",
+            "inputs": [
+                {
+                    "name": "first_token_id",
+                    "type": "TokenIdentifier",
+                    "indexed": true
+                },
+                {
+                    "name": "second_token_id",
+                    "type": "TokenIdentifier",
+                    "indexed": true
+                },
+                {
+                    "name": "caller",
+                    "type": "Address",
+                    "indexed": true
+                },
+                {
+                    "name": "epoch",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "swap_event",
+                    "type": "CreatePairEvent"
+                }
+            ]
+        },
+        {
+            "identifier": "pairSwapEnabled",
+            "inputs": [
+                {
+                    "name": "first_token_id",
+                    "type": "TokenIdentifier",
+                    "indexed": true
+                },
+                {
+                    "name": "second_token_id",
+                    "type": "TokenIdentifier",
+                    "indexed": true
+                },
+                {
+                    "name": "caller",
+                    "type": "Address",
+                    "indexed": true
+                },
+                {
+                    "name": "epoch",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "swap_enabled_event",
+                    "type": "UserPairSwapEnabledEvent"
+                }
+            ]
+        }
+    ],
     "hasCallback": true,
     "types": {
         "CreatePairEvent": {

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -552,7 +552,11 @@
             "SLIPPAGE_VALUES": [0.001, 0.005, 0.01],
             "MAX_SLIPPAGE": 0.05
         },
-        "MIN_SWAP_AMOUNT": 0.05
+        "MIN_SWAP_AMOUNT": 0.05,
+        "roundedSwapEnable": {
+            "USDC-8d4068": "5000000",
+            "WEGLD-d7c6bb": "100000000000000000"
+        }
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"

--- a/src/helpers/decorators/error.logger.ts
+++ b/src/helpers/decorators/error.logger.ts
@@ -15,7 +15,10 @@ const getErrorText = (
         options.className ? options.className + '.' + methodName : methodName
     }`;
 
-    if (options.logArgs) return `${defaultText} with args ${args.join(',')}`;
+    if (options.logArgs)
+        return `${defaultText} with args ${args
+            .map((arg) => JSON.stringify(arg))
+            .join(', ')}`;
 
     return defaultText;
 };

--- a/src/modules/router/mocks/router.abi.service.mock.ts
+++ b/src/modules/router/mocks/router.abi.service.mock.ts
@@ -4,6 +4,8 @@ import { PairMetadata } from '../models/pair.metadata.model';
 import { IRouterAbiService } from '../services/interfaces';
 import { pairs } from 'src/modules/pair/mocks/pair.constants';
 import { RouterAbiService } from '../services/router.abi.service';
+import { SimpleLockModel } from 'src/modules/simple-lock/models/simple.lock.model';
+import { Address } from '@multiversx/sdk-core/out';
 
 export class RouterAbiServiceMock implements IRouterAbiService {
     async pairsAddress(): Promise<string[]> {
@@ -41,11 +43,19 @@ export class RouterAbiServiceMock implements IRouterAbiService {
     temporaryOwnerPeriod(): Promise<string> {
         throw new Error('Method not implemented.');
     }
-    enableSwapByUserConfig(): Promise<EnableSwapByUserConfig> {
-        throw new Error('Method not implemented.');
+    async enableSwapByUserConfig(): Promise<EnableSwapByUserConfig> {
+        return new EnableSwapByUserConfig({
+            lockingSC: new SimpleLockModel({
+                address: Address.Zero().bech32(),
+            }),
+            commonTokenID: 'USDC-1111',
+            lockedTokenID: 'LKESDT-1234',
+            minLockedTokenValue: '8000000000000000000000',
+            minLockPeriodEpochs: 1,
+        });
     }
-    commonTokensForUserPairs(): Promise<string[]> {
-        throw new Error('Method not implemented.');
+    async commonTokensForUserPairs(): Promise<string[]> {
+        return ['USDC-1111'];
     }
 }
 

--- a/src/modules/router/mocks/router.abi.service.mock.ts
+++ b/src/modules/router/mocks/router.abi.service.mock.ts
@@ -25,9 +25,6 @@ export class RouterAbiServiceMock implements IRouterAbiService {
     pairCreationEnabled(): Promise<boolean> {
         throw new Error('Method not implemented.');
     }
-    lastErrorMessage(): Promise<string> {
-        throw new Error('Method not implemented.');
-    }
     state(): Promise<boolean> {
         throw new Error('Method not implemented.');
     }

--- a/src/modules/router/models/factory.model.ts
+++ b/src/modules/router/models/factory.model.ts
@@ -58,8 +58,6 @@ export class FactoryModel {
     maxSlippage: number;
     @Field()
     minSwapAmount: number;
-    @Field()
-    lastErrorMessage: string;
 
     constructor(init?: Partial<FactoryModel>) {
         Object.assign(this, init);

--- a/src/modules/router/models/factory.model.ts
+++ b/src/modules/router/models/factory.model.ts
@@ -3,14 +3,11 @@ import { SimpleLockModel } from 'src/modules/simple-lock/models/simple.lock.mode
 
 @ObjectType()
 export class EnableSwapByUserConfig {
+    lockedTokenID: string;
     @Field(() => SimpleLockModel)
     lockingSC: SimpleLockModel;
-    @Field({
-        deprecationReason:
-            'field is deprecated and will be removed on next release;' +
-            'value can be obtained from lockingSC field',
-    })
-    lockedTokenID: string;
+    @Field()
+    commonTokenID: string;
     @Field() minLockedTokenValue: string;
     @Field(() => Int) minLockPeriodEpochs: number;
 
@@ -49,8 +46,8 @@ export class FactoryModel {
     multiSwapStatus: boolean;
     @Field(() => [String])
     commonTokensForUserPairs: string[];
-    @Field(() => EnableSwapByUserConfig)
-    enableSwapByUserConfig: EnableSwapByUserConfig;
+    @Field(() => [EnableSwapByUserConfig])
+    enableSwapByUserConfig: EnableSwapByUserConfig[];
     @Field()
     defaultSlippage: number;
     @Field(() => [Float])

--- a/src/modules/router/router.resolver.ts
+++ b/src/modules/router/router.resolver.ts
@@ -45,8 +45,15 @@ export class RouterResolver {
     }
 
     @ResolveField()
-    async enableSwapByUserConfig(): Promise<EnableSwapByUserConfig> {
-        return this.routerabi.enableSwapByUserConfig();
+    async enableSwapByUserConfig(): Promise<EnableSwapByUserConfig[]> {
+        const commonTokens = await this.routerabi.commonTokensForUserPairs();
+        const configs = await Promise.all(
+            commonTokens.map((tokenID) =>
+                this.routerabi.enableSwapByUserConfig(tokenID),
+            ),
+        );
+
+        return configs.filter((config) => config !== undefined);
     }
 
     @ResolveField(() => Int)

--- a/src/modules/router/router.resolver.ts
+++ b/src/modules/router/router.resolver.ts
@@ -141,11 +141,6 @@ export class RouterResolver {
         return constantsConfig.MIN_SWAP_AMOUNT;
     }
 
-    @ResolveField(() => String)
-    async lastErrorMessage(): Promise<string> {
-        return this.routerabi.lastErrorMessage();
-    }
-
     @Query(() => [String])
     async pairAddresses(): Promise<string[]> {
         return this.routerabi.pairsAddress();
@@ -248,11 +243,6 @@ export class RouterResolver {
     ): Promise<TransactionModel> {
         await this.routerService.requireOwner(user.address);
         return this.routerTransaction.setPairCreationEnabled(enabled);
-    }
-
-    @Query(() => String)
-    async getLastErrorMessage(): Promise<string> {
-        return await this.routerabi.lastErrorMessage();
     }
 
     @UseGuards(JwtOrNativeAdminGuard)

--- a/src/modules/router/services/interfaces.ts
+++ b/src/modules/router/services/interfaces.ts
@@ -6,7 +6,6 @@ export interface IRouterAbiService {
     pairsAddress(): Promise<string[]>;
     pairsMetadata(): Promise<PairMetadata[]>;
     pairCreationEnabled(): Promise<boolean>;
-    lastErrorMessage(): Promise<string>;
     state(): Promise<boolean>;
     owner(): Promise<string>;
     allPairTokens(): Promise<PairTokens[]>;

--- a/src/modules/router/services/interfaces.ts
+++ b/src/modules/router/services/interfaces.ts
@@ -12,6 +12,6 @@ export interface IRouterAbiService {
     allPairTokens(): Promise<PairTokens[]>;
     pairTemplateAddress(): Promise<string>;
     temporaryOwnerPeriod(): Promise<string>;
-    enableSwapByUserConfig(): Promise<EnableSwapByUserConfig>;
+    enableSwapByUserConfig(tokenID: string): Promise<EnableSwapByUserConfig>;
     commonTokensForUserPairs(): Promise<string[]>;
 }

--- a/src/modules/router/services/router.abi.service.ts
+++ b/src/modules/router/services/router.abi.service.ts
@@ -97,25 +97,6 @@ export class RouterAbiService
     })
     @GetOrSetCache({
         baseKey: 'router',
-        remoteTtl: oneMinute(),
-    })
-    async lastErrorMessage(): Promise<string> {
-        return await this.getLastErrorMessageRaw();
-    }
-
-    async getLastErrorMessageRaw(): Promise<string> {
-        const contract = await this.mxProxy.getRouterSmartContract();
-        const interaction: Interaction =
-            contract.methodsExplicit.getLastErrorMessage();
-        const response = await this.getGenericData(interaction);
-        return response.firstValue.valueOf().toString();
-    }
-
-    @ErrorLoggerAsync({
-        className: RouterAbiService.name,
-    })
-    @GetOrSetCache({
-        baseKey: 'router',
         remoteTtl: oneHour(),
     })
     async state(): Promise<boolean> {

--- a/src/modules/router/specs/router.transactions.service.spec.ts
+++ b/src/modules/router/specs/router.transactions.service.spec.ts
@@ -18,6 +18,7 @@ import { TokenGetterServiceProvider } from 'src/modules/tokens/mocks/token.gette
 import { PairAbiServiceProvider } from 'src/modules/pair/mocks/pair.abi.service.mock';
 import { PairComputeServiceProvider } from 'src/modules/pair/mocks/pair.compute.service.mock';
 import { RouterAbiServiceProvider } from '../mocks/router.abi.service.mock';
+import { InputTokenModel } from 'src/models/inputToken.model';
 
 describe('RouterService', () => {
     let module: TestingModule;
@@ -433,4 +434,145 @@ describe('RouterService', () => {
             signature: undefined,
         });
     });
+
+    it('should get user swap enable transaction', async () => {
+        const service = module.get<RouterTransactionService>(
+            RouterTransactionService,
+        );
+
+        const transaction = await service.setSwapEnabledByUser(
+            Address.Zero().bech32(),
+            new InputTokenModel({
+                tokenID: 'LKESDT-1234',
+                nonce: 1,
+                amount: '1000000000000000000',
+                attributes: 'AAAAClRPSzFVU0RDTFAAAAAAAAAAAAAAAAAAAAAC',
+            }),
+        );
+
+        expect(transaction).toEqual({
+            nonce: 0,
+            value: '0',
+            receiver: Address.Zero().bech32(),
+            sender: 'erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu',
+            gasPrice: 1000000000,
+            gasLimit: 50000000,
+            data: encodeTransactionData(
+                'ESDTNFTTransfer@LKESDT-1234@01@1000000000000000000@erd1qqqqqqqqqqqqqpgqpv09kfzry5y4sj05udcngesat07umyj70n4sa2c0rp@setSwapEnabledByUser@erd1qqqqqqqqqqqqqpgqq67uv84ma3cekpa55l4l68ajzhq8qm3u0n4s20ecvx',
+            ),
+            chainID: mxConfig.chainID,
+            version: 1,
+            options: undefined,
+            signature: undefined,
+        });
+    });
+
+    it(
+        'should get error on user swap enable transaction ' + 'lock period',
+        async () => {
+            const service = module.get<RouterTransactionService>(
+                RouterTransactionService,
+            );
+
+            await expect(
+                service.setSwapEnabledByUser(
+                    Address.Zero().bech32(),
+                    new InputTokenModel({
+                        tokenID: 'LKESDT-1234',
+                        nonce: 1,
+                        amount: '1000000000000000000',
+                        attributes: 'AAAAClRPSzFVU0RDTFAAAAAAAAAAAAAAAAAAAAAA',
+                    }),
+                ),
+            ).rejects.toThrow('Token not locked for long enough');
+        },
+    );
+
+    it(
+        'should get error on user swap enable transaction ' +
+            'invalid locked token',
+        async () => {
+            const service = module.get<RouterTransactionService>(
+                RouterTransactionService,
+            );
+
+            await expect(
+                service.setSwapEnabledByUser(
+                    Address.Zero().bech32(),
+                    new InputTokenModel({
+                        tokenID: 'LKESDT-abcdef',
+                        nonce: 1,
+                        amount: '1000000000000000000',
+                        attributes: 'AAAAClRPSzFVU0RDTFAAAAAAAAAAAAAAAAAAAAAC',
+                    }),
+                ),
+            ).rejects.toThrow('Invalid input token');
+        },
+    );
+
+    it(
+        'should get error on user swap enable transaction ' +
+            'invalid LP token locked',
+        async () => {
+            const service = module.get<RouterTransactionService>(
+                RouterTransactionService,
+            );
+
+            await expect(
+                service.setSwapEnabledByUser(
+                    Address.Zero().bech32(),
+                    new InputTokenModel({
+                        tokenID: 'LKESDT-abcdef',
+                        nonce: 1,
+                        amount: '1000000000000000000',
+                        attributes: 'AAAAClRPSzJUT0szTFAAAAAAAAAAAAAAAAAAAAAA',
+                    }),
+                ),
+            ).rejects.toThrow('Invalid locked LP token');
+        },
+    );
+
+    it(
+        'should get error on user swap enable transaction ' +
+            'wrong common token',
+        async () => {
+            const service = module.get<RouterTransactionService>(
+                RouterTransactionService,
+            );
+
+            await expect(
+                service.setSwapEnabledByUser(
+                    Address.Zero().bech32(),
+                    new InputTokenModel({
+                        tokenID: 'LKESDT-1234',
+                        nonce: 1,
+                        amount: '1000000000000000000',
+                        attributes: 'AAAAClRPSzFUT0syTFAAAAAAAAAAAAAAAAAAAAAA',
+                    }),
+                ),
+            ).rejects.toThrow('Not a valid user defined pair');
+        },
+    );
+
+    it(
+        'should get error on user swap enable transaction ' +
+            'min value locked',
+        async () => {
+            const service = module.get<RouterTransactionService>(
+                RouterTransactionService,
+            );
+
+            await expect(
+                service.setSwapEnabledByUser(
+                    Address.Zero().bech32(),
+                    new InputTokenModel({
+                        tokenID: 'LKESDT-1234',
+                        nonce: 1,
+                        amount: '1000000000000000',
+                        attributes: 'AAAAClRPSzFVU0RDTFAAAAAAAAAAAAAAAAAAAAAC',
+                    }),
+                ),
+            ).rejects.toThrow('Not enough value locked');
+        },
+    );
 });


### PR DESCRIPTION
## Reasoning
- update router smart contract to accept multiple tokens for automatic pair swap enable
  
## Proposed Changes
- updated swap enable config to return an array of configs for each accepted token
- fixed user swap enable transaction input validation

## How to test
```
query Router {
	factory {
		address
		pairCreationEnabled
		commonTokensForUserPairs
		enableSwapByUserConfig {
			lockingSC {
				address
				lockedToken {
					collection
				}
				lpProxyToken {collection}
				farmProxyToken {collection}
			}
			commonTokenID
			minLockedTokenValue
			minLockPeriodEpochs
		}
	}
}
```
- query should return an array of configs for `enableSwapByUserConfig` field
