### PR TITLE
[SERVICES-1690] update min swap

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -552,7 +552,7 @@
             "SLIPPAGE_VALUES": [0.001, 0.005, 0.01],
             "MAX_SLIPPAGE": 0.05
         },
-        "MIN_SWAP_AMOUNT": 0.05
+        "MIN_SWAP_AMOUNT": 0.0005
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"


### PR DESCRIPTION
## Reasoning
- match xExchange's minimum swap amount
  
## Proposed Changes
- update default config of minimum swap

## How to test
```
query {
  factory {
    minSwapAmount
  }
}
```
- query should return new value