### PR TITLE
MEX-354: add a thresholdPercentage for isEnergyOutdated

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -568,7 +568,8 @@
             "USDC-8d4068": "5000000",
             "WEGLD-d7c6bb": "100000000000000000"
         },
-        "COMPOUND_TRANSACTION_FEE": 0.000365144
+        "COMPOUND_TRANSACTION_FEE": 0.000365144,
+        "OUTDATED_ENERGY_THRESHOLD_PERCENTAGE": 1
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"

--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { scAddress } from '../../../../config';
+import { constantsConfig, scAddress } from '../../../../config';
 import { EnergyType } from '@multiversx/sdk-exchange';
 import { ClaimProgress } from '../../../../submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { ContractType, OutdatedContract, UserDualYiledToken, UserLockedFarmTokenV2 } from '../../models/user.model';
@@ -260,6 +260,10 @@ export class UserEnergyComputeService {
                 )
                 .toFixed();
         }
-        return currentUserEnergy.amount !== currentClaimProgress.energy.amount;
+        const energyDifference = new BigNumber(currentUserEnergy.amount).minus(currentClaimProgress.energy.amount).abs();
+        const averageAmount = new BigNumber(currentUserEnergy.amount).plus(currentClaimProgress.energy.amount).dividedBy(2);
+        const relativeDifferencePercentage = energyDifference.dividedBy(averageAmount).multipliedBy(100);
+
+        return relativeDifferencePercentage.isGreaterThan(constantsConfig.OUTDATED_ENERGY_THRESHOLD_PERCENTAGE);
     }
 }

--- a/src/modules/user/specs/user.energy.compute.service.spec.ts
+++ b/src/modules/user/specs/user.energy.compute.service.spec.ts
@@ -194,6 +194,38 @@ describe('UserEnergyComputeService', () => {
             }
         })).toBe(false);
     });
+    it('difference under 1%', () => {
+        const UserEnergyCompute = module.get<UserEnergyComputeService>(UserEnergyComputeService);
+        expect(UserEnergyCompute).toBeDefined();
+        expect(UserEnergyCompute.isEnergyOutdated({
+            amount: '99.1',
+            lastUpdateEpoch: 10,
+            totalLockedTokens: '5',
+        }, {
+            week: 10,
+            energy: {
+                amount: '105',
+                lastUpdateEpoch: 9,
+                totalLockedTokens: '5',
+            }
+        })).toBe(false);
+    });
+    it('difference equals 1%', () => {
+        const UserEnergyCompute = module.get<UserEnergyComputeService>(UserEnergyComputeService);
+        expect(UserEnergyCompute).toBeDefined();
+        expect(UserEnergyCompute.isEnergyOutdated({
+            amount: '101.0050251256281395',
+            lastUpdateEpoch: 10,
+            totalLockedTokens: '5',
+        }, {
+            week: 10,
+            energy: {
+                amount: '105',
+                lastUpdateEpoch: 9,
+                totalLockedTokens: '5',
+            }
+        })).toBe(false);
+    });
 
 
 });


### PR DESCRIPTION
## Reasoning
- `isEnergyOutdated` now returns true if the relative difference in percentage terms is greater than the threshold from the config, implying that the energy value is outdated with a difference greater than the threshold