### PR TITLE
[SERVICES-1670] fix token type create

### DIFF
--- a/src/modules/rabbitmq/handlers/router.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/router.handler.service.ts
@@ -43,17 +43,19 @@ export class RouterHandlerService {
             firstTokenType,
             secondTokenType,
             uniqueTokens,
+            commonTokens,
         ] = await Promise.all([
             this.routerAbiService.pairsMetadata(),
             this.routerAbiService.pairsAddress(),
             this.tokenGetter.getEsdtTokenType(firstTokenID),
             this.tokenGetter.getEsdtTokenType(secondTokenID),
             this.tokenService.getUniqueTokenIDs(true),
+            this.routerAbiService.commonTokensForUserPairs(),
         ]);
 
         if (
-            firstTokenID === constantsConfig.USDC_TOKEN_ID ||
-            secondTokenID === constantsConfig.USDC_TOKEN_ID
+            commonTokens.includes(firstTokenID) ||
+            commonTokens.includes(secondTokenID)
         ) {
             if (firstTokenType === 'Unlisted') {
                 const createTokenDto: CreateTokenDto = {


### PR DESCRIPTION
## Reasoning
- token type create check for hardcoded common token
  
## Proposed Changes
- use router's common tokens to check for create token type when new pair is created

## How to test
- on new pair created for new token paired with a common token, type should be created for the token
