### PR TITLE
[SERVICES-1824] improve escrow queries

### DIFF
--- a/src/modules/escrow/services/escrow.abi.service.ts
+++ b/src/modules/escrow/services/escrow.abi.service.ts
@@ -270,6 +270,12 @@ export class EscrowAbiService extends GenericAbiService {
         remoteTtl: oneDay(),
     })
     async addressPermission(address: string): Promise<SCPermissions[]> {
+        const addressesWithPermissions =
+            await this.allAddressesWithPermissions();
+        if (!addressesWithPermissions.includes(address)) {
+            return [SCPermissions.NONE];
+        }
+
         return await this.getAddressPermissionRaw(address);
     }
 

--- a/src/modules/escrow/services/escrow.abi.service.ts
+++ b/src/modules/escrow/services/escrow.abi.service.ts
@@ -114,10 +114,17 @@ export class EscrowAbiService extends GenericAbiService {
     }
 
     async getAllReceiversRaw(senderAddress: string): Promise<string[]> {
-        const hexValues = await this.mxGateway.getSCStorageKeys(
-            scAddress.escrow,
-            [],
+        let hexValues = await this.cachingService.getCache<object>(
+            `escrow.scKeys`,
         );
+        if (!hexValues || hexValues === undefined) {
+            hexValues = await this.mxGateway.getSCStorageKeys(
+                scAddress.escrow,
+                [],
+            );
+            await this.escrowSetter.setSCStorageKeys(hexValues);
+        }
+
         const receivers = [];
         const allSendersHex = Buffer.from('allSenders').toString('hex');
         const itemHex = Buffer.from('.item').toString('hex');

--- a/src/modules/escrow/services/escrow.abi.service.ts
+++ b/src/modules/escrow/services/escrow.abi.service.ts
@@ -17,12 +17,16 @@ import { ErrorLoggerAsync } from 'src/helpers/decorators/error.logger';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { oneDay } from 'src/helpers/helpers';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
+import { CachingService } from 'src/services/caching/cache.service';
+import { EscrowSetterService } from './escrow.setter.service';
 
 @Injectable()
 export class EscrowAbiService extends GenericAbiService {
     constructor(
         protected readonly mxProxy: MXProxyService,
         private readonly mxGateway: MXGatewayService,
+        private readonly cachingService: CachingService,
+        private readonly escrowSetter: EscrowSetterService,
     ) {
         super(mxProxy);
     }
@@ -292,5 +296,41 @@ export class EscrowAbiService extends GenericAbiService {
             default:
                 return [];
         }
+    }
+
+    @ErrorLoggerAsync({
+        className: EscrowAbiService.name,
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'escrow',
+        remoteTtl: oneDay(),
+    })
+    async allAddressesWithPermissions(): Promise<string[]> {
+        return await this.getAllAddressesWithPermissionsRaw();
+    }
+
+    async getAllAddressesWithPermissionsRaw(): Promise<string[]> {
+        let hexValues = await this.cachingService.getCache<object>(
+            `escrow.scKeys`,
+        );
+        if (!hexValues || hexValues === undefined) {
+            hexValues = await this.mxGateway.getSCStorageKeys(
+                scAddress.escrow,
+                [],
+            );
+            await this.escrowSetter.setSCStorageKeys(hexValues);
+        }
+
+        const addresses = [];
+        const permissionsHex = Buffer.from('permissions').toString('hex');
+        Object.keys(hexValues).forEach((key) => {
+            if (key.includes(permissionsHex)) {
+                const addressHex = key.split(permissionsHex)[1];
+                addresses.push(Address.fromHex(addressHex).bech32());
+            }
+        });
+
+        return addresses;
     }
 }

--- a/src/modules/escrow/services/escrow.setter.service.ts
+++ b/src/modules/escrow/services/escrow.setter.service.ts
@@ -5,6 +5,7 @@ import { CachingService } from 'src/services/caching/cache.service';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
 import { ScheduledTransferModel } from '../models/escrow.model';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 @Injectable()
 export class EscrowSetterService extends GenericSetterService {
@@ -68,6 +69,15 @@ export class EscrowSetterService extends GenericSetterService {
             this.getCacheKey('receiverLastTransferEpoch', address),
             value,
             oneDay(),
+        );
+    }
+
+    async setSCStorageKeys(value: object): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('scKeys'),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
         );
     }
 }

--- a/src/modules/escrow/specs/escrow.abi.service.spec.ts
+++ b/src/modules/escrow/specs/escrow.abi.service.spec.ts
@@ -11,10 +11,12 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { CachingService } from 'src/services/caching/cache.service';
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
+import { EscrowSetterService } from '../services/escrow.setter.service';
 
 describe('EscrowAbiService', () => {
     let service: EscrowAbiService;
     let mxGateway: MXGatewayService;
+    let cachingService: CachingService;
 
     beforeAll(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -27,6 +29,7 @@ describe('EscrowAbiService', () => {
             ],
             providers: [
                 EscrowAbiService,
+                EscrowSetterService,
                 MXProxyServiceProvider,
                 MXGatewayServiceProvider,
                 CachingService,
@@ -36,6 +39,7 @@ describe('EscrowAbiService', () => {
 
         service = module.get<EscrowAbiService>(EscrowAbiService);
         mxGateway = module.get<MXGatewayService>(MXGatewayService);
+        cachingService = module.get<CachingService>(CachingService);
     });
 
     it('should be defined', () => {
@@ -119,6 +123,7 @@ describe('EscrowAbiService', () => {
 
         receivers = await service.getAllReceiversRaw(sender.bech32());
         expect(receivers).toEqual([]);
+        await cachingService.deleteInCache(`escrow.scKeys`);
     });
 
     it('should get one receiver for sender', async () => {
@@ -136,6 +141,7 @@ describe('EscrowAbiService', () => {
         expect(receivers).toEqual([
             'erd1devnet6uy8xjusvusfy3q83qadfhwrtty5fwa8ceh9cl60q2p6ysra7aaa',
         ]);
+        await cachingService.deleteInCache(`escrow.scKeys`);
     });
 
     it('should get two receivers for sender', async () => {
@@ -160,5 +166,6 @@ describe('EscrowAbiService', () => {
             'erd1devnet6uy8xjusvusfy3q83qadfhwrtty5fwa8ceh9cl60q2p6ysra7aaa',
             'erd1932eft30w753xyvme8d49qejgkjc09n5e49w4mwdjtm0neld797su0dlxp',
         ]);
+        await cachingService.deleteInCache(`escrow.scKeys`);
     });
 });


### PR DESCRIPTION
## Reasoning
- escrow queries ends calling SC via vm-queries or get all keys for every user
  
## Proposed Changes
- cache escrow SC keys to be used for all users
- cache all addresses that has at least one permission in escrow SC
- use cached escrow SC keys to get all receivers for a sender

## How to test
```
escrowPermissions
escrowReceivers
```
- queries should resolve in lesser time