### PR TITLE
Gas limit for issue lp token and set local roles

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -76,8 +76,8 @@
     "gasLimits": {
         "router": {
             "createPair": 30000000,
-            "issueToken": 100000000,
-            "setLocalRoles": 100000000,
+            "issueToken": 150000000,
+            "setLocalRoles": 150000000,
             "multiPairSwapMultiplier": 40000000,
             "swapEnableByUser": 50000000,
             "admin": {


### PR DESCRIPTION
## Reasoning
- issue lp token insufficient gas
  
## Proposed Changes
- increase gas limit for issue lp token and set local roles

## How to test
- N/A
