### PR TITLE
MEX-351: governance contract shard field

### DIFF
--- a/src/modules/governance/models/governance.contract.model.ts
+++ b/src/modules/governance/models/governance.contract.model.ts
@@ -6,6 +6,8 @@ import { EsdtToken } from '../../tokens/models/esdtToken.model';
 export class GovernanceTokenSnapshotContract {
     @Field()
     address: string;
+    @Field(() => Int)
+    shard: number;
     @Field()
     minFeeForPropose: string;
     @Field()

--- a/src/modules/governance/resolvers/governance.contract.resolver.ts
+++ b/src/modules/governance/resolvers/governance.contract.resolver.ts
@@ -14,6 +14,11 @@ export class GovernanceTokenSnapshotContractResolver {
     }
 
     @ResolveField()
+    async shard(@Parent() contract: GovernanceTokenSnapshotContract): Promise<number> {
+        return this.governanceAbi.getAddressShardID(contract.address);
+    }
+
+    @ResolveField()
     async minFeeForPropose(@Parent() contract: GovernanceTokenSnapshotContract): Promise<string> {
         return this.governanceAbi.minFeeForPropose(contract.address);
     }

--- a/src/modules/governance/services/governance.abi.service.ts
+++ b/src/modules/governance/services/governance.abi.service.ts
@@ -35,6 +35,16 @@ export class GovernanceTokenSnapshotAbiService
         remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
         localTtl: CacheTtlInfo.ContractState.localTtl,
     })
+    async getAddressShardID(scAddress: string): Promise<number> {
+        return await this.mxProxy.getAddressShardID(scAddress);
+    }
+
+    @ErrorLoggerAsync({ className: GovernanceTokenSnapshotAbiService.name })
+    @GetOrSetCache({
+        baseKey: 'governance',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
     async minFeeForPropose(scAddress: string): Promise<string> {
         return await this.minFeeForProposeRaw(scAddress);
     }


### PR DESCRIPTION
## Reasoning
- frontend needs the SC shard in order to compute timers based on block numbers

