### PR TITLE
[SERVICES-1813] fix lp token price usd

### DIFF
--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -13,6 +13,7 @@ import { AnalyticsQueryService } from 'src/services/analytics/services/analytics
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import { IPairComputeService } from '../interfaces';
 import { TokenService } from 'src/modules/tokens/services/token.service';
+import { computeValueUSD } from 'src/utils/token.converters';
 
 @Injectable()
 export class PairComputeService implements IPairComputeService {
@@ -140,18 +141,18 @@ export class PairComputeService implements IPairComputeService {
             new BigNumber(`1e${lpToken.decimals}`).toFixed(),
         );
 
-        const firstTokenDenom = new BigNumber(10).pow(firstToken.decimals);
-        const secondTokenDenom = new BigNumber(10).pow(secondToken.decimals);
+        const firstTokenValueUSD = computeValueUSD(
+            lpPosition.firstTokenAmount,
+            firstToken.decimals,
+            firstTokenPriceUSD,
+        );
+        const secondTokenValueUSD = computeValueUSD(
+            lpPosition.secondTokenAmount,
+            secondToken.decimals,
+            secondTokenPriceUSD,
+        );
 
-        return new BigNumber(lpPosition.firstTokenAmount)
-            .div(firstTokenDenom)
-            .times(firstTokenPriceUSD)
-            .plus(
-                new BigNumber(lpPosition.secondTokenAmount)
-                    .div(secondTokenDenom)
-                    .times(secondTokenPriceUSD),
-            )
-            .toFixed();
+        return firstTokenValueUSD.plus(secondTokenValueUSD).toFixed();
     }
 
     @ErrorLoggerAsync({

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -147,7 +147,7 @@ export class PairComputeService implements IPairComputeService {
             .div(firstTokenDenom)
             .times(firstTokenPriceUSD)
             .plus(
-                new BigNumber(lpPosition.firstTokenAmount)
+                new BigNumber(lpPosition.secondTokenAmount)
                     .div(secondTokenDenom)
                     .times(secondTokenPriceUSD),
             )

--- a/src/modules/pair/specs/pair.compute.service.spec.ts
+++ b/src/modules/pair/specs/pair.compute.service.spec.ts
@@ -141,18 +141,21 @@ describe('PairService', () => {
 
     it('should get lpToken Price in USD from pair', async () => {
         const service = module.get<PairComputeService>(PairComputeService);
-        const tokenCompute =
-            module.get<TokenComputeService>(TokenComputeService);
-        jest.spyOn(tokenCompute, 'getEgldPriceInUSD').mockReturnValue(
-            Promise.resolve('20'),
-        );
 
-        const lpTokenPriceUSD = await service.computeLpTokenPriceUSD(
+        let lpTokenPriceUSD = await service.computeLpTokenPriceUSD(
             Address.fromHex(
                 '0000000000000000000000000000000000000000000000000000000000000012',
             ).bech32(),
         );
-        expect(lpTokenPriceUSD).toEqual('40');
+        expect(lpTokenPriceUSD).toEqual('20');
+
+        lpTokenPriceUSD = await service.computeLpTokenPriceUSD(
+            Address.fromHex(
+                '0000000000000000000000000000000000000000000000000000000000000013',
+            ).bech32(),
+        );
+
+        expect(lpTokenPriceUSD).toEqual('2000000000000');
     });
 
     it('should get pair type: Core', async () => {


### PR DESCRIPTION
## Reasoning
- fix compute lp token price in USD
  
## Proposed Changes
- use correct denominations for tokens involved in lp token price compute USD

## How to test
```
query Pairs {
	pairs(offset: 0, limit: 100) {
		address
		liquidityPoolTokenPriceUSD
	}
}
``` 
- query should return correct values for lp token price in USD