### PR TITLE
[MEX-363] fix governance addresses

### DIFF
--- a/src/config/mainnet.json
+++ b/src/config/mainnet.json
@@ -41,11 +41,14 @@
                 "erd1qqqqqqqqqqqqqpgqdt9aady5jp7av97m7rqxh6e5ywyqsplz2jps5mw02n"
             ]
         },
-        "energy": {},
+        "energy": {
+            "cvadratic": []
+        },
         "tokenSnapshot": {
             "linear": [
                 "erd1qqqqqqqqqqqqqpgq7cywmem5g66ad49rce0ctu6yqmscmp9v7j6q7cded4"
-            ]
+            ],
+            "cvadratic": []
         }
     },
     "farms": {

--- a/src/config/staging.json
+++ b/src/config/staging.json
@@ -41,11 +41,14 @@
                 "erd1qqqqqqqqqqqqqpgqdt9aady5jp7av97m7rqxh6e5ywyqsplz2jps5mw02n"
             ]
         },
-        "energy": {},
+        "energy": {
+            "cvadratic": []
+        },
         "tokenSnapshot": {
             "linear": [
                 "erd1qqqqqqqqqqqqqpgq7cywmem5g66ad49rce0ctu6yqmscmp9v7j6q7cded4"
-            ]
+            ],
+            "cvadratic": []
         }
     },
     "farms": {


### PR DESCRIPTION
## Reasoning
- specialized configs are overwritten from default if not available
  
## Proposed Changes
- add empty governance addresses for mainnet / staging

## How to test
```
query Governance {
	governanceContracts {
		... on GovernanceTokenSnapshotContract {
			address
			feeToken {
				identifier
			}
		}
	}
}
```
