### PR TITLE
[MEX-410] position creator batch transaction

### DIFF
--- a/src/modules/position-creator/position.creator.transaction.resolver.ts
+++ b/src/modules/position-creator/position.creator.transaction.resolver.ts
@@ -34,14 +34,14 @@ export class PositionCreatorTransactionResolver {
         );
     }
 
-    @Query(() => TransactionModel)
+    @Query(() => [TransactionModel])
     async createFarmPositionSingleToken(
         @AuthUser() user: UserAuthResult,
         @Args('farmAddress') farmAddress: string,
         @Args('payments', { type: () => [InputTokenModel] })
         payments: InputTokenModel[],
         @Args('tolerance') tolerance: number,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         return this.posCreatorTransaction.createFarmPositionSingleToken(
             user.address,
             farmAddress,
@@ -57,14 +57,14 @@ export class PositionCreatorTransactionResolver {
         );
     }
 
-    @Query(() => TransactionModel)
+    @Query(() => [TransactionModel])
     async createDualFarmPositionSingleToken(
         @AuthUser() user: UserAuthResult,
         @Args('dualFarmAddress') dualFarmAddress: string,
         @Args('payments', { type: () => [InputTokenModel] })
         payments: InputTokenModel[],
         @Args('tolerance') tolerance: number,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         return this.posCreatorTransaction.createDualFarmPositionSingleToken(
             user.address,
             dualFarmAddress,
@@ -80,14 +80,14 @@ export class PositionCreatorTransactionResolver {
         );
     }
 
-    @Query(() => TransactionModel)
+    @Query(() => [TransactionModel])
     async createStakingPositionSingleToken(
         @AuthUser() user: UserAuthResult,
         @Args('stakingAddress') stakingAddress: string,
         @Args('payments', { type: () => [InputTokenModel] })
         payments: InputTokenModel[],
         @Args('tolerance') tolerance: number,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         return this.posCreatorTransaction.createStakingPositionSingleToken(
             user.address,
             stakingAddress,

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -20,6 +20,7 @@ import { AutoRouterTransactionService } from 'src/modules/auto-router/services/a
 import { SWAP_TYPE } from 'src/modules/auto-router/models/auto-route.model';
 import { PairService } from 'src/modules/pair/services/pair.service';
 import { TokenService } from 'src/modules/tokens/services/token.service';
+import { WrapTransactionsService } from 'src/modules/wrapping/services/wrap.transactions.service';
 
 @Injectable()
 export class PositionCreatorTransactionService {
@@ -33,6 +34,7 @@ export class PositionCreatorTransactionService {
         private readonly stakingAbi: StakingAbiService,
         private readonly stakingProxyAbi: StakingProxyAbiService,
         private readonly tokenService: TokenService,
+        private readonly wrapTransaction: WrapTransactionsService,
         private readonly mxProxy: MXProxyService,
     ) {}
 
@@ -84,14 +86,25 @@ export class PositionCreatorTransactionService {
         farmAddress: string,
         payments: EsdtTokenPayment[],
         tolerance: number,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         const [pairAddress, farmTokenID, uniqueTokensIDs] = await Promise.all([
             this.farmAbiV2.pairContractAddress(farmAddress),
             this.farmAbiV2.farmTokenID(farmAddress),
             this.tokenService.getUniqueTokenIDs(false),
         ]);
 
-        if (!uniqueTokensIDs.includes(payments[0].tokenIdentifier)) {
+        const transactions = [];
+        if (
+            payments[0].tokenIdentifier === mxConfig.EGLDIdentifier &&
+            payments.length > 1
+        ) {
+            transactions.push(
+                await this.wrapTransaction.wrapEgld(sender, payments[0].amount),
+            );
+        } else if (
+            !uniqueTokensIDs.includes(payments[0].tokenIdentifier) &&
+            payments[0].tokenIdentifier !== mxConfig.EGLDIdentifier
+        ) {
             throw new Error('Invalid ESDT token payment');
         }
 
@@ -110,7 +123,7 @@ export class PositionCreatorTransactionService {
 
         const contract = await this.mxProxy.getPostitionCreatorContract();
 
-        return contract.methodsExplicit
+        const transaction = contract.methodsExplicit
             .createFarmPosFromSingleToken([
                 new AddressValue(Address.fromBech32(farmAddress)),
                 new BigUIntValue(singleTokenPairInput.amount0Min),
@@ -131,6 +144,9 @@ export class PositionCreatorTransactionService {
             .withChainID(mxConfig.chainID)
             .buildTransaction()
             .toPlainObject();
+
+        transactions.push(transaction);
+        return transactions;
     }
 
     async createDualFarmPositionSingleToken(
@@ -138,7 +154,7 @@ export class PositionCreatorTransactionService {
         stakingProxyAddress: string,
         payments: EsdtTokenPayment[],
         tolerance: number,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         const [pairAddress, dualYieldTokenID, uniqueTokensIDs] =
             await Promise.all([
                 this.stakingProxyAbi.pairAddress(stakingProxyAddress),
@@ -146,7 +162,18 @@ export class PositionCreatorTransactionService {
                 this.tokenService.getUniqueTokenIDs(false),
             ]);
 
-        if (!uniqueTokensIDs.includes(payments[0].tokenIdentifier)) {
+        const transactions = [];
+        if (
+            payments[0].tokenIdentifier === mxConfig.EGLDIdentifier &&
+            payments.length > 1
+        ) {
+            transactions.push(
+                await this.wrapTransaction.wrapEgld(sender, payments[0].amount),
+            );
+        } else if (
+            !uniqueTokensIDs.includes(payments[0].tokenIdentifier) &&
+            payments[0].tokenIdentifier !== mxConfig.EGLDIdentifier
+        ) {
             throw new Error('Invalid ESDT token payment');
         }
 
@@ -165,7 +192,7 @@ export class PositionCreatorTransactionService {
 
         const contract = await this.mxProxy.getPostitionCreatorContract();
 
-        return contract.methodsExplicit
+        const transaction = contract.methodsExplicit
             .createMetastakingPosFromSingleToken([
                 new AddressValue(Address.fromBech32(stakingProxyAddress)),
                 new BigUIntValue(singleTokenPairInput.amount0Min),
@@ -186,6 +213,9 @@ export class PositionCreatorTransactionService {
             .withChainID(mxConfig.chainID)
             .buildTransaction()
             .toPlainObject();
+
+        transactions.push(transaction);
+        return transactions;
     }
 
     async createStakingPositionSingleToken(
@@ -193,7 +223,7 @@ export class PositionCreatorTransactionService {
         stakingAddress: string,
         payments: EsdtTokenPayment[],
         tolerance: number,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         const [farmingTokenID, farmTokenID, uniqueTokensIDs] =
             await Promise.all([
                 this.stakingAbi.farmingTokenID(stakingAddress),
@@ -201,7 +231,19 @@ export class PositionCreatorTransactionService {
                 this.tokenService.getUniqueTokenIDs(false),
             ]);
 
-        if (!uniqueTokensIDs.includes(payments[0].tokenIdentifier)) {
+        const transactions = [];
+
+        if (
+            payments[0].tokenIdentifier === mxConfig.EGLDIdentifier &&
+            payments.length > 1
+        ) {
+            transactions.push(
+                await this.wrapTransaction.wrapEgld(sender, payments[0].amount),
+            );
+        } else if (
+            !uniqueTokensIDs.includes(payments[0].tokenIdentifier) &&
+            payments[0].tokenIdentifier !== mxConfig.EGLDIdentifier
+        ) {
             throw new Error('Invalid ESDT token payment');
         }
 
@@ -231,7 +273,7 @@ export class PositionCreatorTransactionService {
                 tokenRoute: swapRoute.tokenRoute,
             });
 
-        return contract.methodsExplicit
+        const transaction = contract.methodsExplicit
             .createFarmStakingPosFromSingleToken([
                 new AddressValue(Address.fromBech32(stakingAddress)),
                 new BigUIntValue(
@@ -257,6 +299,9 @@ export class PositionCreatorTransactionService {
             .withChainID(mxConfig.chainID)
             .buildTransaction()
             .toPlainObject();
+
+        transactions.push(transaction);
+        return transactions;
     }
 
     async createFarmPositionDualTokens(
@@ -275,7 +320,7 @@ export class PositionCreatorTransactionService {
         ]);
 
         if (!this.checkTokensPayments(payments, firstTokenID, secondTokenID)) {
-            throw new Error('Invalid tokens payments');
+            throw new Error('Invalid ESDT tokens payments');
         }
 
         for (const payment of payments.slice(2)) {
@@ -348,7 +393,7 @@ export class PositionCreatorTransactionService {
             ]);
 
         if (!this.checkTokensPayments(payments, firstTokenID, secondTokenID)) {
-            throw new Error('Invalid tokens payments');
+            throw new Error('Invalid ESDT tokens payments');
         }
 
         for (const payment of payments.slice(2)) {

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -49,7 +49,7 @@ export class PositionCreatorTransactionService {
         );
 
         if (
-            !uniqueTokensIDs.includes(payment.tokenIdentifier) ||
+            !uniqueTokensIDs.includes(payment.tokenIdentifier) &&
             payment.tokenIdentifier !== mxConfig.EGLDIdentifier
         ) {
             throw new Error('Invalid ESDT token payment');

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -206,25 +206,27 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    `MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@01@USDC-123456@@100000000000000000000@createFarmPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000021@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327`,
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        `MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@01@USDC-123456@@100000000000000000000@createFarmPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000021@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327`,
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
 
         it('should return transaction with merge farm tokens', async () => {
@@ -251,25 +253,27 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    `MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@USDC-123456@@100000000000000000000@EGLDMEXFL-abcdef@01@100000000000000000000@createFarmPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000021@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327`,
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        `MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@USDC-123456@@100000000000000000000@EGLDMEXFL-abcdef@01@100000000000000000000@createFarmPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000021@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327`,
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
     });
 
@@ -345,25 +349,27 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@01@USDC-123456@@100000000000000000000@createMetastakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@01@USDC-123456@@100000000000000000000@createMetastakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
 
         it('should return transaction with merge dual farm tokens', async () => {
@@ -397,25 +403,27 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@USDC-123456@@100000000000000000000@METASTAKE-1234@01@100000000000000000000@createMetastakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@USDC-123456@@100000000000000000000@METASTAKE-1234@01@100000000000000000000@createMetastakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
     });
 
@@ -482,25 +490,27 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@01@USDC-123456@@100000000000000000000@createFarmStakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@999999999899699097301@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@01@USDC-123456@@100000000000000000000@createFarmStakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@999999999899699097301@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
 
         it('should return transaction with merge staking tokens', async () => {
@@ -525,25 +535,27 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@USDC-123456@@100000000000000000000@STAKETOK-1111@01@100000000000000000000@createFarmStakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@999999999899699097301@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@USDC-123456@@100000000000000000000@STAKETOK-1111@01@100000000000000000000@createFarmStakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@999999999899699097301@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
     });
 
@@ -572,7 +584,7 @@ describe('PositionCreatorTransaction', () => {
                     ],
                     0.01,
                 ),
-            ).rejects.toThrowError('Invalid tokens payments');
+            ).rejects.toThrowError('Invalid ESDT tokens payments');
         });
 
         it('should return error on invalid farm token merge', async () => {
@@ -735,7 +747,7 @@ describe('PositionCreatorTransaction', () => {
                     ],
                     0.01,
                 ),
-            ).rejects.toThrowError('Invalid tokens payments');
+            ).rejects.toThrowError('Invalid ESDT tokens payments');
         });
 
         it('should return error on invalid farm token merge', async () => {


### PR DESCRIPTION
## Reasoning
- transactions with EGLD and consolidate tokens have to be batched for EGLD wrap
  
## Proposed Changes
- added EGLD wrap for transactions with consolidate tokens sent

## How to test
```
query CreateFarmPositionSingleToken {
	createFarmPositionSingleToken(
		farmAddress: "erd1qqqqqqqqqqqqqpgq3chrzjdg3gu40zt6kes6w62cyz8tes6k0n4ssk3hj4",
		payments: [{
			tokenID: "EGLD",
			nonce: 0,
			amount: "1000000000000000000"
		},
		{
			tokenID: <farm_token_id>,
			nonce: 0,
			amount: <amount>
		}
		],
		tolerance: 0.01
	) {
		receiver
		data
	}
}
```
- query should return 2 transactions: wrap + create farm position from single token