### PR TITLE
[SERVICES-1704] fix new pair filtering for events

### DIFF
--- a/src/modules/rabbitmq/handlers/router.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/router.handler.service.ts
@@ -5,7 +5,6 @@ import {
 } from '@multiversx/sdk-exchange';
 import { Inject, Injectable } from '@nestjs/common';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
-import { constantsConfig } from 'src/config';
 import { PUB_SUB } from 'src/services/redis.pubSub.module';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 import { RouterAbiService } from '../../router/services/router.abi.service';
@@ -45,8 +44,8 @@ export class RouterHandlerService {
             uniqueTokens,
             commonTokens,
         ] = await Promise.all([
-            this.routerAbiService.pairsMetadata(),
-            this.routerAbiService.pairsAddress(),
+            this.routerAbiService.getPairsMetadataRaw(),
+            this.routerAbiService.getAllPairsAddressRaw(),
             this.tokenGetter.getEsdtTokenType(firstTokenID),
             this.tokenGetter.getEsdtTokenType(secondTokenID),
             this.tokenService.getUniqueTokenIDs(true),

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -306,7 +306,7 @@ export class RabbitMqConsumer {
 
     async getFilterAddresses(): Promise<void> {
         this.filterAddresses = [];
-        this.filterAddresses = await this.routerAbi.pairsAddress();
+        this.filterAddresses = await this.routerAbi.getAllPairsAddressRaw();
         this.filterAddresses.push(...farmsAddresses());
         this.filterAddresses.push(scAddress.routerAddress);
         this.filterAddresses.push(scAddress.metabondingStakingAddress);


### PR DESCRIPTION
## Reasoning
- pair filtering uses the cached values
  
## Proposed Changes
- use raw methods to get all pairs on create pair event and update filtering for events

## How to test
- N/A
