### PR TITLE
[SERVICES-1740] optimal staking compound

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -560,7 +560,9 @@
         "roundedSwapEnable": {
             "USDC-8d4068": "5000000",
             "WEGLD-d7c6bb": "100000000000000000"
-        }
+        },
+        "COMPOUND_INTERVAL_DAYS": 365,
+        "COMPOUND_TRANSACTION_FEE": 0.000365144
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -561,7 +561,6 @@
             "USDC-8d4068": "5000000",
             "WEGLD-d7c6bb": "100000000000000000"
         },
-        "COMPOUND_INTERVAL_DAYS": 365,
         "COMPOUND_TRANSACTION_FEE": 0.000365144
     },
     "dataApi": {

--- a/src/config/test.json
+++ b/src/config/test.json
@@ -23,6 +23,7 @@
     "constants": {
         "MAX_SWAP_SPREAD": 1,
         "MEX_TOKEN_ID": "MEX-123456",
-        "USDC_TOKEN_ID": "USDC-123456"
+        "USDC_TOKEN_ID": "USDC-123456",
+        "COMPOUND_TRANSACTION_FEE": 0.1
     }
 }

--- a/src/modules/pair/mocks/pair.constants.ts
+++ b/src/modules/pair/mocks/pair.constants.ts
@@ -33,6 +33,7 @@ export const Tokens = (tokenID: string): EsdtToken => {
                 assets: new AssetsModel(),
                 initialMinted: '1',
                 price: '10',
+                derivedEGLD: '1',
                 roles: new RolesModel(),
             });
         case 'MEX-123456':

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -62,3 +62,19 @@ export class StakingRewardsModel {
         Object.assign(this, init);
     }
 }
+
+@ObjectType()
+export class OptimalCompoundModel {
+    @Field(() => Int, {
+        description: 'The optimal number of compounds in the given interval',
+    })
+    interval: number;
+    @Field(() => Int)
+    hours: number;
+    @Field(() => Int)
+    minutes: number;
+
+    constructor(init?: Partial<OptimalCompoundModel>) {
+        Object.assign(this, init);
+    }
+}

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -69,6 +69,10 @@ export class OptimalCompoundModel {
         description: 'The optimal number of compounds in the given interval',
     })
     interval: number;
