### PR TITLE
[SERVICES-1695]: fix token compute price EGLD

### DIFF
--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -36,13 +36,24 @@ export class TokenComputeService implements ITokenComputeService {
         }
 
         const pairsMetadata = await this.routerAbi.pairsMetadata();
-        const tokenPairs: PairMetadata[] = [];
+        let tokenPairs: PairMetadata[] = [];
         for (const pair of pairsMetadata) {
             if (
                 pair.firstTokenID === tokenID ||
                 pair.secondTokenID === tokenID
             ) {
                 tokenPairs.push(pair);
+            }
+        }
+
+        if (tokenPairs.length > 1) {
+            const states = await Promise.all(
+                tokenPairs.map((pair) => this.pairAbi.state(pair.address)),
+            );
+            if (states.find((state) => state === 'Active')) {
+                tokenPairs = tokenPairs.filter((pair, index) => {
+                    return states[index] === 'Active';
+                });
             }
         }
 


### PR DESCRIPTION
## Reasoning
- token price is computed using the pair with most liquidity; if there is an `ActiveNoSwap` and an `Active` pair, only the `Active` should be used
  
## Proposed Changes
- use only Active pairs for token price computation if there are at least 1 active pair
- use all pairs for token price computation if there are no active pairs

## How to test
```
query Tokens {
	tokens(identifiers: ["KOSON-5dd4fa", "TRO-94c925"]) {
		identifier
		decimals
		price
	}
}
```
- on mainnet, `KOSON-5dd4fa` should express token price from USDC pair