### PR TITLE
[MEX-405] weekly rewards splitting integration

### DIFF
--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -3,6 +3,7 @@ import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { StakingTokenAttributesModel } from './stakingTokenAttributes.model';
 import { WeekTimekeepingModel } from 'src/submodules/week-timekeeping/models/week-timekeeping.model';
+import { GlobalInfoByWeekModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 
 @ObjectType()
 export class StakingModel {
@@ -42,6 +43,18 @@ export class StakingModel {
     state: string;
     @Field({ description: 'Timekeeping for boosted rewards' })
     time: WeekTimekeepingModel;
+    @Field(() => [GlobalInfoByWeekModel], {
+        description: 'Global info for boosted rewards',
+    })
+    boosterRewards: [GlobalInfoByWeekModel];
+    @Field()
+    lastGlobalUpdateWeek: number;
+    @Field()
+    energyFactoryAddress: string;
+    @Field()
+    undistributedBoostedRewards: string;
+    @Field()
+    undistributedBoostedRewardsClaimed: string;
 
     constructor(init?: Partial<StakingModel>) {
         Object.assign(this, init);

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -5,6 +5,7 @@ import {
     BytesValue,
     Interaction,
     TypedValue,
+    U32Value,
 } from '@multiversx/sdk-core';
 import { Injectable } from '@nestjs/common';
 import { BigNumber } from 'bignumber.js';
@@ -430,5 +431,103 @@ export class StakingAbiService
             contract.methodsExplicit.getLastErrorMessage();
         const response = await this.getGenericData(interaction);
         return response.firstValue.valueOf().toString();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async energyFactoryAddress(stakeAddress: string): Promise<string> {
+        return await this.getEnergyFactoryAddressRaw(stakeAddress);
+    }
+
+    async getEnergyFactoryAddressRaw(stakeAddress: string): Promise<string> {
+        const contract = await this.mxProxy.getStakingSmartContract(
+            stakeAddress,
+        );
+
+        const interaction: Interaction =
+            contract.methodsExplicit.getEnergyFactoryAddress();
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().bech32();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async undistributedBoostedRewards(stakeAddress: string): Promise<string> {
+        return await this.getUndistributedBoostedRewardsRaw(stakeAddress);
+    }
+
+    async getUndistributedBoostedRewardsRaw(
+        stakeAddress: string,
+    ): Promise<string> {
+        const contract = await this.mxProxy.getStakingSmartContract(
+            stakeAddress,
+        );
+
+        const interaction: Interaction =
+            contract.methodsExplicit.getUndistributedBoostedRewards();
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().toFixed();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async lastUndistributedBoostedRewardsCollectWeek(
+        stakeAddress: string,
+    ): Promise<number> {
+        return this.gatewayService.getSCStorageKey(
+            stakeAddress,
+            'lastUndistributedBoostedRewardsCollectWeek',
+        );
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async remainingBoostedRewardsToDistribute(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string> {
+        return await this.getRemainingBoostedRewardsToDistributeRaw(
+            stakeAddress,
+            week,
+        );
+    }
+
+    async getRemainingBoostedRewardsToDistributeRaw(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string> {
+        const contract = await this.mxProxy.getStakingSmartContract(
+            stakeAddress,
+        );
+        const interaction: Interaction =
+            contract.methodsExplicit.getRemainingBoostedRewardsToDistribute([
+                new U32Value(new BigNumber(week)),
+            ]);
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().toFixed();
     }
 }

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -296,4 +296,60 @@ export class StakingComputeService {
             minutes: Math.floor(frequencyMinutes),
         });
     }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async undistributedBoostedRewards(
+        scAddress: string,
+        currentWeek: number,
+    ): Promise<string> {
+        const amount = await this.undistributedBoostedRewardsRaw(
+            scAddress,
+            currentWeek,
+        );
+        return amount.integerValue().toFixed();
+    }
+
+    async undistributedBoostedRewardsRaw(
+        scAddress: string,
+        currentWeek: number,
+    ): Promise<BigNumber> {
+        const [
+            undistributedBoostedRewards,
+            lastUndistributedBoostedRewardsCollectWeek,
+        ] = await Promise.all([
+            this.stakingAbi.undistributedBoostedRewards(scAddress),
+            this.stakingAbi.lastUndistributedBoostedRewardsCollectWeek(
+                scAddress,
+            ),
+        ]);
+
+        const firstWeek = lastUndistributedBoostedRewardsCollectWeek + 1;
+        const lastWeek = currentWeek - constantsConfig.USER_MAX_CLAIM_WEEKS - 1;
+        if (firstWeek > lastWeek) {
+            return new BigNumber(undistributedBoostedRewards);
+        }
+        const promises = [];
+        for (let week = firstWeek; week <= lastWeek; week++) {
+            promises.push(
+                this.stakingAbi.remainingBoostedRewardsToDistribute(
+                    scAddress,
+                    week,
+                ),
+            );
+        }
+        const remainingRewards = await Promise.all(promises);
+        const totalRemainingRewards = remainingRewards.reduce((acc, curr) => {
+            return new BigNumber(acc).plus(curr);
+        });
+        return new BigNumber(undistributedBoostedRewards).plus(
+            totalRemainingRewards,
+        );
+    }
 }

--- a/src/modules/staking/staking.module.ts
+++ b/src/modules/staking/staking.module.ts
@@ -11,6 +11,7 @@ import { StakingSetterService } from './services/staking.setter.service';
 import { StakingTransactionService } from './services/staking.transactions.service';
 import { StakingResolver } from './staking.resolver';
 import { WeekTimekeepingModule } from 'src/submodules/week-timekeeping/week-timekeeping.module';
+import { WeeklyRewardsSplittingModule } from 'src/submodules/weekly-rewards-splitting/weekly-rewards-splitting.module';
 
 @Module({
     imports: [
@@ -20,6 +21,7 @@ import { WeekTimekeepingModule } from 'src/submodules/week-timekeeping/week-time
         RemoteConfigModule,
         TokenModule,
         WeekTimekeepingModule,
+        WeeklyRewardsSplittingModule,
     ],
     providers: [
         StakingAbiService,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -27,6 +27,9 @@ import { StakingComputeService } from './services/staking.compute.service';
 import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 import { WeekTimekeepingModel } from 'src/submodules/week-timekeeping/models/week-timekeeping.model';
 import { WeekTimekeepingAbiService } from 'src/submodules/week-timekeeping/services/week-timekeeping.abi.service';
+import { GlobalInfoByWeekModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
+import { constantsConfig } from 'src/config';
+import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
 
 @Resolver(() => StakingModel)
 export class StakingResolver {
@@ -36,6 +39,7 @@ export class StakingResolver {
         private readonly stakingCompute: StakingComputeService,
         private readonly stakingTransactionService: StakingTransactionService,
         private readonly weekTimekeepingAbi: WeekTimekeepingAbiService,
+        private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
     ) {}
 
     @ResolveField()
@@ -127,6 +131,68 @@ export class StakingResolver {
             scAddress: parent.address,
             currentWeek: currentWeek,
         });
+    }
+
+    @ResolveField()
+    async boosterRewards(
+        @Parent() parent: StakingModel,
+    ): Promise<GlobalInfoByWeekModel[]> {
+        const modelsList = [];
+        const currentWeek = await this.weekTimekeepingAbi.currentWeek(
+            parent.address,
+        );
+        for (
+            let week = currentWeek - constantsConfig.USER_MAX_CLAIM_WEEKS;
+            week <= currentWeek;
+            week++
+        ) {
+            if (week < 1) {
+                continue;
+            }
+            modelsList.push(
+                new GlobalInfoByWeekModel({
+                    scAddress: parent.address,
+                    week: week,
+                }),
+            );
+        }
+        return modelsList;
+    }
+
+    @ResolveField()
+    async lastGlobalUpdateWeek(
+        @Parent() parent: StakingModel,
+    ): Promise<number> {
+        return this.weeklyRewardsSplittingAbi.lastGlobalUpdateWeek(
+            parent.address,
+        );
+    }
+
+    @ResolveField()
+    async energyFactoryAddress(
+        @Parent() parent: StakingModel,
+    ): Promise<string> {
+        return this.stakingAbi.energyFactoryAddress(parent.address);
+    }
+
+    @ResolveField()
+    async undistributedBoostedRewards(
+        @Parent() parent: StakingModel,
+    ): Promise<string> {
+        const currentWeek = await this.weekTimekeepingAbi.currentWeek(
+            parent.address,
+        );
+        return this.stakingCompute.undistributedBoostedRewards(
+            parent.address,
+            currentWeek,
+        );
+    }
+
+    @ResolveField()
+    async undistributedBoostedRewardsClaimed(
+        @Parent() parent: StakingModel,
+    ): Promise<string> {
+        return this.stakingAbi.undistributedBoostedRewards(parent.address);
     }
 
     @Query(() => String)

--- a/src/submodules/weekly-rewards-splitting/weekly-rewards-splitting.module.ts
+++ b/src/submodules/weekly-rewards-splitting/weekly-rewards-splitting.module.ts
@@ -14,6 +14,7 @@ import { FarmModuleV2 } from '../../modules/farm/v2/farm.v2.module';
 import { ContextModule } from '../../services/context/context.module';
 import { FeesCollectorModule } from 'src/modules/fees-collector/fees-collector.module';
 import { WeeklyRewardsSplittingSetterService } from './services/weekly.rewarrds.splitting.setter.service';
+import { RemoteConfigModule } from 'src/modules/remote-config/remote-config.module';
 
 @Module({
     imports: [
@@ -26,6 +27,7 @@ import { WeeklyRewardsSplittingSetterService } from './services/weekly.rewarrds.
         forwardRef(() => FeesCollectorModule),
         forwardRef(() => ContextModule),
         forwardRef(() => WeekTimekeepingModule),
+        RemoteConfigModule,
     ],
     providers: [
         ApiConfigService,


### PR DESCRIPTION
## Reasoning
- integrate weekly rewards splitting submodule into farm staking model
  
## Proposed Changes
- added new fields into staking model
- added field resolvers for new fields
- added methods to get information for new field resolvers

## How to test
```
query Staking {
	stakingFarms {
		address
		energyFactoryAddress
		lastGlobalUpdateWeek
		undistributedBoostedRewards
		undistributedBoostedRewardsClaimed
		boosterRewards {
			scAddress
			apr
			week
			totalEnergyForWeek
			totalLockedTokensForWeek
			totalRewardsForWeek {
				tokenID
				nonce
				amount
			}
			rewardsDistributionForWeek {
				tokenId
				percentage
			}
		}
	}
}
```