### PR TITLE
[SERVICES-1909] fix swap errors

### DIFF
--- a/src/modules/auto-router/auto-router.resolver.ts
+++ b/src/modules/auto-router/auto-router.resolver.ts
@@ -19,6 +19,13 @@ export class AutoRouterResolver {
         try {
             return await this.autoRouterService.swap(args);
         } catch (error) {
+            if (error.status === 400) {
+                throw new GraphQLError(error.message, {
+                    extensions: {
+                        code: ApolloServerErrorCode.BAD_USER_INPUT,
+                    },
+                });
+            }
             throw new GraphQLError(error.message, {
                 extensions: {
                     code: ApolloServerErrorCode.INTERNAL_SERVER_ERROR,

--- a/src/modules/auto-router/services/auto-router.compute.service.ts
+++ b/src/modules/auto-router/services/auto-router.compute.service.ts
@@ -1,4 +1,4 @@
-import { Inject } from '@nestjs/common';
+import { BadRequestException, Inject } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { PairModel } from 'src/modules/pair/models/pair.model';
@@ -44,6 +44,10 @@ export class AutoRouterComputeService {
             amounts,
             swapType,
         );
+
+        if (pathIndex === -1) {
+            throw new BadRequestException('No route found');
+        }
 
         const addressRoute = this.getAddressRoute(pairs, paths[pathIndex]);
 
@@ -109,10 +113,8 @@ export class AutoRouterComputeService {
                     continue;
                 }
 
-                const [
-                    tokenInReserves,
-                    tokenOutReserves,
-                ] = this.getOrderedReserves(tokenInID, pair);
+                const [tokenInReserves, tokenOutReserves] =
+                    this.getOrderedReserves(tokenInID, pair);
                 const amountOut = getAmountOut(
                     pathAmounts[pathAmounts.length - 1],
                     tokenInReserves,
@@ -143,10 +145,8 @@ export class AutoRouterComputeService {
                 if (pair === undefined) {
                     continue;
                 }
-                const [
-                    tokenInReserves,
-                    tokenOutReserves,
-                ] = this.getOrderedReserves(tokenInID, pair);
+                const [tokenInReserves, tokenOutReserves] =
+                    this.getOrderedReserves(tokenInID, pair);
                 const amountIn =
                     pathAmounts[0] === 'Infinity'
                         ? new BigNumber(0)
@@ -227,9 +227,6 @@ export class AutoRouterComputeService {
     }
 
     computePriceImpactPercent(reserves: string, amount: string): string {
-        return new BigNumber(amount)
-            .dividedBy(reserves)
-            .times(100)
-            .toFixed();
+        return new BigNumber(amount).dividedBy(reserves).times(100).toFixed();
     }
 }

--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { BigNumber } from 'bignumber.js';
 import { PairModel } from 'src/modules/pair/models/pair.model';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
@@ -145,6 +145,10 @@ export class AutoRouterService {
             this.pairCompute.tokenPriceUSD(tokenInID),
             this.pairCompute.tokenPriceUSD(tokenOutID),
         ]);
+
+        if (result === '0') {
+            throw new BadRequestException('Invalid amounts');
+        }
 
         let [amountIn, amountOut] = this.isFixedInput(swapType)
             ? [args.amountIn, result]
@@ -378,6 +382,10 @@ export class AutoRouterService {
         amountIn: string,
         amountOut: string,
     ): string[] {
+        if (amountIn === '0' || amountOut === '0') {
+            return ['0', '0'];
+        }
+
         const tokenInPrice = new BigNumber(10)
             .pow(tokenInDecimals)
             .multipliedBy(amountOut)


### PR DESCRIPTION
## Reasoning
- swap query didn't return user friendly errors
  
## Proposed Changes
- added error handling for swap query

## How to test
```
query Swap {
	swap(
		tokenInID: <tokenID>,
		tokenOutID: <tokenID>,
		tolerance: 0.01,
		amountOut: <amount>
	) {
		swapType
		amountIn
		amountOut
		fees
		pricesImpact
		tokenInExchangeRate
		tokenOutExchangeRate
	}
}
```
- query should return error if no route found for multi swap
- query should return error on swap output type if amount is grater than reserves