### PR TITLE
[SERVICES-1877] farm v2 events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@golevelup/nestjs-rabbitmq": "^4.0.0",
                 "@multiversx/sdk-core": "^12.8.0",
                 "@multiversx/sdk-data-api-client": "^0.5.8",
-                "@multiversx/sdk-exchange": "^0.2.18",
+                "@multiversx/sdk-exchange": "^0.2.19",
                 "@multiversx/sdk-native-auth-server": "1.0.7",
                 "@multiversx/sdk-nestjs-cache": "^2.0.0-beta.2",
                 "@multiversx/sdk-nestjs-common": "^2.0.0-beta.2",
@@ -2856,9 +2856,9 @@
             }
         },
         "node_modules/@multiversx/sdk-exchange": {
-            "version": "0.2.18",
-            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.18.tgz",
-            "integrity": "sha512-E+ilBtNtW+SUYBssNzLBiojhxGsXJXyNCumaiWvD4OZgiHCWbGiPlA1fXZm1A4eTOWuT9rZw97rKJ2wSYXdY4w==",
+            "version": "0.2.19",
+            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.19.tgz",
+            "integrity": "sha512-xxWVJ8IMCyiE+yWZ5dKPX7bln7d6WsRv8aalCB373+oxZl69SG4bZc/ZfDy8zUPdDdwPEkXkaAWstvNNKJFmcg==",
             "dependencies": {
                 "@multiversx/sdk-core": "^11.2.0",
                 "bignumber.js": "9.0.1"
@@ -19006,9 +19006,9 @@
             }
         },
         "@multiversx/sdk-exchange": {
-            "version": "0.2.18",
-            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.18.tgz",
-            "integrity": "sha512-E+ilBtNtW+SUYBssNzLBiojhxGsXJXyNCumaiWvD4OZgiHCWbGiPlA1fXZm1A4eTOWuT9rZw97rKJ2wSYXdY4w==",
+            "version": "0.2.19",
+            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.19.tgz",
+            "integrity": "sha512-xxWVJ8IMCyiE+yWZ5dKPX7bln7d6WsRv8aalCB373+oxZl69SG4bZc/ZfDy8zUPdDdwPEkXkaAWstvNNKJFmcg==",
             "requires": {
                 "@multiversx/sdk-core": "^11.2.0",
                 "bignumber.js": "9.0.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@golevelup/nestjs-rabbitmq": "^4.0.0",
         "@multiversx/sdk-core": "^12.8.0",
         "@multiversx/sdk-data-api-client": "^0.5.8",
-        "@multiversx/sdk-exchange": "^0.2.18",
+        "@multiversx/sdk-exchange": "^0.2.19",
         "@multiversx/sdk-native-auth-server": "1.0.7",
         "@multiversx/sdk-nestjs-cache": "^2.0.0-beta.2",
         "@multiversx/sdk-nestjs-common": "^2.0.0-beta.2",

--- a/src/modules/rabbitmq/handlers/farm.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/farm.handler.service.ts
@@ -24,7 +24,7 @@ import { FarmSetterFactory } from '../../farm/farm.setter.factory';
 import { FarmAbiFactory } from '../../farm/farm.abi.factory';
 
 @Injectable()
-export class RabbitMQFarmHandlerService {
+export class FarmHandlerService {
     constructor(
         private readonly farmAbiFactory: FarmAbiFactory,
         private readonly farmSetterFactory: FarmSetterFactory,

--- a/src/modules/rabbitmq/handlers/farm.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/farm.handler.service.ts
@@ -134,35 +134,26 @@ export class FarmHandlerService {
     private async handleEnterFarmEventV2(
         event: EnterFarmEventV2,
     ): Promise<void> {
-        const cacheKeys = await Promise.all([
-            this.farmSetterFactory
-                .useSetter(event.address)
-                .setFarmTokenSupply(event.address, event.farmSupply.toFixed()),
-        ]);
-
-        await this.deleteCacheKeys(cacheKeys);
+        const cacheKey = await this.farmSetterFactory
+            .useSetter(event.address)
+            .setFarmTokenSupply(event.address, event.farmSupply.toFixed());
+        await this.deleteCacheKeys([cacheKey]);
     }
 
     private async handleExitFarmEventV2(event: ExitFarmEventV2): Promise<void> {
-        const cacheKeys = await Promise.all([
-            this.farmSetterFactory
-                .useSetter(event.address)
-                .setFarmTokenSupply(event.address, event.farmSupply.toFixed()),
-        ]);
-
-        await this.deleteCacheKeys(cacheKeys);
+        const cacheKey = await this.farmSetterFactory
+            .useSetter(event.address)
+            .setFarmTokenSupply(event.address, event.farmSupply.toFixed());
+        await this.deleteCacheKeys([cacheKey]);
     }
 
     private async handleClaimRewardsEventV2(
         event: ClaimRewardsEventV2,
     ): Promise<void> {
-        const cacheKeys = await Promise.all([
-            this.farmSetterFactory
-                .useSetter(event.address)
-                .setFarmTokenSupply(event.address, event.farmSupply.toFixed()),
-        ]);
-
-        await this.deleteCacheKeys(cacheKeys);
+        const cacheKey = await this.farmSetterFactory
+            .useSetter(event.address)
+            .setFarmTokenSupply(event.address, event.farmSupply.toFixed());
+        await this.deleteCacheKeys([cacheKey]);
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -6,7 +6,7 @@ import { RabbitMQProxyHandlerService } from './rabbitmq.proxy.handler.service';
 import { CompetingRabbitConsumer } from './rabbitmq.consumers';
 import { scAddress } from 'src/config';
 import { RabbitMQEsdtTokenHandlerService } from './rabbitmq.esdtToken.handler.service';
-import { farmsAddresses } from 'src/utils/farm.utils';
+import { farmVersion, farmsAddresses } from 'src/utils/farm.utils';
 import { RouterHandlerService } from './handlers/router.handler.service';
 import { RabbitMQMetabondingHandlerService } from './rabbitmq.metabonding.handler.service';
 import { PriceDiscoveryEventHandler } from './handlers/price.discovery.handler.service';
@@ -64,6 +64,8 @@ import { RouterAbiService } from '../router/services/router.abi.service';
 import { EscrowHandlerService } from './handlers/escrow.handler.service';
 import { governanceContractsAddresses } from '../../utils/governance';
 import { GovernanceHandlerService } from './handlers/governance.handler.service';
+import { FarmVersion } from '../farm/models/farm.model';
+import { raw } from '@nestjs/mongoose';
 
 @Injectable()
 export class RabbitMqConsumer {
@@ -165,13 +167,31 @@ export class RabbitMqConsumer {
                     this.updateIngestData(eventData);
                     break;
                 case FARM_EVENTS.ENTER_FARM:
-                    await this.wsFarmHandler.handleEnterFarmEvent(rawEvent);
+                    if (farmVersion(rawEvent.address) === FarmVersion.V2) {
+                        await this.wsFarmHandler.handleEnterFarmEventV2(
+                            rawEvent,
+                        );
+                    } else {
+                        await this.wsFarmHandler.handleEnterFarmEvent(rawEvent);
+                    }
                     break;
                 case FARM_EVENTS.EXIT_FARM:
-                    await this.wsFarmHandler.handleExitFarmEvent(rawEvent);
+                    if (farmVersion(rawEvent.address) === FarmVersion.V2) {
+                        await this.wsFarmHandler.handleExitFarmEventV2(
+                            rawEvent,
+                        );
+                    } else {
+                        await this.wsFarmHandler.handleExitFarmEvent(rawEvent);
+                    }
                     break;
                 case FARM_EVENTS.CLAIM_REWARDS:
-                    await this.wsFarmHandler.handleRewardsEvent(rawEvent);
+                    if (farmVersion(rawEvent.address) === FarmVersion.V2) {
+                        await this.wsFarmHandler.handleClaimRewardsEventV2(
+                            rawEvent,
+                        );
+                    } else {
+                        await this.wsFarmHandler.handleRewardsEvent(rawEvent);
+                    }
                     break;
                 case FARM_EVENTS.COMPOUND_REWARDS:
                     await this.wsFarmHandler.handleRewardsEvent(rawEvent);

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
-import { RabbitMQFarmHandlerService } from './rabbitmq.farm.handler.service';
+import { RabbitMQFarmHandlerService } from './handlers/farm.handler.service';
 import { RabbitMQProxyHandlerService } from './rabbitmq.proxy.handler.service';
 import { CompetingRabbitConsumer } from './rabbitmq.consumers';
 import { scAddress } from 'src/config';
@@ -167,31 +167,14 @@ export class RabbitMqConsumer {
                     this.updateIngestData(eventData);
                     break;
                 case FARM_EVENTS.ENTER_FARM:
-                    if (farmVersion(rawEvent.address) === FarmVersion.V2) {
-                        await this.wsFarmHandler.handleEnterFarmEventV2(
-                            rawEvent,
-                        );
-                    } else {
-                        await this.wsFarmHandler.handleEnterFarmEvent(rawEvent);
-                    }
+                    await this.wsFarmHandler.handleEnterFarmEvent(rawEvent);
                     break;
                 case FARM_EVENTS.EXIT_FARM:
-                    if (farmVersion(rawEvent.address) === FarmVersion.V2) {
-                        await this.wsFarmHandler.handleExitFarmEventV2(
-                            rawEvent,
-                        );
-                    } else {
-                        await this.wsFarmHandler.handleExitFarmEvent(rawEvent);
-                    }
+                    await this.wsFarmHandler.handleExitFarmEvent(rawEvent);
+
                     break;
                 case FARM_EVENTS.CLAIM_REWARDS:
-                    if (farmVersion(rawEvent.address) === FarmVersion.V2) {
-                        await this.wsFarmHandler.handleClaimRewardsEventV2(
-                            rawEvent,
-                        );
-                    } else {
-                        await this.wsFarmHandler.handleRewardsEvent(rawEvent);
-                    }
+                    await this.wsFarmHandler.handleRewardsEvent(rawEvent);
                     break;
                 case FARM_EVENTS.COMPOUND_REWARDS:
                     await this.wsFarmHandler.handleRewardsEvent(rawEvent);

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
-import { RabbitMQFarmHandlerService } from './handlers/farm.handler.service';
+import { FarmHandlerService } from './handlers/farm.handler.service';
 import { RabbitMQProxyHandlerService } from './rabbitmq.proxy.handler.service';
 import { CompetingRabbitConsumer } from './rabbitmq.consumers';
 import { scAddress } from 'src/config';
 import { RabbitMQEsdtTokenHandlerService } from './rabbitmq.esdtToken.handler.service';
-import { farmVersion, farmsAddresses } from 'src/utils/farm.utils';
+import { farmsAddresses } from 'src/utils/farm.utils';
 import { RouterHandlerService } from './handlers/router.handler.service';
 import { RabbitMQMetabondingHandlerService } from './rabbitmq.metabonding.handler.service';
 import { PriceDiscoveryEventHandler } from './handlers/price.discovery.handler.service';
@@ -64,8 +64,6 @@ import { RouterAbiService } from '../router/services/router.abi.service';
 import { EscrowHandlerService } from './handlers/escrow.handler.service';
 import { governanceContractsAddresses } from '../../utils/governance';
 import { GovernanceHandlerService } from './handlers/governance.handler.service';
-import { FarmVersion } from '../farm/models/farm.model';
-import { raw } from '@nestjs/mongoose';
 
 @Injectable()
 export class RabbitMqConsumer {
@@ -76,7 +74,7 @@ export class RabbitMqConsumer {
         private readonly routerAbi: RouterAbiService,
         private readonly liquidityHandler: LiquidityHandler,
         private readonly swapHandler: SwapEventHandler,
-        private readonly wsFarmHandler: RabbitMQFarmHandlerService,
+        private readonly wsFarmHandler: FarmHandlerService,
         private readonly wsProxyHandler: RabbitMQProxyHandlerService,
         private readonly routerHandler: RouterHandlerService,
         private readonly wsEsdtTokenHandler: RabbitMQEsdtTokenHandlerService,

--- a/src/modules/rabbitmq/rabbitmq.module.ts
+++ b/src/modules/rabbitmq/rabbitmq.module.ts
@@ -3,7 +3,7 @@ import { DynamicModule, Module } from '@nestjs/common';
 import { CommonAppModule } from 'src/common.app.module';
 import { FarmModule } from '../farm/farm.module';
 import { PairModule } from '../pair/pair.module';
-import { RabbitMQFarmHandlerService } from './rabbitmq.farm.handler.service';
+import { RabbitMQFarmHandlerService } from './handlers/farm.handler.service';
 import { RabbitMQProxyHandlerService } from './rabbitmq.proxy.handler.service';
 import { RabbitMqConsumer } from './rabbitmq.consumer';
 import { RabbitMQEsdtTokenHandlerService } from './rabbitmq.esdtToken.handler.service';

--- a/src/modules/rabbitmq/rabbitmq.module.ts
+++ b/src/modules/rabbitmq/rabbitmq.module.ts
@@ -3,7 +3,7 @@ import { DynamicModule, Module } from '@nestjs/common';
 import { CommonAppModule } from 'src/common.app.module';
 import { FarmModule } from '../farm/farm.module';
 import { PairModule } from '../pair/pair.module';
-import { RabbitMQFarmHandlerService } from './handlers/farm.handler.service';
+import { FarmHandlerService } from './handlers/farm.handler.service';
 import { RabbitMQProxyHandlerService } from './rabbitmq.proxy.handler.service';
 import { RabbitMqConsumer } from './rabbitmq.consumer';
 import { RabbitMQEsdtTokenHandlerService } from './rabbitmq.esdtToken.handler.service';
@@ -62,7 +62,7 @@ import { GovernanceModule } from '../governance/governance.module';
     ],
     providers: [
         RabbitMqConsumer,
-        RabbitMQFarmHandlerService,
+        FarmHandlerService,
         RabbitMQProxyHandlerService,
         RouterHandlerService,
         RabbitMQEsdtTokenHandlerService,


### PR DESCRIPTION
## Reasoning
- missing handlers for farm v2 events
  
## Proposed Changes
- added new methods to handle farm v2 events
- update rabbitmq handler to handle farm v2 events using new handlers

## How to test
- with `ENABLE_EVENTS_NOTIFIER=true` farm v2 events should be handled
