### PR TITLE
[SERVICES-1801] new devnet farm addresses

### DIFF
--- a/src/config/devnet.json
+++ b/src/config/devnet.json
@@ -94,8 +94,8 @@
                 "unlockedRewards": [
                 ],
                 "lockedRewards": [
-                    "erd1qqqqqqqqqqqqqpgq59hlx9lmclzngxfnxwjpzru3ukm3hfvj0n4sh8pkmp",
-                    "erd1qqqqqqqqqqqqqpgq835vpevjysz042t3wnp6q5a7skxaerm90n4sg85ekq"
+                    "erd1qqqqqqqqqqqqqpgqnqe5qhepftkxny7n8q2uaytlzjqww64p0n4sylm47u",
+                    "erd1qqqqqqqqqqqqqpgqzwvzevy2dg20fr5t5pfethsqr8zdc3ga0n4svh20vp"
                 ]
         }
     },


### PR DESCRIPTION
## Reasoning
- current devnet farms are not upgradable
  
## Proposed Changes
- update devnet farm addresses with new ones

## How to test
```
query Farms {
	farms {
		... on FarmModelV2 {
			address
			burnGasLimit
			boostedYieldsFactors {
				maxRewardsFactor
				minFarmAmount
				minEnergyAmount
				userRewardsFarm
				userRewardsEnergy
				
			}
			boostedYieldsRewardsPercenatage
			divisionSafetyConstant
			energyFactoryAddress
			
			farmedToken {identifier}
			farmedTokenPriceUSD
			farmingToken {identifier}
			farmingTokenPriceUSD
			farmToken {collection}
			farmTokenPriceUSD
			farmTokenSupply
			lastErrorMessage
			lastRewardBlockNonce
			minimumFarmingEpochs
			pair {address}
			penaltyPercent
			perBlockRewards
			produceRewardsEnabled
			rewardPerShare
			rewardReserve
			state
			totalValueLockedUSD
			transferExecGasLimit
			version
			lastGlobalUpdateWeek
			optimalEnergyPerLp
			rewardType
			time {
				scAddress
				firstWeekStartEpoch
				startEpochForWeek
				endEpochForWeek
				currentWeek
			}
			boosterRewards {
				scAddress
				week
				apr
				totalEnergyForWeek
				totalLockedTokensForWeek
				rewardsDistributionForWeek {
					tokenId
					percentage
				}
				totalRewardsForWeek {
					tokenType
					tokenID
					amount
				}
			}
		}
	}
}
```
- query should return new farms on devnet setup