### PR TITLE
[SERVICES-1740] optimal staking compound fix

### DIFF
--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -267,6 +267,16 @@ export class StakingComputeService {
             }
         }
 
+        if (optimalCompoundIterations === 0) {
+            return new OptimalCompoundModel({
+                optimalProfit: 0,
+                interval: 0,
+                days: 0,
+                hours: 0,
+                minutes: 0,
+            });
+        }
+
         /*
             Compute optimal compound frequency expressed in hours and minutes:
                 freqDays = (timeInterval/OptimalCompound)

--- a/src/modules/staking/specs/staking.compute.service.spec.ts
+++ b/src/modules/staking/specs/staking.compute.service.spec.ts
@@ -161,4 +161,27 @@ describe('StakingComputeService', () => {
             }),
         );
     });
+
+    it('should NOT compute optimal compound frequency', async () => {
+        const service = module.get<StakingComputeService>(
+            StakingComputeService,
+        );
+        jest.spyOn(service, 'stakeFarmAPR').mockResolvedValue('0.10');
+        const optimalCompoundFrequency =
+            await service.computeOptimalCompoundFrequency(
+                Address.Zero().bech32(),
+                '100000000000000000',
+                365,
+            );
+
+        expect(optimalCompoundFrequency).toEqual(
+            new OptimalCompoundModel({
+                optimalProfit: 0,
+                interval: 0,
+                days: 0,
+                hours: 0,
+                minutes: 0,
+            }),
+        );
+    });
 });


### PR DESCRIPTION
## Reasoning
- rewards generated from small positions can not cover the transactions fees
  
## Proposed Changes
- return zero values for small positions of staked tokens

## How to test
```
query OptimalCompound {
	getOptimalCompoundFrequency(
		stakeAddress: "erd1qqqqqqqqqqqqqpgqzps75vsk97w9nsx2cenv2r2tyxl4fl402jpsx78m9j",
		amount: "5063512981963332000",
		timeInterval: 365
	) {
		optimalProfit
		interval
		days
		hours
		minutes
	}
}
```
- query should return `0` on mainnet