### PR TITLE
[MEX-353] fix outdated contracts for users with no energy

### DIFF
--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -137,6 +137,10 @@ export class UserEnergyComputeService {
                 this.energyAbi.energyEntryForUser(userAddress),
             ]);
 
+        if (currentClaimProgress.week === 0) {
+            return new OutdatedContract();
+        }
+
         const outdatedClaimProgress = currentClaimProgress.week !== currentWeek;
 
         if (

--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -108,6 +108,10 @@ export class UserEnergyComputeService {
                 this.energyAbi.energyEntryForUser(userAddress),
             ]);
 
+        if (currentClaimProgress.week === 0) {
+            return new OutdatedContract();
+        }
+
         const outdatedClaimProgress = currentClaimProgress.week !== currentWeek;
 
         if (

--- a/src/modules/user/specs/user.energy.compute.service.spec.ts
+++ b/src/modules/user/specs/user.energy.compute.service.spec.ts
@@ -241,4 +241,42 @@ describe('UserEnergyComputeService', () => {
         });
     });
 
+    it('should NOT get outdated contracts if no claim progress', async () => {
+        const service = module.get<UserEnergyComputeService>(
+            UserEnergyComputeService,
+        );
+        const weeklyRewardsSplittingAbi =
+            module.get<WeeklyRewardsSplittingAbiService>(
+                WeeklyRewardsSplittingAbiService,
+            );
+        const weekTimekeepingAbi = module.get<WeekTimekeepingAbiService>(
+            WeekTimekeepingAbiService,
+        );
+        const energyAbi = module.get<EnergyAbiService>(EnergyAbiService);
+        jest.spyOn(
+            weeklyRewardsSplittingAbi,
+            'currentClaimProgress',
+        ).mockResolvedValue({
+            week: 0,
+            energy: {
+                amount: '0',
+                lastUpdateEpoch: 0,
+                totalLockedTokens: '0',
+            },
+        });
+        jest.spyOn(weekTimekeepingAbi, 'currentWeek').mockResolvedValue(10);
+        jest.spyOn(energyAbi, 'energyEntryForUser').mockResolvedValue({
+            amount: '0',
+            lastUpdateEpoch: 0,
+            totalLockedTokens: '0',
+        });
+
+        const outdatedContracts =
+            await service.computeFeesCollectorOutdatedContract(
+                Address.Zero().bech32(),
+            );
+
+        expect(outdatedContracts).toEqual({});
+    });
+
 });


### PR DESCRIPTION
## Reasoning
- users with no claim progress in farms or fees collector should not get outdated energy pop-up for these contracts
  
## Proposed Changes
- add check for claim progress week

## How to test
```
query UserOutdatedContracts {
	userOutdatedContracts {
		address
		type
		claimProgressOutdated
	}
}
```
- query should return empty array for accounts with no energy