### PR TITLE
[MEX-376] migrate positions transactions

### DIFF
--- a/src/config/test.json
+++ b/src/config/test.json
@@ -4,7 +4,8 @@
         "MEX-123456": "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqfqktvqkr",
         "WEGLD_USDC": "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqfsr2ycrs",
         "proxyDexAddress": {
-            "v1": "erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl"
+            "v1": "erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl",
+            "v2": "erd1qqqqqqqqqqqqqpgqt6ltx52ukss9d2qag2k67at28a36xc9lkp2sr06394"
         }
     },
     "farms": {
@@ -16,6 +17,11 @@
             "lockedRewards": ["erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqeqs727zc"],
             "customRewards": [
                 "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqes9lzxht"
+            ]
+        },
+        "v2": {
+            "lockedRewards": [
+                "erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqsdtp6mh"
             ]
         }
     },

--- a/src/modules/analytics/specs/analytics.service.spec.ts
+++ b/src/modules/analytics/specs/analytics.service.spec.ts
@@ -122,6 +122,6 @@ describe('AnalyticsService', () => {
 
         const totalLockedValueUSDFarms =
             await service.computeLockedValueUSDFarms();
-        expect(totalLockedValueUSDFarms.toString()).toEqual('90');
+        expect(totalLockedValueUSDFarms.toString()).toEqual('110');
     });
 });

--- a/src/modules/farm/mocks/farm.constants.ts
+++ b/src/modules/farm/mocks/farm.constants.ts
@@ -49,4 +49,16 @@ export const farms = [
         rewardsPerBlock: '2000000000000000000',
         rewardPerShare: '0',
     },
+    {
+        address: Address.fromHex(
+            '0000000000000000000000000000000000000000000000000000000000000041',
+        ).bech32(),
+        farmedTokenID: 'MEX-123456',
+        farmTokenID: 'EGLDMEXFL-ghijkl',
+        farmingTokenID: 'EGLDMEXLP-abcdef',
+        farmTotalSupply: '1000000000000000000',
+        farmingTokenReserve: '1000000000000000000',
+        rewardsPerBlock: '2000000000000000000',
+        rewardPerShare: '0',
+    },
 ];

--- a/src/modules/farm/mocks/farm.v2.abi.service.mock.ts
+++ b/src/modules/farm/mocks/farm.v2.abi.service.mock.ts
@@ -55,6 +55,10 @@ export class FarmAbiServiceMockV2
     ): Promise<string> {
         throw new Error('Method not implemented.');
     }
+
+    async farmPositionMigrationNonce(farmAddress: string): Promise<number> {
+        return 10;
+    }
 }
 
 export const FarmAbiServiceProviderV2 = {

--- a/src/modules/farm/specs/farm.service.spec.ts
+++ b/src/modules/farm/specs/farm.service.spec.ts
@@ -159,6 +159,12 @@ describe('FarmService', () => {
                 rewardType: 'customRewards',
                 version: 'v1.3',
             },
+            {
+                address:
+                    'erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqsdtp6mh',
+                rewardType: 'lockedRewards',
+                version: 'v2',
+            },
         ]);
     });
 