+    @Field()
+    optimalProfit: number;
+    @Field(() => Int)
+    days: number;
     @Field(() => Int)
     hours: number;
     @Field(() => Int)

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -241,18 +241,15 @@ export class StakingComputeService {
             .multipliedBy(egldPriceFarmingToken)
             .toNumber();
 
-        // Express compound iterations in minutes
-        const compoundIterations =
-            constantsConfig.COMPOUND_INTERVAL_DAYS * 24 * 60;
+        // Express compound iterations in hours
+        const compoundIterations = 365 * 24;
 
         let optimalCompoundIterations = 0;
         let optimalProfit = 0;
 
         for (let iterator = 1; iterator < compoundIterations; iterator += 1) {
             const rewards =
-                (1 +
-                    (parseFloat(apr) * timeHorizon) /
-                        (constantsConfig.COMPOUND_INTERVAL_DAYS * iterator)) **
+                (1 + (parseFloat(apr) * timeHorizon) / (365 * iterator)) **
                 iterator;
 
             const finalAmount = denominatedAmount * rewards;

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -269,15 +269,19 @@ export class StakingComputeService {
 
         /*
             Compute optimal compound frequency expressed in hours and minutes:
+                freqDays = (timeInterval/OptimalCompound)
                 freqHours = (timeInterval*24h/OptimalCompound)
                 freqMinutes = [(timeInterval*24h/OptimalCompound) - INT((timeInterval*24h/OptimalCompound))] * 60
         */
-        const frequencyHours = (timeHorizon * 24) / optimalCompoundIterations;
+        const freqDays = timeHorizon / optimalCompoundIterations;
+        const frequencyHours = (freqDays - Math.floor(freqDays)) * 24;
         const frequencyMinutes =
             (frequencyHours - Math.floor(frequencyHours)) * 60;
 
         return new OptimalCompoundModel({
+            optimalProfit: optimalProfit,
             interval: optimalCompoundIterations,
+            days: Math.floor(freqDays),
             hours: Math.floor(frequencyHours),
             minutes: Math.floor(frequencyMinutes),
         });

--- a/src/modules/staking/specs/staking.compute.service.spec.ts
+++ b/src/modules/staking/specs/staking.compute.service.spec.ts
@@ -147,15 +147,17 @@ describe('StakingComputeService', () => {
         const optimalCompoundFrequency =
             await service.computeOptimalCompoundFrequency(
                 Address.Zero().bech32(),
-                '1000000000000000000',
+                '1000000000000000000000',
                 365,
             );
 
         expect(optimalCompoundFrequency).toEqual(
             new OptimalCompoundModel({
-                interval: 1,
-                hours: 8760,
-                minutes: 0,
+                optimalProfit: 103.68922538240217,
+                interval: 7,
+                days: 52,
+                hours: 3,
+                minutes: 25,
             }),
         );
     });

--- a/src/modules/staking/specs/staking.compute.service.spec.ts
+++ b/src/modules/staking/specs/staking.compute.service.spec.ts
@@ -12,6 +12,7 @@ import { CachingModule } from 'src/services/caching/cache.module';
 import { ContextGetterServiceProvider } from 'src/services/context/mocks/context.getter.service.mock';
 import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 import { RemoteConfigGetterServiceProvider } from 'src/modules/remote-config/mocks/remote-config.getter.mock';
+import { OptimalCompoundModel } from '../models/staking.model';
 
 describe('StakingComputeService', () => {
     let module: TestingModule;
@@ -136,5 +137,26 @@ describe('StakingComputeService', () => {
 
         const apr = await service.computeStakeFarmAPR(Address.Zero().bech32());
         expect(apr).toEqual('0.21749328');
+    });
+
+    it('should compute optimal compound frequency', async () => {
+        const service = module.get<StakingComputeService>(
+            StakingComputeService,
+        );
+        jest.spyOn(service, 'stakeFarmAPR').mockResolvedValue('0.10');
+        const optimalCompoundFrequency =
+            await service.computeOptimalCompoundFrequency(
+                Address.Zero().bech32(),
+                '1000000000000000000',
+                365,
+            );
+
+        expect(optimalCompoundFrequency).toEqual(
+            new OptimalCompoundModel({
+                interval: 1,
+                hours: 8760,
+                minutes: 0,
+            }),
+        );
     });
 });

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -1,5 +1,12 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import {
+    Args,
+    Int,
+    Parent,
+    Query,
+    ResolveField,
+    Resolver,
+} from '@nestjs/graphql';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { TransactionModel } from 'src/models/transaction.model';
@@ -11,7 +18,11 @@ import {
     GenericStakeFarmArgs,
     ClaimRewardsWithNewValueArgs,
 } from './models/staking.args';
-import { StakingModel, StakingRewardsModel } from './models/staking.model';
+import {
+    OptimalCompoundModel,
+    StakingModel,
+    StakingRewardsModel,
+} from './models/staking.model';
 import {
     StakingTokenAttributesModel,
     UnbondTokenAttributesModel,
@@ -156,6 +167,20 @@ export class StakingResolver {
     ): Promise<StakingRewardsModel[]> {
         return this.stakingService.getBatchRewardsForPosition(
             args.farmsPositions,
+        );
+    }
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => OptimalCompoundModel)
+    async getOptimalCompoundFrequency(
+        @Args('stakeAddress') stakeAddress: string,
+        @Args('amount') amount: string,
+        @Args('timeInterval') timeInterval: number,
+    ): Promise<OptimalCompoundModel> {
+        return this.stakingCompute.computeOptimalCompoundFrequency(
+            stakeAddress,
+            amount,
+            timeInterval,
         );
     }
 

--- a/src/modules/tokens/mocks/token.getter.service.mock.ts
+++ b/src/modules/tokens/mocks/token.getter.service.mock.ts
@@ -11,6 +11,10 @@ export class TokenGetterServiceMock {
     async getEsdtTokenType(tokenID: string): Promise<string> {
         return Tokens(tokenID).type;
     }
+
+    async getDerivedEGLD(tokenID: string): Promise<string> {
+        return Tokens(tokenID).derivedEGLD;
+    }
 }
 
 export const TokenGetterServiceProvider = {


### PR DESCRIPTION
## Reasoning
- staking contracts positions can be compounded directly without rewards harvesting; because investment and rewards are the same type, we can compound the rewards and calculate the optimal frequency for compounding
  
## Proposed Changes
- add method to compute optimal compound frequency for any staking position expressed in hours and minutes interval

## How to test
```
query OptimalCompound {
	getOptimalCompoundFrequency(
		stakeAddress: "erd1qqqqqqqqqqqqqpgq8w0s682m88xae2ne3qkq7w2h26u5a5c00n4stt02d7",
		amount: "900000000000000000000",
		timeInterval: 365
	) {
		interval
		hours
		minutes
	}
}
```
- query should return an OptimalCompound object
```
{
  "optimalProfit": 114.31687566993836,
  "interval": 34,
  "days": 10,
  "hours": 17,
  "minutes": 38
}
```