### PR TITLE
[MEX-332] fees collector known contracts

### DIFF
--- a/src/modules/fees-collector/fees-collector.resolver.ts
+++ b/src/modules/fees-collector/fees-collector.resolver.ts
@@ -71,6 +71,16 @@ export class FeesCollectorResolver {
         return this.feesCollectorAbi.lockedTokensPerBlock();
     }
 
+    @ResolveField(() => [String])
+    async allTokens(): Promise<string[]> {
+        return this.feesCollectorAbi.allTokens();
+    }
+
+    @ResolveField(() => [String])
+    async knownContracts(): Promise<string[]> {
+        return this.feesCollectorAbi.knownContracts();
+    }
+
     @Query(() => FeesCollectorModel)
     async feesCollector(): Promise<FeesCollectorModel> {
         return this.feesCollectorService.feesCollector(scAddress.feesCollector);

--- a/src/modules/fees-collector/models/fees-collector.model.ts
+++ b/src/modules/fees-collector/models/fees-collector.model.ts
@@ -31,6 +31,9 @@ export class FeesCollectorModel {
     @Field(() => [String])
     allTokens: string[];
 
+    @Field(() => [String])
+    knownContracts: string[];
+
     @Field(() => [EsdtTokenPayment])
     accumulatedFees: [EsdtTokenPayment];
 

--- a/src/modules/fees-collector/services/fees-collector.abi.service.ts
+++ b/src/modules/fees-collector/services/fees-collector.abi.service.ts
@@ -4,6 +4,7 @@ import { MXProxyService } from '../../../services/multiversx-communication/mx.pr
 import {
     Interaction,
     TokenIdentifierValue,
+    TypedValue,
     U32Value,
 } from '@multiversx/sdk-core';
 import BigNumber from 'bignumber.js';
@@ -103,5 +104,27 @@ export class FeesCollectorAbiService
             contract.methodsExplicit.getAllTokens();
         const response = await this.getGenericData(interaction);
         return response.firstValue.valueOf();
+    }
+
+    @ErrorLoggerAsync({
+        className: FeesCollectorAbiService.name,
+    })
+    @GetOrSetCache({
+        baseKey: 'feesCollector',
+        remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
+        localTtl: CacheTtlInfo.ContractInfo.localTtl,
+    })
+    async knownContracts(): Promise<string[]> {
+        return await this.getKnownContractsRaw();
+    }
+
+    async getKnownContractsRaw(): Promise<string[]> {
+        const contract = await this.mxProxy.getFeesCollectorContract();
+        const interaction: Interaction =
+            contract.methodsExplicit.getAllKnownContracts();
+        const response = await this.getGenericData(interaction);
+        return response.firstValue
+            .valueOf()
+            .map((value: TypedValue) => value.valueOf().bech32());
     }
 }


### PR DESCRIPTION
## Reasoning
- fees collector didn't exposed all information
  
## Proposed Changes
- add missing `allTokens` field resolver
- expose fees collector known contracts on fees collector model

## How to test
```
query FeesCollector {
  feesCollector {
    allTokens
    knownContracts
  }
}
```
- query should return valid values