--- a/src/modules/farm/specs/farm.v2.transactions.service.spec.ts
+++ b/src/modules/farm/specs/farm.v2.transactions.service.spec.ts
@@ -1,0 +1,127 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FarmTransactionServiceV2 } from '../v2/services/farm.v2.transaction.service';
+import { ConfigModule } from '@nestjs/config';
+import { WinstonModule } from 'nest-winston';
+import winston from 'winston';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXProxyServiceProvider } from 'src/services/multiversx-communication/mx.proxy.service.mock';
+import { FarmAbiServiceProviderV2 } from '../mocks/farm.v2.abi.service.mock';
+import { PairService } from 'src/modules/pair/services/pair.service';
+import { PairAbiServiceProvider } from 'src/modules/pair/mocks/pair.abi.service.mock';
+import { PairComputeServiceProvider } from 'src/modules/pair/mocks/pair.compute.service.mock';
+import { RouterAbiServiceProvider } from 'src/modules/router/mocks/router.abi.service.mock';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
+import { WrapAbiServiceProvider } from 'src/modules/wrapping/mocks/wrap.abi.service.mock';
+import { ApiConfigService } from 'src/helpers/api.config.service';
+import { TokenServiceProvider } from 'src/modules/tokens/mocks/token.service.mock';
+import { ContextGetterServiceProvider } from 'src/services/context/mocks/context.getter.service.mock';
+import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
+import { Address } from '@multiversx/sdk-core/out';
+import { encodeTransactionData } from 'src/helpers/helpers';
+
+describe('FarmTransactionsServiceV2', () => {
+    let module: TestingModule;
+
+    beforeAll(async () => {
+        module = await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({}),
+                WinstonModule.forRoot({
+                    transports: [new winston.transports.Console({})],
+                }),
+                DynamicModuleUtils.getCacheModule(),
+            ],
+            providers: [
+                ApiConfigService,
+                MXProxyServiceProvider,
+                MXApiServiceProvider,
+                FarmAbiServiceProviderV2,
+                PairService,
+                PairAbiServiceProvider,
+                PairComputeServiceProvider,
+                RouterAbiServiceProvider,
+                WrapAbiServiceProvider,
+                TokenServiceProvider,
+                ContextGetterServiceProvider,
+                FarmTransactionServiceV2,
+            ],
+        }).compile();
+    });
+
+    it('should be defined', () => {
+        const service = module.get<FarmTransactionServiceV2>(
+            FarmTransactionServiceV2,
+        );
+        expect(service).toBeDefined();
+    });
+
+    it('should NOT get migrate total farm position transaction', async () => {
+        const service = module.get<FarmTransactionServiceV2>(
+            FarmTransactionServiceV2,
+        );
+        const mxApi = module.get<MXApiService>(MXApiService);
+        jest.spyOn(mxApi, 'getNftsForUser').mockResolvedValue([
+            {
+                identifier: 'EGLDMEXFL-ghijkl-0a',
+                collection: 'EGLDMEXFL-ghijkl',
+                attributes:
+                    'AAAACBEpiw/pcSUIAAAAAAAADNIAAAAAAAAABysPQGpo9rtgu2ARp4Hri1PWHXkEdFCtqkaXfiAjkxKVEmLBBX0QkA==',
+                nonce: 10,
+                type: 'MetaESDT',
+                name: 'EGLDMEXLPStakedLK',
+                creator:
+                    'erd1qqqqqqqqqqqqqpgqna8cqqzdtdg849hr0pd5cmft8ujaguhv295qgchtqa',
+                balance: '12120193336145595',
+                decimals: 18,
+                ticker: 'EGLDMEXFL-2d2bba',
+            },
+        ]);
+
+        const transactions = await service.migrateTotalFarmPosition(
+            Address.fromHex(
+                '0000000000000000000000000000000000000000000000000000000000000041',
+            ).bech32(),
+            Address.Zero().bech32(),
+        );
+
+        expect(transactions.length).toEqual(0);
+    });
+
+    it('should NOT get migrate total farm position transaction', async () => {
+        const service = module.get<FarmTransactionServiceV2>(
+            FarmTransactionServiceV2,
+        );
+        const mxApi = module.get<MXApiService>(MXApiService);
+        jest.spyOn(mxApi, 'getNftsForUser').mockResolvedValue([
+            {
+                identifier: 'EGLDMEXFL-ghijkl-01',
+                collection: 'EGLDMEXFL-ghijkl',
+                attributes:
+                    'AAAACBEpiw/pcSUIAAAAAAAADNIAAAAAAAAABysPQGpo9rtgu2ARp4Hri1PWHXkEdFCtqkaXfiAjkxKVEmLBBX0QkA==',
+                nonce: 1,
+                type: 'MetaESDT',
+                name: 'EGLDMEXLPStakedLK',
+                creator:
+                    'erd1qqqqqqqqqqqqqpgqna8cqqzdtdg849hr0pd5cmft8ujaguhv295qgchtqa',
+                balance: '12120193336145595',
+                decimals: 18,
+                ticker: 'EGLDMEXFL-2d2bba',
+            },
+        ]);
+
+        const transactions = await service.migrateTotalFarmPosition(
+            Address.fromHex(
+                '0000000000000000000000000000000000000000000000000000000000000041',
+            ).bech32(),
+            Address.Zero().bech32(),
+        );
+        console.log(transactions);
+        expect(transactions[0].data).toEqual(
+            encodeTransactionData(
+                `ESDTNFTTransfer@EGLDMEXFL-ghijkl@01@12120193336145595@${Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000041',
+                ).bech32()}@claimRewards`,
+            ),
+        );
+    });
+});

