### PR TITLE
[MEX-409] staking migration to boosted rewards

### DIFF
--- a/src/modules/staking/mocks/staking.abi.service.mock.ts
+++ b/src/modules/staking/mocks/staking.abi.service.mock.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { IStakingAbiService } from '../services/interfaces';
 import { StakingAbiService } from '../services/staking.abi.service';
+import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
 
 export class StakingAbiServiceMock implements IStakingAbiService {
     async farmTokenID(stakeAddress: string): Promise<string> {
@@ -60,6 +61,47 @@ export class StakingAbiServiceMock implements IStakingAbiService {
     }
     lastErrorMessage(stakeAddress: string): Promise<string> {
         throw new Error('Method not implemented.');
+    }
+    energyFactoryAddress(stakeAddress: string): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+    boostedYieldsRewardsPercenatage(stakeAddress: string): Promise<number> {
+        throw new Error('Method not implemented.');
+    }
+    boostedYieldsFactors(stakeAddress: string): Promise<BoostedYieldsFactors> {
+        throw new Error('Method not implemented.');
+    }
+    accumulatedRewardsForWeek(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+    undistributedBoostedRewards(stakeAddress: string): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+    lastUndistributedBoostedRewardsCollectWeek(
+        stakeAddress: string,
+    ): Promise<number> {
+        throw new Error('Method not implemented.');
+    }
+    remainingBoostedRewardsToDistribute(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+    userTotalStakePosition(
+        stakeAddress: string,
+        userAddress: string,
+    ): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+    async farmPositionMigrationNonce(stakeAddress: string): Promise<number> {
+        return 2;
+    }
+    async stakingShard(stakeAddress: string): Promise<number> {
+        return 1;
     }
 }
 

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -68,6 +68,11 @@ export class StakingModel {
     undistributedBoostedRewards: string;
     @Field()
     undistributedBoostedRewardsClaimed: string;
+    @Field({
+        description:
+            'The nonce of the first staking farm token with total farm position',
+    })
+    stakingPositionMigrationNonce: number;
 
     constructor(init?: Partial<StakingModel>) {
         Object.assign(this, init);

--- a/src/modules/staking/services/interfaces.ts
+++ b/src/modules/staking/services/interfaces.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
 
 export interface IStakingAbiService {
     farmTokenID(stakeAddress: string): Promise<string>;
@@ -24,4 +25,25 @@ export interface IStakingAbiService {
     lockedAssetFactoryAddress(stakeAddress: string): Promise<string>;
     isWhitelisted(stakeAddress: string, scAddress: string): Promise<boolean>;
     lastErrorMessage(stakeAddress: string): Promise<string>;
+    energyFactoryAddress(stakeAddress: string): Promise<string>;
+    boostedYieldsRewardsPercenatage(stakeAddress: string): Promise<number>;
+    boostedYieldsFactors(stakeAddress: string): Promise<BoostedYieldsFactors>;
+    accumulatedRewardsForWeek(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string>;
+    undistributedBoostedRewards(stakeAddress: string): Promise<string>;
+    lastUndistributedBoostedRewardsCollectWeek(
+        stakeAddress: string,
+    ): Promise<number>;
+    remainingBoostedRewardsToDistribute(
+        stakeAddress: string,
+        week: number,
+    ): Promise<string>;
+    userTotalStakePosition(
+        stakeAddress: string,
+        userAddress: string,
+    ): Promise<string>;
+    farmPositionMigrationNonce(stakeAddress: string): Promise<number>;
+    stakingShard(stakeAddress: string): Promise<number>;
 }

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -678,6 +678,31 @@ export class StakingAbiService
         remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
         localTtl: CacheTtlInfo.ContractInfo.localTtl,
     })
+    async farmPositionMigrationNonce(stakeAddress: string): Promise<number> {
+        return await this.getFarmPositionMigrationNonceRaw(stakeAddress);
+    }
+
+    async getFarmPositionMigrationNonceRaw(
+        stakeAddress: string,
+    ): Promise<number> {
+        const contract = await this.mxProxy.getStakingSmartContract(
+            stakeAddress,
+        );
+
+        const interaction: Interaction =
+            contract.methodsExplicit.getFarmPositionMigrationNonce();
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().toNumber();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
+        localTtl: CacheTtlInfo.ContractInfo.localTtl,
+    })
     async stakingShard(stakeAddress: string): Promise<number> {
         return await this.getStakingShardRaw(stakeAddress);
     }

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -225,6 +225,13 @@ export class StakingResolver {
         return this.stakingAbi.undistributedBoostedRewards(parent.address);
     }
 
+    @ResolveField()
+    async stakingPositionMigrationNonce(
+        @Parent() parent: StakingModel,
+    ): Promise<number> {
+        return this.stakingAbi.farmPositionMigrationNonce(parent.address);
+    }
+
     @Query(() => String)
     async getLastErrorMessage(
         @Args('stakeAddress') stakeAddress: string,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -327,6 +327,18 @@ export class StakingResolver {
         );
     }
 
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => [TransactionModel])
+    async migrateTotalStakingPosition(
+        @Args('stakeAddress') stakeAddress: string,
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TransactionModel[]> {
+        return this.stakingTransactionService.migrateTotalStakingPosition(
+            stakeAddress,
+            user.address,
+        );
+    }
+
     @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async setPerBlockRewardAmount(


### PR DESCRIPTION
## Reasoning
- users have to perform at least one action with the existing staking tokens to start earn boosted rewards
  
## Proposed Changes
- added query to return a migration transaction for current staking positions; proposed transaction is a claim rewards

## How to test
```
query TotalStakingMigrate {
	migrateTotalStakingPosition(
		stakeAddress: <staking_address>
	) {
		data
	}
}
```
- query should return transactions if user has at least one current staking position