### PR TITLE
[SERVICES-1573] fix price discovery charts

### DIFF
--- a/src/modules/rabbitmq/handlers/price.discovery.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/price.discovery.handler.service.ts
@@ -22,6 +22,10 @@ export class PriceDiscoveryEventHandler {
     async handleEvent(
         event: DepositEvent | WithdrawEvent,
     ): Promise<[any[], number]> {
+        const launchedToken = await this.priceDiscoveryService.getLaunchedToken(
+            event.getAddress(),
+        );
+
         const [
             priceDiscoveryAddress,
             launchedTokenAmount,
@@ -31,12 +35,10 @@ export class PriceDiscoveryEventHandler {
             event.getAddress(),
             event.launchedTokenAmount.toFixed(),
             event.acceptedTokenAmount.toFixed(),
-            event.launchedTokenPrice,
+            event.launchedTokenPrice
+                .multipliedBy(`1e-${launchedToken.decimals}`)
+                .toFixed(),
         ];
-
-        const launchedToken = await this.priceDiscoveryService.getLaunchedToken(
-            priceDiscoveryAddress,
-        );
 
         let cacheKeys: string[] = await Promise.all([
             this.priceDiscoverySetter.setLaunchedTokenAmount(
@@ -49,9 +51,7 @@ export class PriceDiscoveryEventHandler {
             ),
             this.priceDiscoverySetter.setLaunchedTokenPrice(
                 priceDiscoveryAddress,
-                launchedTokenPrice
-                    .multipliedBy(`1e-${launchedToken.decimals}`)
-                    .toFixed(),
+                launchedTokenPrice,
             ),
             this.priceDiscoverySetter.setCurrentPhase(
                 priceDiscoveryAddress,

--- a/src/modules/rabbitmq/handlers/price.discovery.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/price.discovery.handler.service.ts
@@ -22,7 +22,7 @@ export class PriceDiscoveryEventHandler {
     async handleEvent(
         event: DepositEvent | WithdrawEvent,
     ): Promise<[any[], number]> {
-        const launchedToken = await this.priceDiscoveryService.getLaunchedToken(
+        const acceptedToken = await this.priceDiscoveryService.getAcceptedToken(
             event.getAddress(),
         );
 
@@ -36,7 +36,7 @@ export class PriceDiscoveryEventHandler {
             event.launchedTokenAmount.toFixed(),
             event.acceptedTokenAmount.toFixed(),
             event.launchedTokenPrice
-                .multipliedBy(`1e-${launchedToken.decimals}`)
+                .multipliedBy(`1e-${acceptedToken.decimals}`)
                 .toFixed(),
         ];
 

--- a/src/services/analytics/interfaces/analytics.query.interface.ts
+++ b/src/services/analytics/interfaces/analytics.query.interface.ts
@@ -25,5 +25,7 @@ export interface AnalyticsQueryInterface {
         series,
         metric,
         timeBucket,
+        startDate,
+        endDate,
     }): Promise<HistoricDataModel[]>;
 }

--- a/src/services/analytics/services/analytics.query.service.ts
+++ b/src/services/analytics/services/analytics.query.service.ts
@@ -61,12 +61,16 @@ export class AnalyticsQueryService implements AnalyticsQueryInterface {
         series,
         metric,
         timeBucket,
+        startDate,
+        endDate,
     }): Promise<HistoricDataModel[]> {
         const service = await this.getService();
         return await service.getPDCloseValues({
             series,
             metric,
             timeBucket,
+            startDate,
+            endDate,
         });
     }
 

--- a/src/services/analytics/timescaledb/entities/timescaledb.entities.ts
+++ b/src/services/analytics/timescaledb/entities/timescaledb.entities.ts
@@ -197,7 +197,6 @@ export class CloseHourly {
         'acceptedTokenPrice',
         'launchedTokenPriceUSD',
         'acceptedTokenPriceUSD')
-    AND timestamp >= NOW() - INTERVAL '1 day'
     GROUP BY time, series, key;
   `,
     materialized: true,

--- a/src/services/analytics/timescaledb/migration/1684167998347-xExchange.ts
+++ b/src/services/analytics/timescaledb/migration/1684167998347-xExchange.ts
@@ -18,7 +18,6 @@ export class xExchange1684167998347 implements MigrationInterface {
         'acceptedTokenPrice',
         'launchedTokenPriceUSD',
         'acceptedTokenPriceUSD')
-    AND timestamp >= NOW() - INTERVAL '1 day'
     GROUP BY time, series, key;
   `);
         await queryRunner.query(

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -308,6 +308,8 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
         series,
         metric,
         timeBucket,
+        startDate,
+        endDate,
     }): Promise<HistoricDataModel[]> {
         const query = await this.pdCloseMinute
             .createQueryBuilder()
@@ -315,7 +317,10 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
             .addSelect('locf(last(last, time)) as last')
             .where('series = :series', { series })
             .andWhere('key = :metric', { metric })
-            .andWhere("time between now() - INTERVAL '1 day' and now()")
+            .andWhere('time between :start and :end', {
+                start: startDate,
+                end: endDate,
+            })
             .groupBy('bucket')
             .getRawMany();
 

--- a/src/services/multiversx-communication/mx.api.service.ts
+++ b/src/services/multiversx-communication/mx.api.service.ts
@@ -304,6 +304,15 @@ export class MXApiService {
         return latestBlock[0].nonce;
     }
 
+    async getBlockByNonce(shardId: number, nonce: number): Promise<any> {
+        const blocks = await this.doGetGeneric(
+            this.getBlockByNonce.name,
+            `blocks?nonce=${nonce}&shard=${shardId}`,
+        );
+
+        return blocks[0] ?? undefined;
+    }
+
     async getShardTimestamp(shardId: number): Promise<number> {
         const latestShardBlock = await this.doGetGeneric(
             this.getShardTimestamp.name,


### PR DESCRIPTION
## Reasoning
- price discovery charts data display only the last 1 day of data
  
## Proposed Changes
- remove time constraint from materialized view
- add time interval to get price discovery chart data

## How to test
```
query {
	closingValues(
		priceDiscoveryAddress: "erd1qqqqqqqqqqqqqpgq6dszt34rl3zffwvfce8meq8e63zss5v70n4srreusz",
		metric: "launchedTokenPrice",
		bucket: MINUTE_1
	) {
		timestamp
		value
	}
}
```
- query should return values between price discovery phase