### PR TITLE
[SERVICES-1863] add new no auth transaction field for auto router

### DIFF
--- a/src/modules/auto-router/auto-router.resolver.ts
+++ b/src/modules/auto-router/auto-router.resolver.ts
@@ -64,4 +64,20 @@ export class AutoRouterResolver {
             });
         }
     }
+
+    @ResolveField(() => [TransactionModel])
+    async noAuthTransactions(
+        @Parent() parent: AutoRouteModel,
+        @Args('sender') sender: string,
+    ) {
+        try {
+            return await this.autoRouterService.getTransactions(sender, parent);
+        } catch (error) {
+            throw new GraphQLError(error.message, {
+                extensions: {
+                    code: ApolloServerErrorCode.INTERNAL_SERVER_ERROR,
+                },
+            });
+        }
+    }
 }

--- a/src/modules/auto-router/models/auto-route.model.ts
+++ b/src/modules/auto-router/models/auto-route.model.ts
@@ -63,6 +63,9 @@ export class AutoRouteModel {
     @Field(() => [TransactionModel], { nullable: true })
     transactions: TransactionModel[];
 
+    @Field(() => [TransactionModel], { nullable: true })
+    noAuthTransactions: TransactionModel[];
+
     constructor(init?: Partial<AutoRouteModel>) {
         Object.assign(this, init);
     }


### PR DESCRIPTION
## Reasoning
- 3rd party APIs could not get transctions for users without auth token
  
## Proposed Changes
- add a special unauthenticated field to get transactions for a user

## How to test
```
query Swap {
  swap(
    tokenInID: "EGLD",
    amountIn: "1000000000",
    tokenOutID: "USDC-8d4068",
    tolerance: 0.01
  ) {
    swapType
    tokenInID
    tokenOutID
    tokenInExchangeRate
    tokenOutExchangeRate
    tokenInPriceUSD
    tokenOutPriceUSD
    tokenRoute
    intermediaryAmounts
    amountOut
    fees
    pricesImpact
   noAuthtransactions(sender: "")
  }
}
```
- query should return transactions event without auth token