### PR TITLE
[SERVICES-1871] fix farm v2 base rewards

### DIFF
--- a/src/modules/farm/base-module/services/farm.abi.service.ts
+++ b/src/modules/farm/base-module/services/farm.abi.service.ts
@@ -404,4 +404,20 @@ export class FarmAbiService
         return (await this.apiService.getAccountStats(farmAddress))
             .ownerAddress;
     }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'farm',
+        remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
+        localTtl: CacheTtlInfo.ContractInfo.localTtl,
+    })
+    async farmShard(farmAddress: string): Promise<number> {
+        return await this.getFarmShardRaw(farmAddress);
+    }
+
+    async getFarmShardRaw(farmAddress: string): Promise<number> {
+        return (await this.apiService.getAccountStats(farmAddress)).shard;
+    }
 }

--- a/src/modules/farm/base-module/services/farm.compute.service.ts
+++ b/src/modules/farm/base-module/services/farm.compute.service.ts
@@ -107,13 +107,14 @@ export abstract class FarmComputeService implements IFarmComputeService {
     }
 
     async computeMintedRewards(farmAddress: string): Promise<BigNumber> {
+        const shardID = await this.farmAbi.farmShard(farmAddress);
         const [
             currentNonce,
             lastRewardBlockNonce,
             perBlockRewardAmount,
             produceRewardsEnabled,
         ] = await Promise.all([
-            this.contextGetter.getShardCurrentBlockNonce(1),
+            this.contextGetter.getShardCurrentBlockNonce(shardID),
             this.farmAbi.lastRewardBlockNonce(farmAddress),
             this.farmAbi.rewardsPerBlock(farmAddress),
             this.farmAbi.produceRewardsEnabled(farmAddress),

--- a/src/modules/farm/base-module/services/farm.compute.service.ts
+++ b/src/modules/farm/base-module/services/farm.compute.service.ts
@@ -106,36 +106,22 @@ export abstract class FarmComputeService implements IFarmComputeService {
         return this.pairCompute.computeLpTokenPriceUSD(pairAddress);
     }
 
-    async computeFarmRewardsForPosition(
-        positon: CalculateRewardsArgs,
-        rewardPerShare: string,
-    ): Promise<BigNumber> {
+    async computeMintedRewards(farmAddress: string): Promise<BigNumber> {
         const [
             currentNonce,
             lastRewardBlockNonce,
             perBlockRewardAmount,
-            divisionSafetyConstant,
-            farmTokenSupply,
-            farmRewardPerShare,
             produceRewardsEnabled,
         ] = await Promise.all([
             this.contextGetter.getShardCurrentBlockNonce(1),
-            this.farmAbi.lastRewardBlockNonce(positon.farmAddress),
-            this.farmAbi.rewardsPerBlock(positon.farmAddress),
-            this.farmAbi.divisionSafetyConstant(positon.farmAddress),
-            this.farmAbi.farmTokenSupply(positon.farmAddress),
-            this.farmAbi.rewardPerShare(positon.farmAddress),
-            this.farmAbi.produceRewardsEnabled(positon.farmAddress),
+            this.farmAbi.lastRewardBlockNonce(farmAddress),
+            this.farmAbi.rewardsPerBlock(farmAddress),
+            this.farmAbi.produceRewardsEnabled(farmAddress),
         ]);
 
-        const amountBig = new BigNumber(positon.liquidity);
         const currentBlockBig = new BigNumber(currentNonce);
         const lastRewardBlockNonceBig = new BigNumber(lastRewardBlockNonce);
         const perBlockRewardAmountBig = new BigNumber(perBlockRewardAmount);
-        const divisionSafetyConstantBig = new BigNumber(divisionSafetyConstant);
-        const farmTokenSupplyBig = new BigNumber(farmTokenSupply);
-        const farmRewardPerShareBig = new BigNumber(farmRewardPerShare);
-        const rewardPerShareBig = new BigNumber(rewardPerShare);
 
         let toBeMinted = new BigNumber(0);
 
@@ -144,10 +130,36 @@ export abstract class FarmComputeService implements IFarmComputeService {
                 currentBlockBig.minus(lastRewardBlockNonceBig),
             );
         }
-        const rewardIncrease = toBeMinted;
+
+        return toBeMinted;
+    }
+
+    async computeFarmRewardsForPosition(
+        positon: CalculateRewardsArgs,
+        rewardPerShare: string,
+    ): Promise<BigNumber> {
+        const [
+            rewardIncrease,
+            divisionSafetyConstant,
+            farmTokenSupply,
+            farmRewardPerShare,
+        ] = await Promise.all([
+            this.computeMintedRewards(positon.farmAddress),
+            this.farmAbi.divisionSafetyConstant(positon.farmAddress),
+            this.farmAbi.farmTokenSupply(positon.farmAddress),
+            this.farmAbi.rewardPerShare(positon.farmAddress),
+        ]);
+
+        const amountBig = new BigNumber(positon.liquidity);
+        const divisionSafetyConstantBig = new BigNumber(divisionSafetyConstant);
+        const farmTokenSupplyBig = new BigNumber(farmTokenSupply);
+        const farmRewardPerShareBig = new BigNumber(farmRewardPerShare);
+        const rewardPerShareBig = new BigNumber(rewardPerShare);
+
         const rewardPerShareIncrease = rewardIncrease
             .times(divisionSafetyConstantBig)
-            .dividedBy(farmTokenSupplyBig);
+            .dividedBy(farmTokenSupplyBig)
+            .integerValue();
         const futureRewardPerShare = farmRewardPerShareBig.plus(
             rewardPerShareIncrease,
         );
@@ -158,7 +170,8 @@ export abstract class FarmComputeService implements IFarmComputeService {
 
             return amountBig
                 .times(rewardPerShareDiff)
-                .dividedBy(divisionSafetyConstantBig);
+                .dividedBy(divisionSafetyConstantBig)
+                .integerValue();
         }
         return new BigNumber(0);
     }

--- a/src/modules/farm/base-module/services/interfaces.ts
+++ b/src/modules/farm/base-module/services/interfaces.ts
@@ -23,6 +23,7 @@ export interface IFarmAbiService {
     pairContractAddress(farmAddress: string): Promise<string>;
     lastErrorMessage(farmAddress: string): Promise<string>;
     ownerAddress(farmAddress: string): Promise<string>;
+    farmShard(farmAddress: string): Promise<number>;
 }
 
 export interface IFarmComputeService {
@@ -30,4 +31,5 @@ export interface IFarmComputeService {
     farmedTokenPriceUSD(farmAddress: string): Promise<string>;
     farmTokenPriceUSD(farmAddress: string): Promise<string>;
     farmingTokenPriceUSD(farmAddress: string): Promise<string>;
+    computeMintedRewards(farmAddress: string): Promise<BigNumber>;
 }

--- a/src/modules/farm/mocks/farm.abi.service.mock.ts
+++ b/src/modules/farm/mocks/farm.abi.service.mock.ts
@@ -76,6 +76,10 @@ export class FarmAbiServiceMock implements IFarmAbiService {
     ): Promise<BigNumber> {
         return new BigNumber('1000000000000000000');
     }
+
+    async farmShard(farmAddress: string): Promise<number> {
+        return 1;
+    }
 }
 
 export const FarmAbiServiceProvider = {

--- a/src/modules/farm/mocks/farm.compute.service.mock.ts
+++ b/src/modules/farm/mocks/farm.compute.service.mock.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { FarmComputeService } from '../base-module/services/farm.compute.service';
 import { IFarmComputeService } from '../base-module/services/interfaces';
 
@@ -13,6 +14,9 @@ export class FarmComputeServiceMock implements IFarmComputeService {
     }
     async farmingTokenPriceUSD(farmAddress: string): Promise<string> {
         return '200';
+    }
+    computeMintedRewards(farmAddress: string): Promise<BigNumber> {
+        throw new Error('Method not implemented.');
     }
 }
 

--- a/src/modules/farm/v2/services/farm.v2.abi.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.service.ts
@@ -1,5 +1,6 @@
 import {
     Address,
+    AddressType,
     AddressValue,
     BigUIntType,
     BigUIntValue,
@@ -16,13 +17,12 @@ import { Injectable } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { CalculateRewardsArgs } from '../../models/farm.args';
 import { FarmAbiService } from '../../base-module/services/farm.abi.service';
-import { FarmTokenAttributesV1_3 } from '@multiversx/sdk-exchange';
+import { FarmTokenAttributesV2 } from '@multiversx/sdk-exchange';
 import { FarmRewardType } from '../../models/farm.model';
 import { farmType } from 'src/utils/farm.utils';
 import { BoostedYieldsFactors } from '../../models/farm.v2.model';
 import { MXProxyService } from '../../../../services/multiversx-communication/mx.proxy.service';
 import { MXGatewayService } from '../../../../services/multiversx-communication/mx.gateway.service';
-import { tokenNonce } from '../../../../utils/token.converters';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
@@ -296,13 +296,12 @@ export class FarmAbiServiceV2
         const contract = await this.mxProxy.getFarmSmartContract(
             args.farmAddress,
         );
-        const decodedAttributes = FarmTokenAttributesV1_3.fromAttributes(
+        const decodedAttributes = FarmTokenAttributesV2.fromAttributes(
             args.attributes,
         );
         const interaction: Interaction =
             contract.methodsExplicit.calculateRewardsForGivenPosition([
                 new AddressValue(Address.fromString(args.user)),
-                new U64Value(new BigNumber(tokenNonce(args.identifier))),
                 new BigUIntValue(new BigNumber(args.liquidity)),
                 new Struct(
                     new StructType('FarmTokenAttributes', [
@@ -312,19 +311,9 @@ export class FarmAbiServiceV2
                             new BigUIntType(),
                         ),
                         new FieldDefinition(
-                            'original_entering_epoch',
-                            '',
-                            new U64Type(),
-                        ),
-                        new FieldDefinition(
                             'entering_epoch',
                             '',
                             new U64Type(),
-                        ),
-                        new FieldDefinition(
-                            'initial_farming_amount',
-                            '',
-                            new BigUIntType(),
                         ),
                         new FieldDefinition(
                             'compounded_reward',
@@ -336,6 +325,11 @@ export class FarmAbiServiceV2
                             '',
                             new BigUIntType(),
                         ),
+                        new FieldDefinition(
+                            'original_owner',
+                            '',
+                            new AddressType(),
+                        ),
                     ]),
                     [
                         new Field(
@@ -346,25 +340,9 @@ export class FarmAbiServiceV2
                         ),
                         new Field(
                             new U64Value(
-                                new BigNumber(
-                                    decodedAttributes.originalEnteringEpoch,
-                                ),
-                            ),
-                            'original_entering_epoch',
-                        ),
-                        new Field(
-                            new U64Value(
                                 new BigNumber(decodedAttributes.enteringEpoch),
                             ),
                             'entering_epoch',
-                        ),
-                        new Field(
-                            new BigUIntValue(
-                                new BigNumber(
-                                    decodedAttributes.initialFarmingAmount,
-                                ),
-                            ),
-                            'initial_farming_amount',
                         ),
                         new Field(
                             new BigUIntValue(
@@ -381,6 +359,14 @@ export class FarmAbiServiceV2
                                 ),
                             ),
                             'current_farm_amount',
+                        ),
+                        new Field(
+                            new AddressValue(
+                                Address.fromString(
+                                    decodedAttributes.originalOwner,
+                                ),
+                            ),
+                            'original_owner',
                         ),
                     ],
                 ),

--- a/src/modules/farm/v2/services/farm.v2.compute.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.compute.service.ts
@@ -92,6 +92,20 @@ export class FarmComputeServiceV2
             .toFixed();
     }
 
+    async computeMintedRewards(farmAddress: string): Promise<BigNumber> {
+        const [toBeMinted, boostedYieldsRewardsPercenatage] = await Promise.all(
+            [
+                super.computeMintedRewards(farmAddress),
+                this.farmAbi.boostedYieldsRewardsPercenatage(farmAddress),
+            ],
+        );
+
+        return this.computeBaseRewards(
+            toBeMinted,
+            boostedYieldsRewardsPercenatage,
+        );
+    }
+
     async computeFarmRewardsForPosition(
         positon: CalculateRewardsArgs,
         rewardPerShare: string,


### PR DESCRIPTION
## Reasoning
- computed minted rewards used for compute rewards for position used full rewards instead of only base rewards
  
## Proposed Changes
- extract compute minted rewards in a method; for farm v2 override base implementation to return only base rewards
- use farm shard ID fetched from network

## How to test
- `getRewardsForPosition` query should return the same values for both `vmQuery: true` and `vmQuery: false` for a position(might have a slight deviation based on timing to execute and caches)
