### PR TITLE
SERVICES-1687: dynamic gasLimit for cancelUnbond

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -455,7 +455,10 @@
                 "default": 8500000,
                 "additionalTokens": 5000000
             },
-            "cancelUnbond": 21000000
+            "cancelUnbond": {
+                "default": 8500000,
+                "additionalTokens": 1000000
+            }
         },
         "lockedTokenWrapper": {
             "wrapLockedToken": 15000000,

--- a/src/modules/token-unstake/services/token.unstake.transaction.service.ts
+++ b/src/modules/token-unstake/services/token.unstake.transaction.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
-import { mxConfig, gasConfig } from 'src/config';
+import { gasConfig, mxConfig } from 'src/config';
 import { TransactionModel } from 'src/models/transaction.model';
 import { MXProxyService } from 'src/services/multiversx-communication/mx.proxy.service';
 import { TokenUnstakeAbiService } from './token.unstake.abi.service';
@@ -34,12 +34,25 @@ export class TokenUnstakeTransactionService {
             .toPlainObject();
     }
 
-    async cancelUnbond(): Promise<TransactionModel> {
+    async cancelUnbond(sender: string): Promise<TransactionModel> {
         const contract = await this.mxProxy.getTokenUnstakeContract();
+
+        const unstakedTokens = await this.tokenUnstakeAbi.unlockedTokensForUser(
+            sender,
+        );
+
+        const gasLimit = new BigNumber(
+            gasConfig.tokenUnstake.cancelUnbond.default,
+        ).plus(
+            new BigNumber(
+                gasConfig.tokenUnstake.cancelUnbond.additionalTokens,
+            ).multipliedBy(unstakedTokens.length),
+        );
+
         return contract.methodsExplicit
             .cancelUnbond()
             .withChainID(mxConfig.chainID)
-            .withGasLimit(gasConfig.tokenUnstake.cancelUnbond)
+            .withGasLimit(gasLimit.integerValue().toNumber())
             .buildTransaction()
             .toPlainObject();
     }

--- a/src/modules/token-unstake/specs/token.unstake.transaction.service.spec.ts
+++ b/src/modules/token-unstake/specs/token.unstake.transaction.service.spec.ts
@@ -60,13 +60,15 @@ describe('TokenUnstakeTransactionService', () => {
             module.get<TokenUnstakeTransactionService>(
                 TokenUnstakeTransactionService,
             );
-        const transaction = await service.cancelUnbond();
+        const transaction = await service.cancelUnbond(
+            Address.Zero().bech32(),
+        );
 
         expect(transaction).toEqual(
             new TransactionModel({
                 chainID: mxConfig.chainID,
                 data: encodeTransactionData('cancelUnbond'),
-                gasLimit: 21000000,
+                gasLimit: 9500000,
                 gasPrice: 1000000000,
                 nonce: 0,
                 sender: Address.Zero().bech32(),

--- a/src/modules/token-unstake/token.unstake.resolver.ts
+++ b/src/modules/token-unstake/token.unstake.resolver.ts
@@ -5,10 +5,7 @@ import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { TransactionModel } from 'src/models/transaction.model';
 import { JwtOrNativeAuthGuard } from '../auth/jwt.or.native.auth.guard';
-import {
-    TokenUnstakeModel,
-    UnstakePairModel,
-} from './models/token.unstake.model';
+import { TokenUnstakeModel, UnstakePairModel } from './models/token.unstake.model';
 import { TokenUnstakeTransactionService } from './services/token.unstake.transaction.service';
 import { TokenUnstakeAbiService } from './services/token.unstake.abi.service';
 
@@ -64,7 +61,9 @@ export class TokenUnstakeResolver {
 
     @UseGuards(JwtOrNativeAuthGuard)
     @Query(() => TransactionModel)
-    async cancelUnbond(): Promise<TransactionModel> {
-        return this.tokenUnstakeTransactions.cancelUnbond();
+    async cancelUnbond(
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TransactionModel> {
+        return this.tokenUnstakeTransactions.cancelUnbond(user.address);
     }
 }


### PR DESCRIPTION
## Reasoning
- gasLimit for cancelUnbond was static, no matter how many unlocked tokens a user has. This approach has the disadvantage of giving too much gas for few tokens and too little for many tokens

## Proposed Changes
- compute the gasLimit in a dynamic way depending on the number of unlocked tokens for user

## How to test
- cancelUnbond transaction shall have 9.5mil gasLimit for 1 unlocked tokens
- cancelUnbond transaction shall have 10.5mil gasLimit for 2 unlocked tokens
- cancelUnbond transaction shall have 21.5mil gasLimit for 13 unlocked tokens
