### PR TITLE
[SERVICES-1670] backwards compatibility for pair type

### DIFF
--- a/src/utils/token.type.compare.ts
+++ b/src/utils/token.type.compare.ts
@@ -16,6 +16,15 @@ export function leastType(typeA: string, typeB: string): string {
                 return typeA;
             }
             return typeB;
+        case 'Jungle-Community':
+            if (
+                typeB === 'Core' ||
+                typeB === 'Ecosystem' ||
+                typeB === 'Community'
+            ) {
+                return 'Community';
+            }
+            return typeB;
         case 'Experimental':
             if (
                 typeB === 'Core' ||
@@ -24,6 +33,29 @@ export function leastType(typeA: string, typeB: string): string {
                 typeB === 'Jungle-Community'
             ) {
                 return typeA;
+            }
+            return typeB;
+        case 'Jungle-Experimental':
+            if (
+                typeB === 'Core' ||
+                typeB === 'Ecosystem' ||
+                typeB === 'Community' ||
+                typeB === 'Jungle-Community' ||
+                typeB === 'Experimental'
+            ) {
+                return 'Experimental';
+            }
+            return typeB;
+        case 'Jungle':
+            if (
+                typeB === 'Core' ||
+                typeB === 'Ecosystem' ||
+                typeB === 'Community' ||
+                typeB === 'Jungle-Community' ||
+                typeB === 'Experimental' ||
+                typeB === 'Jungle-Experimental'
+            ) {
+                return 'Experimental';
             }
             return typeB;
         case 'Unlisted':


### PR DESCRIPTION
## Reasoning
- keep backwards compatibility for pair types
  
## Proposed Changes
- for any `Jungle` based type return `Experimental` or upper type

## How to test
```
query {
  pairs(offset:0, limit: 100) {
    address
    type
  }
}
```
- query should return type for all pairs; for `Jungle` tokens return `Experimental`; for `Jungle-*` return upper type
