### PR TITLE
[MEX-407] compute boosted rewards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@golevelup/nestjs-rabbitmq": "^4.0.0",
                 "@multiversx/sdk-core": "^12.8.0",
                 "@multiversx/sdk-data-api-client": "^0.5.8",
-                "@multiversx/sdk-exchange": "^0.2.19",
+                "@multiversx/sdk-exchange": "^0.2.20",
                 "@multiversx/sdk-native-auth-server": "1.0.7",
                 "@multiversx/sdk-nestjs-cache": "^2.0.0-beta.2",
                 "@multiversx/sdk-nestjs-common": "^2.0.0-beta.2",
@@ -2856,9 +2856,9 @@
             }
         },
         "node_modules/@multiversx/sdk-exchange": {
-            "version": "0.2.19",
-            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.19.tgz",
-            "integrity": "sha512-xxWVJ8IMCyiE+yWZ5dKPX7bln7d6WsRv8aalCB373+oxZl69SG4bZc/ZfDy8zUPdDdwPEkXkaAWstvNNKJFmcg==",
+            "version": "0.2.20",
+            "resolved": "http://localhost:4873/@multiversx/sdk-exchange/-/sdk-exchange-0.2.20.tgz",
+            "integrity": "sha512-PK5XKlsg//Iu4cvX2ffaY6mJrm4tHtruJNxpCzAIrHd3eBaonmcqR/EqEHjZVAaUgtbxF8SvWoBKoHy6MRQWfw==",
             "dependencies": {
                 "@multiversx/sdk-core": "^11.2.0",
                 "bignumber.js": "9.0.1"
@@ -2866,7 +2866,7 @@
         },
         "node_modules/@multiversx/sdk-exchange/node_modules/@multiversx/sdk-core": {
             "version": "11.6.0",
-            "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
+            "resolved": "http://localhost:4873/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
             "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
             "dependencies": {
                 "@multiversx/sdk-transaction-decoder": "1.0.2",
@@ -2881,7 +2881,7 @@
         },
         "node_modules/@multiversx/sdk-exchange/node_modules/protobufjs": {
             "version": "6.11.3",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+            "resolved": "http://localhost:4873/protobufjs/-/protobufjs-6.11.3.tgz",
             "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
             "hasInstallScript": true,
             "dependencies": {
@@ -19006,9 +19006,9 @@
             }
         },
         "@multiversx/sdk-exchange": {
-            "version": "0.2.19",
-            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.19.tgz",
-            "integrity": "sha512-xxWVJ8IMCyiE+yWZ5dKPX7bln7d6WsRv8aalCB373+oxZl69SG4bZc/ZfDy8zUPdDdwPEkXkaAWstvNNKJFmcg==",
+            "version": "0.2.20",
+            "resolved": "http://localhost:4873/@multiversx/sdk-exchange/-/sdk-exchange-0.2.20.tgz",
+            "integrity": "sha512-PK5XKlsg//Iu4cvX2ffaY6mJrm4tHtruJNxpCzAIrHd3eBaonmcqR/EqEHjZVAaUgtbxF8SvWoBKoHy6MRQWfw==",
             "requires": {
                 "@multiversx/sdk-core": "^11.2.0",
                 "bignumber.js": "9.0.1"
@@ -19016,7 +19016,7 @@
             "dependencies": {
                 "@multiversx/sdk-core": {
                     "version": "11.6.0",
-                    "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
+                    "resolved": "http://localhost:4873/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
                     "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
                     "requires": {
                         "@multiversx/sdk-transaction-decoder": "1.0.2",
@@ -19031,7 +19031,7 @@
                 },
                 "protobufjs": {
                     "version": "6.11.3",
-                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+                    "resolved": "http://localhost:4873/protobufjs/-/protobufjs-6.11.3.tgz",
                     "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
                     "requires": {
                         "@protobufjs/aspromise": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2857,8 +2857,8 @@
         },
         "node_modules/@multiversx/sdk-exchange": {
             "version": "0.2.20",
-            "resolved": "http://localhost:4873/@multiversx/sdk-exchange/-/sdk-exchange-0.2.20.tgz",
-            "integrity": "sha512-PK5XKlsg//Iu4cvX2ffaY6mJrm4tHtruJNxpCzAIrHd3eBaonmcqR/EqEHjZVAaUgtbxF8SvWoBKoHy6MRQWfw==",
+            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.20.tgz",
+            "integrity": "sha512-qUmdoYsTga/mi3wyjJcmPhqRxP34TWN9bpRWsVj3j/3pkNAnpu6wnv/9Jc7QPG/+mppkox3KBSKgQtyrK845Mg==",
             "dependencies": {
                 "@multiversx/sdk-core": "^11.2.0",
                 "bignumber.js": "9.0.1"
@@ -2866,7 +2866,7 @@
         },
         "node_modules/@multiversx/sdk-exchange/node_modules/@multiversx/sdk-core": {
             "version": "11.6.0",
-            "resolved": "http://localhost:4873/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
             "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
             "dependencies": {
                 "@multiversx/sdk-transaction-decoder": "1.0.2",
@@ -2881,7 +2881,7 @@
         },
         "node_modules/@multiversx/sdk-exchange/node_modules/protobufjs": {
             "version": "6.11.3",
-            "resolved": "http://localhost:4873/protobufjs/-/protobufjs-6.11.3.tgz",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
             "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
             "hasInstallScript": true,
             "dependencies": {
@@ -19007,8 +19007,8 @@
         },
         "@multiversx/sdk-exchange": {
             "version": "0.2.20",
-            "resolved": "http://localhost:4873/@multiversx/sdk-exchange/-/sdk-exchange-0.2.20.tgz",
-            "integrity": "sha512-PK5XKlsg//Iu4cvX2ffaY6mJrm4tHtruJNxpCzAIrHd3eBaonmcqR/EqEHjZVAaUgtbxF8SvWoBKoHy6MRQWfw==",
+            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.20.tgz",
+            "integrity": "sha512-qUmdoYsTga/mi3wyjJcmPhqRxP34TWN9bpRWsVj3j/3pkNAnpu6wnv/9Jc7QPG/+mppkox3KBSKgQtyrK845Mg==",
             "requires": {
                 "@multiversx/sdk-core": "^11.2.0",
                 "bignumber.js": "9.0.1"
@@ -19016,7 +19016,7 @@
             "dependencies": {
                 "@multiversx/sdk-core": {
                     "version": "11.6.0",
-                    "resolved": "http://localhost:4873/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
+                    "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
                     "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
                     "requires": {
                         "@multiversx/sdk-transaction-decoder": "1.0.2",
@@ -19031,7 +19031,7 @@
                 },
                 "protobufjs": {
                     "version": "6.11.3",
-                    "resolved": "http://localhost:4873/protobufjs/-/protobufjs-6.11.3.tgz",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
                     "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
                     "requires": {
                         "@protobufjs/aspromise": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@golevelup/nestjs-rabbitmq": "^4.0.0",
         "@multiversx/sdk-core": "^12.8.0",
         "@multiversx/sdk-data-api-client": "^0.5.8",
-        "@multiversx/sdk-exchange": "^0.2.19",
+        "@multiversx/sdk-exchange": "^0.2.20",
         "@multiversx/sdk-native-auth-server": "1.0.7",
         "@multiversx/sdk-nestjs-cache": "^2.0.0-beta.2",
         "@multiversx/sdk-nestjs-common": "^2.0.0-beta.2",

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -117,7 +117,7 @@
             "removeLiquidity": 8500000,
             "removeLiquidityAndBuyBackAndBurnToken": 200000000,
             "swapTokensFixedInput": {
-                "default": 12000000,
+                "default": 13000000,
                 "withFeeSwap": 25500000
             },
             "swapTokensFixedOutput": {
@@ -379,14 +379,14 @@
         },
         "stake": {
             "stakeFarm": {
-                "default": 7500000,
-                "withTokenMerge": 10000000
+                "default": 17500000,
+                "withTokenMerge": 20000000
             },
-            "unstakeFarm": 9500000,
+            "unstakeFarm": 20000000,
             "unbondFarm": 7500000,
-            "claimRewards": 8500000,
-            "claimRewardsWithNewValue": 7500000,
-            "compoundRewards": 8500000,
+            "claimRewards": 17000000,
+            "claimRewardsWithNewValue": 17000000,
+            "compoundRewards": 17000000,
             "mergeTokens": 20000000,
             "admin": {
                 "setState": 20000000,

--- a/src/modules/rabbitmq/handlers/staking.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/staking.handler.service.ts
@@ -1,8 +1,8 @@
 import {
-    ClaimRewardsEventV2,
-    EnterFarmEventV2,
-    ExitFarmEventV2,
     RawEvent,
+    StakeClaimRewardsEvent,
+    StakeEvent,
+    UnstakeEvent,
 } from '@multiversx/sdk-exchange';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
@@ -21,7 +21,7 @@ export class StakingHandlerService {
     ) {}
 
     async handleStakeEvent(rawEvent: RawEvent): Promise<void> {
-        const event = new EnterFarmEventV2(rawEvent);
+        const event = new StakeEvent(rawEvent);
         const userTotalFarmPosition =
             await this.stakingAbi.getUserTotalStakePositionRaw(
                 event.address,
@@ -42,7 +42,7 @@ export class StakingHandlerService {
     }
 
     async handleUnstakeEvent(rawEvent: RawEvent): Promise<void> {
-        const event = new ExitFarmEventV2(rawEvent);
+        const event = new UnstakeEvent(rawEvent);
         const userTotalFarmPosition =
             await this.stakingAbi.getUserTotalStakePositionRaw(
                 event.address,
@@ -63,7 +63,7 @@ export class StakingHandlerService {
     }
 
     async handleClaimRewardsEvent(rawEvent: RawEvent): Promise<void> {
-        const event = new ClaimRewardsEventV2(rawEvent);
+        const event = new StakeClaimRewardsEvent(rawEvent);
         const userTotalFarmPosition =
             await this.stakingAbi.getUserTotalStakePositionRaw(
                 event.address,

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -169,30 +169,21 @@ export class RabbitMqConsumer {
                     this.updateIngestData(eventData);
                     break;
                 case FARM_EVENTS.ENTER_FARM:
-                    let isStakingAddress = await this.isStakingAddress(
-                        rawEvent.address,
-                    );
-                    if (isStakingAddress) {
+                    if (await this.isStakingAddress(rawEvent.address)) {
                         await this.stakingHandler.handleStakeEvent(rawEvent);
                     } else {
                         await this.wsFarmHandler.handleEnterFarmEvent(rawEvent);
                     }
                     break;
                 case FARM_EVENTS.EXIT_FARM:
-                    isStakingAddress = await this.isStakingAddress(
-                        rawEvent.address,
-                    );
-                    if (isStakingAddress) {
+                    if (await this.isStakingAddress(rawEvent.address)) {
                         await this.stakingHandler.handleUnstakeEvent(rawEvent);
                     } else {
                         await this.wsFarmHandler.handleExitFarmEvent(rawEvent);
                     }
                     break;
                 case FARM_EVENTS.CLAIM_REWARDS:
-                    isStakingAddress = await this.isStakingAddress(
-                        rawEvent.address,
-                    );
-                    if (isStakingAddress) {
+                    if (await this.isStakingAddress(rawEvent.address)) {
                         await this.stakingHandler.handleClaimRewardsEvent(
                             rawEvent,
                         );

--- a/src/modules/rabbitmq/rabbitmq.module.ts
+++ b/src/modules/rabbitmq/rabbitmq.module.ts
@@ -39,6 +39,7 @@ import { GovernanceModule } from '../governance/governance.module';
 import { FarmModuleV2 } from '../farm/v2/farm.v2.module';
 import { RemoteConfigModule } from '../remote-config/remote-config.module';
 import { StakingHandlerService } from './handlers/staking.handler.service';
+import { StakingModule } from '../staking/staking.module';
 
 @Module({
     imports: [
@@ -51,6 +52,7 @@ import { StakingHandlerService } from './handlers/staking.handler.service';
         FarmModuleV1_2,
         FarmModuleV1_3,
         FarmModuleV2,
+        StakingModule,
         RouterModule,
         MetabondingModule,
         PriceDiscoveryModule,

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -4,6 +4,7 @@ import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { StakingTokenAttributesModel } from './stakingTokenAttributes.model';
 import { WeekTimekeepingModel } from 'src/submodules/week-timekeeping/models/week-timekeeping.model';
 import { GlobalInfoByWeekModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
+import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
 
 @ObjectType()
 export class StakingModel {
@@ -41,6 +42,12 @@ export class StakingModel {
     lockedAssetFactoryManagedAddress: string;
     @Field()
     state: string;
+    @Field(() => Int, { description: 'The percentage of boosted rewards' })
+    boostedYieldsRewardsPercenatage: number;
+    @Field(() => BoostedYieldsFactors, {
+        description: 'Factors used to compute boosted rewards',
+    })
+    boostedYieldsFactors: BoostedYieldsFactors;
     @Field({ description: 'Timekeeping for boosted rewards' })
     time: WeekTimekeepingModel;
     @Field(() => [GlobalInfoByWeekModel], {

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -58,6 +58,8 @@ export class StakingModel {
     lastGlobalUpdateWeek: number;
     @Field()
     energyFactoryAddress: string;
+    @Field({ description: 'Accumulated boosted rewards for specific week' })
+    accumulatedRewardsForWeek: string;
     @Field()
     undistributedBoostedRewards: string;
     @Field()

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -3,7 +3,11 @@ import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { StakingTokenAttributesModel } from './stakingTokenAttributes.model';
 import { WeekTimekeepingModel } from 'src/submodules/week-timekeeping/models/week-timekeeping.model';
-import { GlobalInfoByWeekModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
+import {
+    ClaimProgress,
+    GlobalInfoByWeekModel,
+    UserInfoByWeekModel,
+} from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
 
 @ObjectType()
@@ -76,6 +80,14 @@ export class StakingRewardsModel {
     decodedAttributes: StakingTokenAttributesModel;
     @Field()
     rewards: string;
+    @Field(() => Int, { nullable: true })
+    remainingFarmingEpochs?: number;
+    @Field(() => [UserInfoByWeekModel], { nullable: true })
+    boostedRewardsWeeklyInfo: UserInfoByWeekModel[];
+    @Field(() => ClaimProgress, { nullable: true })
+    claimProgress: ClaimProgress;
+    @Field({ nullable: true })
+    accumulatedRewards: string;
 
     constructor(init?: Partial<StakingRewardsModel>) {
         Object.assign(this, init);

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -526,6 +526,34 @@ export class StakingAbiService
         remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
         localTtl: CacheTtlInfo.ContractState.localTtl,
     })
+    async accumulatedRewardsForWeek(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string> {
+        return await this.getAccumulatedRewardsForWeekRaw(stakeAddress, week);
+    }
+
+    async getAccumulatedRewardsForWeekRaw(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string> {
+        const contract = await this.mxProxy.getFarmSmartContract(stakeAddress);
+        const interaction: Interaction =
+            contract.methodsExplicit.getAccumulatedRewardsForWeek([
+                new U32Value(new BigNumber(week)),
+            ]);
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().integerValue().toFixed();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
     async undistributedBoostedRewards(stakeAddress: string): Promise<string> {
         return await this.getUndistributedBoostedRewardsRaw(stakeAddress);
     }

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -399,11 +399,11 @@ export class StakingComputeService {
     @ErrorLoggerAsync({
         logArgs: true,
     })
-    // @GetOrSetCache({
-    //     baseKey: 'stake',
-    //     remoteTtl: CacheTtlInfo.ContractBalance.remoteTtl,
-    //     localTtl: CacheTtlInfo.ContractBalance.localTtl,
-    // })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractBalance.remoteTtl,
+        localTtl: CacheTtlInfo.ContractBalance.localTtl,
+    })
     async userAccumulatedRewards(
         scAddress: string,
         userAddress: string,

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -12,6 +12,11 @@ import { denominateAmount } from 'src/utils/token.converters';
 import { OptimalCompoundModel } from '../models/staking.model';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
+import { TokenDistributionModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
+import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
+import { WeekTimekeepingComputeService } from 'src/submodules/week-timekeeping/services/week-timekeeping.compute.service';
+import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
+import { EsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
 
 @Injectable()
 export class StakingComputeService {
@@ -22,6 +27,9 @@ export class StakingComputeService {
         private readonly contextGetter: ContextGetterService,
         private readonly tokenService: TokenService,
         private readonly tokenCompute: TokenComputeService,
+        private readonly weekTimekeepingCompute: WeekTimekeepingComputeService,
+        private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
+        private readonly weeklyRewardsSplittingCompute: WeeklyRewardsSplittingComputeService,
     ) {}
 
     async computeStakeRewardsForPosition(
@@ -351,5 +359,291 @@ export class StakingComputeService {
         return new BigNumber(undistributedBoostedRewards).plus(
             totalRemainingRewards,
         );
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractBalance.remoteTtl,
+        localTtl: CacheTtlInfo.ContractBalance.localTtl,
+    })
+    async userRewardsDistributionForWeek(
+        scAddress: string,
+        userAddress: string,
+        week: number,
+    ): Promise<TokenDistributionModel[]> {
+        return await this.computeUserRewardsDistributionForWeek(
+            scAddress,
+            userAddress,
+            week,
+        );
+    }
+
+    async computeUserRewardsDistributionForWeek(
+        scAddress: string,
+        userAddress: string,
+        week: number,
+    ): Promise<TokenDistributionModel[]> {
+        const userRewardsForWeek = await this.userRewardsForWeek(
+            scAddress,
+            userAddress,
+            week,
+        );
+        return await this.weeklyRewardsSplittingCompute.computeDistribution(
+            userRewardsForWeek,
+        );
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    // @GetOrSetCache({
+    //     baseKey: 'stake',
+    //     remoteTtl: CacheTtlInfo.ContractBalance.remoteTtl,
+    //     localTtl: CacheTtlInfo.ContractBalance.localTtl,
+    // })
+    async userAccumulatedRewards(
+        scAddress: string,
+        userAddress: string,
+        week: number,
+    ): Promise<string> {
+        return this.computeUserAccumulatedRewards(scAddress, userAddress, week);
+    }
+
+    async computeUserAccumulatedRewards(
+        scAddress: string,
+        userAddress: string,
+        week: number,
+    ): Promise<string> {
+        const [
+            boostedYieldsFactors,
+            boostedYieldsRewardsPercenatage,
+            userEnergy,
+            totalRewards,
+            rewardsPerBlock,
+            farmTokenSupply,
+            totalEnergy,
+            blocksInWeek,
+            liquidity,
+        ] = await Promise.all([
+            this.stakingAbi.boostedYieldsFactors(scAddress),
+            this.stakingAbi.boostedYieldsRewardsPercenatage(scAddress),
+            this.weeklyRewardsSplittingAbi.userEnergyForWeek(
+                scAddress,
+                userAddress,
+                week,
+            ),
+            this.stakingAbi.accumulatedRewardsForWeek(scAddress, week),
+            this.stakingAbi.perBlockRewardsAmount(scAddress),
+            this.stakingAbi.farmTokenSupply(scAddress),
+            this.weeklyRewardsSplittingAbi.totalEnergyForWeek(scAddress, week),
+            this.computeBlocksInWeek(scAddress, week),
+            this.stakingAbi.userTotalStakePosition(scAddress, userAddress),
+        ]);
+
+        const energyAmount = userEnergy.amount;
+
+        const userHasMinEnergy = new BigNumber(energyAmount).isGreaterThan(
+            boostedYieldsFactors.minEnergyAmount,
+        );
+        if (!userHasMinEnergy) {
+            return '0';
+        }
+
+        const userMinFarmAmount = new BigNumber(liquidity).isGreaterThan(
+            boostedYieldsFactors.minFarmAmount,
+        );
+        if (!userMinFarmAmount) {
+            return '0';
+        }
+
+        if (totalRewards.length === 0) {
+            return '0';
+        }
+
+        const userMaxBoostedRewardsPerBlock = new BigNumber(rewardsPerBlock)
+            .multipliedBy(boostedYieldsRewardsPercenatage)
+            .dividedBy(constantsConfig.MAX_PERCENT)
+            .multipliedBy(liquidity)
+            .dividedBy(farmTokenSupply);
+
+        const userRewardsForWeek = new BigNumber(
+            boostedYieldsFactors.maxRewardsFactor,
+        )
+            .multipliedBy(userMaxBoostedRewardsPerBlock)
+            .multipliedBy(blocksInWeek);
+
+        const boostedRewardsByEnergy = new BigNumber(totalRewards)
+            .multipliedBy(boostedYieldsFactors.userRewardsEnergy)
+            .multipliedBy(userEnergy.amount)
+            .dividedBy(totalEnergy);
+
+        const boostedRewardsByTokens = new BigNumber(totalRewards)
+            .multipliedBy(boostedYieldsFactors.userRewardsFarm)
+            .multipliedBy(liquidity)
+            .dividedBy(farmTokenSupply);
+
+        const constantsBase = new BigNumber(
+            boostedYieldsFactors.userRewardsEnergy,
+        ).plus(boostedYieldsFactors.userRewardsFarm);
+
+        const boostedRewardAmount = boostedRewardsByEnergy
+            .plus(boostedRewardsByTokens)
+            .dividedBy(constantsBase);
+
+        const paymentAmount =
+            boostedRewardAmount.comparedTo(userRewardsForWeek) < 1
+                ? boostedRewardAmount
+                : userRewardsForWeek;
+
+        return paymentAmount.integerValue().toFixed();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractBalance.remoteTtl,
+        localTtl: CacheTtlInfo.ContractBalance.localTtl,
+    })
+    async userRewardsForWeek(
+        scAddress: string,
+        userAddress: string,
+        week: number,
+    ): Promise<EsdtTokenPayment[]> {
+        return this.computeUserRewardsForWeek(scAddress, userAddress, week);
+    }
+
+    async computeUserRewardsForWeek(
+        scAddress: string,
+        userAddress: string,
+        week: number,
+    ): Promise<EsdtTokenPayment[]> {
+        const payments: EsdtTokenPayment[] = [];
+        const [
+            totalRewardsForWeek,
+            userEnergyForWeek,
+            totalEnergyForWeek,
+            liquidity,
+        ] = await Promise.all([
+            this.weeklyRewardsSplittingAbi.totalRewardsForWeek(scAddress, week),
+            this.weeklyRewardsSplittingAbi.userEnergyForWeek(
+                scAddress,
+                userAddress,
+                week,
+            ),
+            this.weeklyRewardsSplittingAbi.totalEnergyForWeek(scAddress, week),
+            this.stakingAbi.userTotalStakePosition(scAddress, userAddress),
+        ]);
+
+        const boostedYieldsFactors = await this.stakingAbi.boostedYieldsFactors(
+            scAddress,
+        );
+
+        const userHasMinEnergy = new BigNumber(
+            userEnergyForWeek.amount,
+        ).isGreaterThan(boostedYieldsFactors.minEnergyAmount);
+        if (!userHasMinEnergy) {
+            return payments;
+        }
+
+        const userMinFarmAmount = new BigNumber(liquidity).isGreaterThan(
+            boostedYieldsFactors.minFarmAmount,
+        );
+        if (!userMinFarmAmount) {
+            return payments;
+        }
+
+        if (totalRewardsForWeek.length === 0) {
+            return payments;
+        }
+
+        const [
+            rewardsPerBlock,
+            farmTokenSupply,
+            boostedYieldsRewardsPercenatage,
+        ] = await Promise.all([
+            this.stakingAbi.perBlockRewardsAmount(scAddress),
+            this.stakingAbi.farmTokenSupply(scAddress),
+            this.stakingAbi.boostedYieldsRewardsPercenatage(scAddress),
+        ]);
+
+        const userMaxBoostedRewardsPerBlock = new BigNumber(rewardsPerBlock)
+            .multipliedBy(boostedYieldsRewardsPercenatage)
+            .dividedBy(constantsConfig.MAX_PERCENT)
+            .multipliedBy(liquidity)
+            .dividedBy(farmTokenSupply);
+
+        const userRewardsForWeek = new BigNumber(
+            boostedYieldsFactors.maxRewardsFactor,
+        )
+            .multipliedBy(userMaxBoostedRewardsPerBlock)
+            .multipliedBy(constantsConfig.BLOCKS_PER_WEEK);
+
+        for (const weeklyRewards of totalRewardsForWeek) {
+            const boostedRewardsByEnergy = new BigNumber(weeklyRewards.amount)
+                .multipliedBy(boostedYieldsFactors.userRewardsEnergy)
+                .multipliedBy(userEnergyForWeek.amount)
+                .dividedBy(totalEnergyForWeek);
+
+            const boostedRewardsByTokens = new BigNumber(weeklyRewards.amount)
+                .multipliedBy(boostedYieldsFactors.userRewardsFarm)
+                .multipliedBy(liquidity)
+                .dividedBy(farmTokenSupply);
+
+            const constantsBase = new BigNumber(
+                boostedYieldsFactors.userRewardsEnergy,
+            ).plus(boostedYieldsFactors.userRewardsFarm);
+
+            const boostedRewardAmount = boostedRewardsByEnergy
+                .plus(boostedRewardsByTokens)
+                .dividedBy(constantsBase);
+
+            const paymentAmount =
+                boostedRewardAmount.comparedTo(userRewardsForWeek) < 1
+                    ? boostedRewardAmount
+                    : userRewardsForWeek;
+            if (paymentAmount.isPositive()) {
+                const payment = new EsdtTokenPayment();
+                payment.amount = paymentAmount.integerValue().toFixed();
+                payment.nonce = 0;
+                payment.tokenID = weeklyRewards.tokenID;
+                payment.tokenType = weeklyRewards.tokenType;
+                payments.push(payment);
+            }
+        }
+
+        return payments;
+    }
+
+    async computeBlocksInWeek(
+        scAddress: string,
+        week: number,
+    ): Promise<number> {
+        const [startEpochForCurrentWeek, currentEpoch, shardID] =
+            await Promise.all([
+                this.weekTimekeepingCompute.startEpochForWeek(scAddress, week),
+                this.contextGetter.getCurrentEpoch(),
+                this.stakingAbi.stakingShard(scAddress),
+            ]);
+
+        const promises = [];
+        for (
+            let epoch = startEpochForCurrentWeek;
+            epoch <= currentEpoch;
+            epoch++
+        ) {
+            promises.push(
+                this.contextGetter.getBlocksCountInEpoch(epoch, shardID),
+            );
+        }
+
+        const blocksInEpoch = await Promise.all(promises);
+        return blocksInEpoch.reduce((total, current) => {
+            return total + current;
+        });
     }
 }

--- a/src/modules/staking/services/staking.service.ts
+++ b/src/modules/staking/services/staking.service.ts
@@ -19,6 +19,13 @@ import { StakingComputeService } from './staking.compute.service';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { TokenService } from 'src/modules/tokens/services/token.service';
+import {
+    ClaimProgress,
+    UserInfoByWeekModel,
+} from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
+import { WeekTimekeepingAbiService } from 'src/submodules/week-timekeeping/services/week-timekeeping.abi.service';
+import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
+import { constantsConfig } from 'src/config';
 
 @Injectable()
 export class StakingService {
@@ -30,6 +37,8 @@ export class StakingService {
         private readonly tokenService: TokenService,
         private readonly apiService: MXApiService,
         private readonly remoteConfigGetter: RemoteConfigGetterService,
+        private readonly weekTimekeepingAbi: WeekTimekeepingAbiService,
+        private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
     ) {}
 
     async getFarmsStaking(): Promise<StakingModel[]> {
@@ -102,15 +111,17 @@ export class StakingService {
 
     async getBatchRewardsForPosition(
         positions: CalculateRewardsArgs[],
+        computeBoosted = false,
     ): Promise<StakingRewardsModel[]> {
         const promises = positions.map(async (position) => {
-            return await this.getRewardsForPosition(position);
+            return await this.getRewardsForPosition(position, computeBoosted);
         });
         return await Promise.all(promises);
     }
 
     async getRewardsForPosition(
         positon: CalculateRewardsArgs,
+        computeBoosted = false,
     ): Promise<StakingRewardsModel> {
         const stakeTokenAttributes = this.decodeStakingTokenAttributes({
             batchAttributes: [
@@ -135,9 +146,60 @@ export class StakingService {
             );
         }
 
+        let modelsList: UserInfoByWeekModel[] = undefined;
+        let currentClaimProgress: ClaimProgress = undefined;
+        let userAccumulatedRewards: string = undefined;
+        if (computeBoosted) {
+            const currentWeek = await this.weekTimekeepingAbi.currentWeek(
+                positon.farmAddress,
+            );
+            modelsList = [];
+            let lastActiveWeekUser =
+                await this.weeklyRewardsSplittingAbi.lastActiveWeekForUser(
+                    positon.farmAddress,
+                    positon.user,
+                );
+            if (lastActiveWeekUser === 0) {
+                lastActiveWeekUser = currentWeek;
+            }
+            const startWeek = Math.max(
+                currentWeek - constantsConfig.USER_MAX_CLAIM_WEEKS,
+                lastActiveWeekUser,
+            );
+
+            for (let week = startWeek; week <= currentWeek - 1; week++) {
+                if (week < 1) {
+                    continue;
+                }
+                const model = new UserInfoByWeekModel({
+                    scAddress: positon.farmAddress,
+                    userAddress: positon.user,
+                    week: week,
+                });
+                model.positionAmount = positon.liquidity;
+                modelsList.push(model);
+            }
+
+            currentClaimProgress =
+                await this.weeklyRewardsSplittingAbi.currentClaimProgress(
+                    positon.farmAddress,
+                    positon.user,
+                );
+
+            userAccumulatedRewards =
+                await this.stakingCompute.userAccumulatedRewards(
+                    positon.farmAddress,
+                    positon.user,
+                    currentWeek,
+                );
+        }
+
         return new StakingRewardsModel({
             decodedAttributes: stakeTokenAttributes[0],
             rewards: rewards.integerValue().toFixed(),
+            boostedRewardsWeeklyInfo: modelsList,
+            claimProgress: currentClaimProgress,
+            accumulatedRewards: userAccumulatedRewards,
         });
     }
 

--- a/src/modules/staking/specs/staking.compute.service.spec.ts
+++ b/src/modules/staking/specs/staking.compute.service.spec.ts
@@ -18,6 +18,11 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { TokenComputeServiceProvider } from 'src/modules/tokens/mocks/token.compute.service.mock';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { WeekTimekeepingAbiServiceProvider } from 'src/submodules/week-timekeeping/mocks/week.timekeeping.abi.service.mock';
+import { WeeklyRewardsSplittingAbiServiceProvider } from 'src/submodules/weekly-rewards-splitting/mocks/weekly.rewards.splitting.abi.mock';
+import { WeekTimekeepingComputeService } from 'src/submodules/week-timekeeping/services/week-timekeeping.compute.service';
+import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
+import { EnergyAbiServiceProvider } from 'src/modules/energy/mocks/energy.abi.service.mock';
 
 describe('StakingComputeService', () => {
     let module: TestingModule;
@@ -35,8 +40,13 @@ describe('StakingComputeService', () => {
                 StakingComputeService,
                 StakingService,
                 StakingAbiServiceProvider,
+                EnergyAbiServiceProvider,
                 TokenServiceProvider,
                 TokenComputeServiceProvider,
+                WeekTimekeepingAbiServiceProvider,
+                WeekTimekeepingComputeService,
+                WeeklyRewardsSplittingAbiServiceProvider,
+                WeeklyRewardsSplittingComputeService,
                 ContextGetterServiceProvider,
                 MXApiServiceProvider,
                 RemoteConfigGetterServiceProvider,

--- a/src/modules/staking/specs/staking.service.spec.ts
+++ b/src/modules/staking/specs/staking.service.spec.ts
@@ -15,6 +15,11 @@ import { WinstonModule } from 'nest-winston';
 import winston from 'winston';
 import { TokenComputeServiceProvider } from 'src/modules/tokens/mocks/token.compute.service.mock';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { WeekTimekeepingAbiServiceProvider } from 'src/submodules/week-timekeeping/mocks/week.timekeeping.abi.service.mock';
+import { WeeklyRewardsSplittingAbiServiceProvider } from 'src/submodules/weekly-rewards-splitting/mocks/weekly.rewards.splitting.abi.mock';
+import { WeekTimekeepingComputeService } from 'src/submodules/week-timekeeping/services/week-timekeeping.compute.service';
+import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
+import { EnergyAbiServiceProvider } from 'src/modules/energy/mocks/energy.abi.service.mock';
 
 describe('StakingService', () => {
     let module: TestingModule;
@@ -32,12 +37,16 @@ describe('StakingService', () => {
                 StakingService,
                 StakingAbiServiceProvider,
                 StakingComputeService,
+                EnergyAbiServiceProvider,
                 ContextGetterServiceProvider,
+                WeekTimekeepingAbiServiceProvider,
+                WeekTimekeepingComputeService,
+                WeeklyRewardsSplittingAbiServiceProvider,
+                WeeklyRewardsSplittingComputeService,
                 RemoteConfigGetterServiceProvider,
                 MXProxyServiceProvider,
                 MXApiServiceProvider,
                 MXGatewayService,
-                ApiConfigService,
                 TokenServiceProvider,
                 TokenComputeServiceProvider,
                 ApiConfigService,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -192,6 +192,20 @@ export class StakingResolver {
     }
 
     @ResolveField()
+    async accumulatedRewardsForWeek(
+        @Parent() parent: StakingModel,
+        @Args('week', { nullable: true }) week: number,
+    ): Promise<string> {
+        const currentWeek = await this.weekTimekeepingAbi.currentWeek(
+            parent.address,
+        );
+        return this.stakingAbi.accumulatedRewardsForWeek(
+            parent.address,
+            week ?? currentWeek,
+        );
+    }
+
+    @ResolveField()
     async undistributedBoostedRewards(
         @Parent() parent: StakingModel,
     ): Promise<string> {

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -252,9 +252,11 @@ export class StakingResolver {
     @Query(() => [StakingRewardsModel])
     async getStakingRewardsForPosition(
         @Args('stakingPositions') args: BatchFarmRewardsComputeArgs,
+        @Args('computeBoosted', { nullable: true }) computeBoosted: boolean,
     ): Promise<StakingRewardsModel[]> {
         return this.stakingService.getBatchRewardsForPosition(
             args.farmsPositions,
+            computeBoosted,
         );
     }
 

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -31,6 +31,7 @@ import { GlobalInfoByWeekModel } from 'src/submodules/weekly-rewards-splitting/m
 import { constantsConfig } from 'src/config';
 import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
 import { StakeAddressValidationPipe } from './validators/stake.address.validator';
+import { BoostedYieldsFactors } from '../farm/models/farm.v2.model';
 
 @Resolver(() => StakingModel)
 export class StakingResolver {
@@ -174,6 +175,20 @@ export class StakingResolver {
         @Parent() parent: StakingModel,
     ): Promise<string> {
         return this.stakingAbi.energyFactoryAddress(parent.address);
+    }
+
+    @ResolveField()
+    async boostedYieldsRewardsPercenatage(
+        @Parent() parent: StakingModel,
+    ): Promise<number> {
+        return this.stakingAbi.boostedYieldsRewardsPercenatage(parent.address);
+    }
+
+    @ResolveField()
+    async boostedYieldsFactors(
+        @Parent() parent: StakingModel,
+    ): Promise<BoostedYieldsFactors> {
+        return this.stakingAbi.boostedYieldsFactors(parent.address);
     }
 
     @ResolveField()

--- a/src/modules/user/models/user.model.ts
+++ b/src/modules/user/models/user.model.ts
@@ -2,8 +2,14 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftToken } from 'src/modules/tokens/models/nftToken.model';
 import { FarmToken } from 'src/modules/tokens/models/farmToken.model';
-import { LockedLpToken, LockedLpTokenV2 } from 'src/modules/tokens/models/lockedLpToken.model';
-import { LockedFarmToken, LockedFarmTokenV2 } from 'src/modules/tokens/models/lockedFarmToken.model';
+import {
+    LockedLpToken,
+    LockedLpTokenV2,
+} from 'src/modules/tokens/models/lockedLpToken.model';
+import {
+    LockedFarmToken,
+    LockedFarmTokenV2,
+} from 'src/modules/tokens/models/lockedFarmToken.model';
 import { LockedAssetToken } from 'src/modules/tokens/models/lockedAssetToken.model';
 import { StakeFarmToken } from 'src/modules/tokens/models/stakeFarmToken.model';
 import { UnbondFarmToken } from 'src/modules/tokens/models/unbondFarmToken.model';
@@ -14,10 +20,10 @@ import { LockedSimpleLpToken } from 'src/modules/tokens/models/lockedSimpleLpTok
 import { PaginationArgs } from 'src/modules/dex.model';
 import { WrappedLockedTokenAttributesModel } from 'src/modules/simple-lock/models/simple.lock.model';
 
-
 export enum ContractType {
     Farm = 'Farm',
-    FeesCollector = 'FeesCollector'
+    FeesCollector = 'FeesCollector',
+    StakingFarm = 'StakingFarm',
 }
 
 @ObjectType()

--- a/src/modules/user/user.info-by-week.resolver.ts
+++ b/src/modules/user/user.info-by-week.resolver.ts
@@ -10,14 +10,18 @@ import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-
 import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
 import { FeesCollectorComputeService } from '../fees-collector/services/fees-collector.compute.service';
 import { FarmComputeServiceV2 } from '../farm/v2/services/farm.v2.compute.service';
+import { StakingComputeService } from '../staking/services/staking.compute.service';
+import { RemoteConfigGetterService } from '../remote-config/remote-config.getter.service';
 
 @Resolver(() => UserInfoByWeekModel)
 export class UserInfoByWeekResolver {
     constructor(
         private readonly farmComputeV2: FarmComputeServiceV2,
         private readonly feesCollectorCompute: FeesCollectorComputeService,
+        private readonly stakingCompute: StakingComputeService,
         private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
         private readonly weeklyRewardsSplittingCompute: WeeklyRewardsSplittingComputeService,
+        private readonly remoteConfig: RemoteConfigGetterService,
     ) {}
 
     @ResolveField(() => EnergyModel)
@@ -51,6 +55,16 @@ export class UserInfoByWeekResolver {
                 parent.week,
             );
         }
+
+        const stakingAddresses = await this.remoteConfig.getStakingAddresses();
+        if (stakingAddresses.includes(parent.scAddress)) {
+            return this.stakingCompute.userRewardsForWeek(
+                parent.scAddress,
+                parent.userAddress,
+                parent.week,
+            );
+        }
+
         return this.farmComputeV2.userRewardsForWeek(
             parent.scAddress,
             parent.userAddress,
@@ -69,6 +83,15 @@ export class UserInfoByWeekResolver {
                 parent.week,
             );
         }
+        const stakingAddresses = await this.remoteConfig.getStakingAddresses();
+        if (stakingAddresses.includes(parent.scAddress)) {
+            return this.stakingCompute.userRewardsDistributionForWeek(
+                parent.scAddress,
+                parent.userAddress,
+                parent.week,
+            );
+        }
+
         return this.farmComputeV2.userRewardsDistributionForWeek(
             parent.scAddress,
             parent.userAddress,


### PR DESCRIPTION
## Reasoning
- add support for boosted rewards into staking module
  
## Proposed Changes
- added new fields into staking model for boosted rewards information
- added compute method for user's boosted rewards from staking contract
- added outdated energy compute for staking contract

## How to test
```
query StakingRewards {
	getStakingRewardsForPosition(
		computeBoosted: true,
		stakingPositions: {
			farmsPositions: [
				{
					farmAddress: <staking_address>,
					user: <user_address>,
					liquidity: ,
					attributes: ,
					identifier: 
				}
			]
		}
	) {
		rewards
		accumulatedRewards
		claimProgress {
			week
			energy {
				amount
				lastUpdateEpoch
				totalLockedTokens
			}
		}
		boostedRewardsWeeklyInfo {
			scAddress
			userAddress
			week
			positionAmount
			apr
			energyForWeek {
				amount
				lastUpdateEpoch
				totalLockedTokens
			}
			rewardsDistributionForWeek {
				tokenId
				percentage
			}
			rewardsForWeek {
				tokenID
				amount
			}
		}
	}
}
```
- query should return base staking rewards and boosted staking rewards

```
query UserOutdatedContracts {
	userOutdatedContracts {
		address
		type
		claimProgressOutdated
	}
}
```
- query result should contain staking address if the energy is outdated