### PR TITLE
Increase gas limit for multi pair txs

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -98,7 +98,7 @@
             "createPair": 30000000,
             "issueToken": 150000000,
             "setLocalRoles": 150000000,
-            "multiPairSwapMultiplier": 40000000,
+            "multiPairSwapMultiplier": 50000000,
             "swapEnableByUser": 50000000,
             "admin": {
                 "setState": 200000000,


### PR DESCRIPTION
## Reasoning
- failed multi pair swap transactions with not enough gas
  
## Proposed Changes
- increase gas limit multiplier for multi pair txs


## How to test
- N/A