--- a/src/modules/farm/specs/farm.v2.transactions.service.spec.ts
+++ b/src/modules/farm/specs/farm.v2.transactions.service.spec.ts
@@ -115,7 +115,7 @@ describe('FarmTransactionsServiceV2', () => {
             ).bech32(),
             Address.Zero().bech32(),
         );
-        console.log(transactions);
+
         expect(transactions[0].data).toEqual(
             encodeTransactionData(
                 `ESDTNFTTransfer@EGLDMEXFL-ghijkl@01@12120193336145595@${Address.fromHex(

--- a/src/modules/farm/v2/farm.v2.module.ts
+++ b/src/modules/farm/v2/farm.v2.module.ts
@@ -12,6 +12,7 @@ import { FarmSetterServiceV2 } from './services/farm.v2.setter.service';
 import { WeekTimekeepingModule } from '../../../submodules/week-timekeeping/week-timekeeping.module';
 import { WeeklyRewardsSplittingModule } from '../../../submodules/weekly-rewards-splitting/weekly-rewards-splitting.module';
 import { EnergyModule } from '../../energy/energy.module';
+import { FarmTransactionResolverV2 } from './farm.v2.transaction.resolver';
 
 @Module({
     imports: [
@@ -30,6 +31,7 @@ import { EnergyModule } from '../../energy/energy.module';
         FarmComputeServiceV2,
         FarmTransactionServiceV2,
         FarmResolverV2,
+        FarmTransactionResolverV2,
     ],
     exports: [
         FarmServiceV2,

--- a/src/modules/farm/v2/farm.v2.transaction.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.transaction.resolver.ts
@@ -1,0 +1,24 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+import { FarmTransactionServiceV2 } from './services/farm.v2.transaction.service';
+import { UseGuards } from '@nestjs/common';
+import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard';
+import { TransactionModel } from 'src/models/transaction.model';
+import { AuthUser } from 'src/modules/auth/auth.user';
+import { UserAuthResult } from 'src/modules/auth/user.auth.result';
+
+@Resolver()
+export class FarmTransactionResolverV2 {
+    constructor(private readonly farmTransaction: FarmTransactionServiceV2) {}
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => [TransactionModel])
+    async migrateTotalFarmPositions(
+        @Args('farmAddress') farmAddress: string,
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TransactionModel[]> {
+        return this.farmTransaction.migrateTotalFarmPosition(
+            farmAddress,
+            user.address,
+        );
+    }
+}

--- a/src/modules/farm/v2/farm.v2.transaction.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.transaction.resolver.ts
@@ -5,17 +5,31 @@ import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard'
 import { TransactionModel } from 'src/models/transaction.model';
 import { AuthUser } from 'src/modules/auth/auth.user';
 import { UserAuthResult } from 'src/modules/auth/user.auth.result';
+import { farmVersion } from 'src/utils/farm.utils';
+import { FarmVersion } from '../models/farm.model';
+import { GraphQLError } from 'graphql';
+import { ApolloServerErrorCode } from '@apollo/server/errors';
 
 @Resolver()
 export class FarmTransactionResolverV2 {
     constructor(private readonly farmTransaction: FarmTransactionServiceV2) {}
 
     @UseGuards(JwtOrNativeAuthGuard)
-    @Query(() => [TransactionModel])
+    @Query(() => [TransactionModel], {
+        description:
+            'Generate transactions to initialize the total farm positions for a user',
+    })
     async migrateTotalFarmPositions(
         @Args('farmAddress') farmAddress: string,
         @AuthUser() user: UserAuthResult,
     ): Promise<TransactionModel[]> {
+        if (farmVersion(farmAddress) !== FarmVersion.V2) {
+            throw new GraphQLError('Farm version is not supported', {
+                extensions: {
+                    code: ApolloServerErrorCode.BAD_USER_INPUT,
+                },
+            });
+        }
         return this.farmTransaction.migrateTotalFarmPosition(
             farmAddress,
             user.address,

--- a/src/modules/farm/v2/services/farm.v2.abi.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.service.ts
@@ -416,4 +416,26 @@ export class FarmAbiServiceV2
 
         return response.firstValue.valueOf().toFixed();
     }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'farm',
+        remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
+        localTtl: CacheTtlInfo.ContractInfo.localTtl,
+    })
+    async farmPositionMigrationNonce(farmAddress: string): Promise<number> {
+        return this.getFarmPositionMigrationNonceRaw(farmAddress);
+    }
+
+    async getFarmPositionMigrationNonceRaw(
+        farmAddress: string,
+    ): Promise<number> {
+        const contract = await this.mxProxy.getFarmSmartContract(farmAddress);
+        const interaction: Interaction =
+            contract.methodsExplicit.getFarmPositionMigrationNonce();
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().toNumber();
+    }
 }

--- a/src/modules/farm/v2/services/farm.v2.abi.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.service.ts
@@ -410,11 +410,14 @@ export class FarmAbiServiceV2
             ]);
         const response = await this.getGenericData(interaction);
 
-        if (response.returnCode.equals(ReturnCode.FunctionNotFound)) {
+        if (
+            response.returnCode.equals(ReturnCode.FunctionNotFound) ||
+            response.returnCode.equals(ReturnCode.UserError)
+        ) {
             return '0';
         }
 
-        return response.firstValue.valueOf().toFixed();
+        return response.firstValue.valueOf().total_farm_position.toFixed();
     }
 
     @ErrorLoggerAsync({

--- a/src/modules/farm/v2/services/farm.v2.transaction.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.transaction.service.ts
@@ -17,6 +17,7 @@ import { MXProxyService } from 'src/services/multiversx-communication/mx.proxy.s
 import { FarmAbiServiceV2 } from './farm.v2.abi.service';
 import { PairService } from 'src/modules/pair/services/pair.service';
 import { PairAbiService } from 'src/modules/pair/services/pair.abi.service';
+import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 
 @Injectable()
 export class FarmTransactionServiceV2 extends TransactionsFarmService {
@@ -25,6 +26,7 @@ export class FarmTransactionServiceV2 extends TransactionsFarmService {
         protected readonly farmAbi: FarmAbiServiceV2,
         protected readonly pairService: PairService,
         protected readonly pairAbi: PairAbiService,
+        private readonly mxApi: MXApiService,
     ) {
         super(mxProxy, farmAbi, pairService, pairAbi);
     }
@@ -135,5 +137,45 @@ export class FarmTransactionServiceV2 extends TransactionsFarmService {
         args: CompoundRewardsArgs,
     ): Promise<TransactionModel> {
         throw new Error('Method not implemented.');
+    }
+
+    async migrateTotalFarmPosition(
+        farmAddress: string,
+        userAddress: string,
+    ): Promise<TransactionModel[]> {
+        const [farmTokenID, migrationNonce, userNftsCount] = await Promise.all([
+            this.farmAbi.farmTokenID(farmAddress),
+            this.farmAbi.farmPositionMigrationNonce(farmAddress),
+            this.mxApi.getNftsCountForUser(userAddress),
+        ]);
+
+        if (userNftsCount === 0) {
+            return [];
+        }
+
+        const userNfts = await this.mxApi.getNftsForUser(
+            userAddress,
+            0,
+            userNftsCount,
+            'MetaESDT',
+            [farmTokenID],
+        );
+
+        const promises: Promise<TransactionModel>[] = [];
+        userNfts.forEach((nft) => {
+            if (nft.nonce < migrationNonce) {
+                promises.push(
+                    this.claimRewards(userAddress, {
+                        farmAddress,
+                        farmTokenID: nft.collection,
+                        farmTokenNonce: nft.nonce,
+                        amount: nft.balance,
+                        lockRewards: true,
+                    }),
+                );
+            }
+        });
+
+        return Promise.all(promises);
     }
 }

--- a/src/modules/farm/v2/services/interfaces.ts
+++ b/src/modules/farm/v2/services/interfaces.ts
@@ -25,6 +25,7 @@ export interface IFarmAbiServiceV2 extends IFarmAbiService {
         farmAddress: string,
         userAddress: string,
     ): Promise<string>;
+    farmPositionMigrationNonce(farmAddress: string): Promise<number>;
 }
 
 export interface IFarmComputeServiceV2 extends IFarmComputeService {

--- a/src/modules/proxy/mocks/proxy.abi.service.mock.ts
+++ b/src/modules/proxy/mocks/proxy.abi.service.mock.ts
@@ -9,13 +9,13 @@ import { ProxyFarmAbiService } from '../services/proxy-farm/proxy.farm.abi.servi
 
 export class ProxyAbiServiceMock implements IProxyAbiService {
     async lockedAssetTokenID(proxyAddress: string): Promise<string[]> {
-        return ['LKMEX-1234'];
+        return ['LKMEX-123456'];
     }
 }
 
 export class ProxyPairAbiServiceMock implements IProxyPairAbiService {
     async wrappedLpTokenID(proxyAddress: string): Promise<string> {
-        return 'LKLP-abcd';
+        return 'LKLP-abcdef';
     }
     intermediatedPairs(proxyAddress: string): Promise<string[]> {
         throw new Error('Method not implemented.');
@@ -24,7 +24,7 @@ export class ProxyPairAbiServiceMock implements IProxyPairAbiService {
 
 export class ProxyFarmAbiServiceMock implements IProxyFarmAbiService {
     async wrappedFarmTokenID(proxyAddress: string): Promise<string> {
-        return 'LKFARM-1234';
+        return 'LKFARM-123456';
     }
     intermediatedFarms(proxyAddress: string): Promise<string[]> {
         throw new Error('Method not implemented.');

--- a/src/modules/proxy/proxy.transaction.resolver.ts
+++ b/src/modules/proxy/proxy.transaction.resolver.ts
@@ -197,7 +197,10 @@ export class ProxyTransactionResolver {
     }
 
     @UseGuards(JwtOrNativeAuthGuard)
-    @Query(() => [TransactionModel])
+    @Query(() => [TransactionModel], {
+        description:
+            'Generate transactions to initialize the total farm positions for a user',
+    })
     async migrateTotalFarmPositionsProxy(
         @Args('proxyAddress') proxyAddress: string,
         @AuthUser() user: UserAuthResult,

--- a/src/modules/proxy/proxy.transaction.resolver.ts
+++ b/src/modules/proxy/proxy.transaction.resolver.ts
@@ -195,4 +195,16 @@ export class ProxyTransactionResolver {
             args,
         );
     }
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => [TransactionModel])
+    async migrateTotalFarmPositionsProxy(
+        @Args('proxyAddress') proxyAddress: string,
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TransactionModel[]> {
+        return this.transactionsProxyFarmService.migrateTotalFarmPosition(
+            user.address,
+            proxyAddress,
+        );
+    }
 }

--- a/src/modules/proxy/proxy.transaction.resolver.ts
+++ b/src/modules/proxy/proxy.transaction.resolver.ts
@@ -24,6 +24,7 @@ import { InputTokenModel } from 'src/models/inputToken.model';
 import { LiquidityTokensValidationPipe } from './validators/add.liquidity.input.validator';
 import { ProxyService } from './services/proxy.service';
 import { scAddress } from 'src/config';
+import { ProxyAddressValidationPipe } from './validators/proxy.address.validator';
 
 @Resolver()
 export class ProxyTransactionResolver {
@@ -202,7 +203,7 @@ export class ProxyTransactionResolver {
             'Generate transactions to initialize the total farm positions for a user',
     })
     async migrateTotalFarmPositionsProxy(
-        @Args('proxyAddress') proxyAddress: string,
+        @Args('proxyAddress', ProxyAddressValidationPipe) proxyAddress: string,
         @AuthUser() user: UserAuthResult,
     ): Promise<TransactionModel[]> {
         return this.transactionsProxyFarmService.migrateTotalFarmPosition(

--- a/src/modules/proxy/services/proxy-farm/proxy.farm.module.ts
+++ b/src/modules/proxy/services/proxy-farm/proxy.farm.module.ts
@@ -8,6 +8,7 @@ import { ProxyModule } from '../../proxy.module';
 import { PairModule } from 'src/modules/pair/pair.module';
 import { TokenModule } from 'src/modules/tokens/token.module';
 import { FarmModule } from 'src/modules/farm/farm.module';
+import { FarmModuleV2 } from 'src/modules/farm/v2/farm.v2.module';
 
 @Module({
     imports: [
@@ -16,6 +17,7 @@ import { FarmModule } from 'src/modules/farm/farm.module';
         ProxyPairModule,
         forwardRef(() => ProxyModule),
         FarmModule,
+        FarmModuleV2,
         PairModule,
         TokenModule,
     ],

--- a/src/modules/proxy/specs/proxy-pair-transactions.service.spec.ts
+++ b/src/modules/proxy/specs/proxy-pair-transactions.service.spec.ts
@@ -102,7 +102,7 @@ describe('TransactionProxyPairService', () => {
                         amount: firstTokenAmount,
                     },
                     {
-                        tokenID: 'LKMEX-1234',
+                        tokenID: 'LKMEX-123456',
                         nonce: 1,
                         amount: secondTokenAmount,
                     },
@@ -116,7 +116,7 @@ describe('TransactionProxyPairService', () => {
         expect(wrapEgldTransaction.value).toEqual(firstTokenAmount);
         expect(addLiquidityProxy.data).toEqual(
             encodeTransactionData(
-                'MultiESDTNFTTransfer@000000000000000005001e2a1428dd1e3a5146b3960d9e0f4a50369904ee5483@02@WEGLD-123456@@10@LKMEX-1234@01@09@addLiquidityProxy@0000000000000000000000000000000000000000000000000000000000000000@09@08',
+                'MultiESDTNFTTransfer@000000000000000005001e2a1428dd1e3a5146b3960d9e0f4a50369904ee5483@02@WEGLD-123456@@10@LKMEX-123456@01@09@addLiquidityProxy@0000000000000000000000000000000000000000000000000000000000000000@09@08',
             ),
         );
     });
@@ -148,7 +148,7 @@ describe('TransactionProxyPairService', () => {
                 pairAddress: Address.Zero().bech32(),
                 tokens: [
                     {
-                        tokenID: 'LKMEX-1234',
+                        tokenID: 'LKMEX-123456',
                         nonce: 1,
                         amount: firstTokenAmount,
                     },
@@ -167,7 +167,7 @@ describe('TransactionProxyPairService', () => {
         expect(wrapEgldTransaction.value).toEqual(secondTokenAmount);
         expect(addLiquidityProxy.data).toEqual(
             encodeTransactionData(
-                'MultiESDTNFTTransfer@000000000000000005001e2a1428dd1e3a5146b3960d9e0f4a50369904ee5483@02@WEGLD-123456@@09@LKMEX-1234@01@10@addLiquidityProxy@0000000000000000000000000000000000000000000000000000000000000000@08@09',
+                'MultiESDTNFTTransfer@000000000000000005001e2a1428dd1e3a5146b3960d9e0f4a50369904ee5483@02@WEGLD-123456@@09@LKMEX-123456@01@10@addLiquidityProxy@0000000000000000000000000000000000000000000000000000000000000000@08@09',
             ),
         );
     });

--- a/src/modules/proxy/specs/proxy.farm.transactions.service.spec.ts
+++ b/src/modules/proxy/specs/proxy.farm.transactions.service.spec.ts
@@ -1,0 +1,134 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProxyFarmTransactionsService } from '../services/proxy-farm/proxy.farm.transactions.service';
+import { WinstonModule } from 'nest-winston';
+import winston from 'winston';
+import { ConfigModule } from '@nestjs/config';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXProxyServiceProvider } from 'src/services/multiversx-communication/mx.proxy.service.mock';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
+import { FarmAbiServiceProviderV1_2 } from 'src/modules/farm/mocks/farm.v1.2.abi.service.mock';
+import { FarmAbiServiceProviderV1_3 } from 'src/modules/farm/mocks/farm.v1.3.abi.service.mock';
+import { FarmAbiServiceProviderV2 } from 'src/modules/farm/mocks/farm.v2.abi.service.mock';
+import { PairService } from 'src/modules/pair/services/pair.service';
+import { PairAbiServiceProvider } from 'src/modules/pair/mocks/pair.abi.service.mock';
+import { ProxyFarmAbiServiceProvider } from '../mocks/proxy.abi.service.mock';
+import { PairComputeServiceProvider } from 'src/modules/pair/mocks/pair.compute.service.mock';
+import { RouterAbiServiceProvider } from 'src/modules/router/mocks/router.abi.service.mock';
+import { WrapAbiServiceProvider } from 'src/modules/wrapping/mocks/wrap.abi.service.mock';
+import { TokenServiceProvider } from 'src/modules/tokens/mocks/token.service.mock';
+import { ContextGetterServiceProvider } from 'src/services/context/mocks/context.getter.service.mock';
+import { FarmAbiFactory } from 'src/modules/farm/farm.abi.factory';
+import { ApiConfigService } from 'src/helpers/api.config.service';
+import { Address } from '@multiversx/sdk-core/out';
+import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
+import { encodeTransactionData } from 'src/helpers/helpers';
+
+describe('ProxyFarmTransactionsService', () => {
+    let module: TestingModule;
+
+    beforeAll(async () => {
+        module = await Test.createTestingModule({
+            imports: [
+                WinstonModule.forRoot({
+                    transports: [new winston.transports.Console({})],
+                }),
+                ConfigModule.forRoot({}),
+                DynamicModuleUtils.getCacheModule(),
+            ],
+            providers: [
+                ProxyFarmTransactionsService,
+                MXProxyServiceProvider,
+                MXApiServiceProvider,
+                FarmAbiFactory,
+                FarmAbiServiceProviderV1_2,
+                FarmAbiServiceProviderV1_3,
+                FarmAbiServiceProviderV2,
+                PairService,
+                PairAbiServiceProvider,
+                PairComputeServiceProvider,
+                RouterAbiServiceProvider,
+                WrapAbiServiceProvider,
+                TokenServiceProvider,
+                ContextGetterServiceProvider,
+                ApiConfigService,
+                ProxyFarmAbiServiceProvider,
+            ],
+        }).compile();
+    });
+
+    it('should be defined', () => {
+        const service: ProxyFarmTransactionsService =
+            module.get<ProxyFarmTransactionsService>(
+                ProxyFarmTransactionsService,
+            );
+        expect(service).toBeDefined();
+    });
+
+    it('should NOT get migrate to total farm position transaction', async () => {
+        const service: ProxyFarmTransactionsService =
+            module.get<ProxyFarmTransactionsService>(
+                ProxyFarmTransactionsService,
+            );
+        const mxApi = module.get<MXApiService>(MXApiService);
+        jest.spyOn(mxApi, 'getNftsCountForUser').mockResolvedValue(1);
+        jest.spyOn(mxApi, 'getNftsForUser').mockResolvedValue([
+            {
+                identifier: 'LKFARM-123456-0a',
+                collection: 'LKFARM-123456',
+                attributes:
+                    'AAAAEEVHTERNRVhGTC1naGlqa2wAAAAAAAAACgAAAAcrKmP2fki2AAAAC0xLTFAtYWJjZGVmAAAAAAAAAAEAAAAHKypj9n5Itg==',
+                nonce: 10,
+                type: 'MetaESDT',
+                name: 'xMEXLPStaked',
+                creator:
+                    'erd1qqqqqqqqqqqqqpgqat0auzsgk9x0g9gm8n6tq6qa9xtmwu4h295qaalzvq',
+                balance: '12150032824158390',
+                decimals: 18,
+                ticker: 'LKFARM-123456',
+            },
+        ]);
+
+        const transactions = await service.migrateTotalFarmPosition(
+            Address.Zero().bech32(),
+            'erd1qqqqqqqqqqqqqpgqt6ltx52ukss9d2qag2k67at28a36xc9lkp2sr06394',
+        );
+
+        expect(transactions.length).toEqual(0);
+    });
+
+    it('should get migrate to total farm position transaction', async () => {
+        const service: ProxyFarmTransactionsService =
+            module.get<ProxyFarmTransactionsService>(
+                ProxyFarmTransactionsService,
+            );
+        const mxApi = module.get<MXApiService>(MXApiService);
+        jest.spyOn(mxApi, 'getNftsCountForUser').mockResolvedValue(1);
+        jest.spyOn(mxApi, 'getNftsForUser').mockResolvedValue([
+            {
+                identifier: 'LKFARM-123456-05',
+                collection: 'LKFARM-123456',
+                attributes:
+                    'AAAAEEVHTERNRVhGTC1naGlqa2wAAAAAAAAAAQAAAAcrKmP2fki2AAAAC0xLTFAtYWJjZGVmAAAAAAAAAAEAAAAHKypj9n5Itg==',
+                nonce: 5,
+                type: 'MetaESDT',
+                name: 'xMEXLPStaked',
+                creator:
+                    'erd1qqqqqqqqqqqqqpgqat0auzsgk9x0g9gm8n6tq6qa9xtmwu4h295qaalzvq',
+                balance: '12150032824158390',
+                decimals: 18,
+                ticker: 'LKFARM-123456',
+            },
+        ]);
+
+        const transactions = await service.migrateTotalFarmPosition(
+            Address.Zero().bech32(),
+            'erd1qqqqqqqqqqqqqpgqt6ltx52ukss9d2qag2k67at28a36xc9lkp2sr06394',
+        );
+
+        expect(transactions[0].data).toEqual(
+            encodeTransactionData(
+                'ESDTNFTTransfer@LKFARM-123456@05@12150032824158390@erd1qqqqqqqqqqqqqpgqt6ltx52ukss9d2qag2k67at28a36xc9lkp2sr06394@claimRewardsProxy@erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqsdtp6mh',
+            ),
+        );
+    });
+});

--- a/src/modules/proxy/validators/proxy.address.validator.ts
+++ b/src/modules/proxy/validators/proxy.address.validator.ts
@@ -1,0 +1,25 @@
+import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
+import { UserInputError } from '@nestjs/apollo';
+import { Address } from '@multiversx/sdk-core/out';
+import { scAddress } from 'src/config';
+
+@Injectable()
+export class ProxyAddressValidationPipe implements PipeTransform {
+    async transform(value: string, metadata: ArgumentMetadata) {
+        let address: Address;
+        try {
+            address = Address.fromBech32(value);
+        } catch (error) {
+            throw new UserInputError('Invalid address format');
+        }
+
+        const proxAddresses: string[] = Object.values(
+            scAddress.proxyDexAddress,
+        );
+        if (!proxAddresses.includes(address.bech32())) {
+            throw new UserInputError('Invalid proxy address');
+        }
+
+        return value;
+    }
+}

--- a/src/services/multiversx-communication/mx.api.service.mock.ts
+++ b/src/services/multiversx-communication/mx.api.service.mock.ts
@@ -33,6 +33,10 @@ export class MXApiServiceMock {
         ];
     }
 
+    async getNftsCountForUser(address: string): Promise<number> {
+        return 1;
+    }
+
     async getNftsForUser(address: string): Promise<NftToken[]> {
         return [
             {


### PR DESCRIPTION
## Reasoning
- users will have to initialize the total farm position with all their positions on a farm;
- users will perform a migration by claiming rewards with all the positions;
  
## Proposed Changes
- added method to get farm token migration nonce from smart contract;
- added method to generate claim rewards transactions for all farm positions with lower nonce than migration nonce;

## How to test
```
query MigrateToFarmPosition {
	migrateTotalFarmPositionsProxy(
		proxyAddress: <proxy_address>
	) {
            data
        }
}
```
```
query MigrateToFarmPosition {
	migrateTotalFarmPositions(
		farmAddress: <farm_address>
	) {
		data
	}
}
```
- queries should return transactions if user had positions in farm prior to upgrade