### PR TITLE
[MEX-416] farm boosted rewards

### DIFF
--- a/src/modules/farm/models/farm.model.ts
+++ b/src/modules/farm/models/farm.model.ts
@@ -37,7 +37,24 @@ export class RewardsModel {
     claimProgress: ClaimProgress;
     @Field({ nullable: true })
     accumulatedRewards: string;
+
     constructor(init?: Partial<RewardsModel>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class BoostedRewardsModel {
+    @Field()
+    farmAddress: string;
+    @Field(() => [UserInfoByWeekModel], { nullable: true })
+    boostedRewardsWeeklyInfo: UserInfoByWeekModel[];
+    @Field(() => ClaimProgress, { nullable: true })
+    claimProgress: ClaimProgress;
+    @Field({ nullable: true })
+    accumulatedRewards: string;
+
+    constructor(init?: Partial<BoostedRewardsModel>) {
         Object.assign(this, init);
     }
 }

--- a/src/modules/farm/v2/farm.v2.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.resolver.ts
@@ -14,7 +14,7 @@ import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard'
 import { UserAuthResult } from 'src/modules/auth/user.auth.result';
 import { AuthUser } from 'src/modules/auth/auth.user';
 import { farmVersion } from 'src/utils/farm.utils';
-import { FarmVersion } from '../models/farm.model';
+import { BoostedRewardsModel, FarmVersion } from '../models/farm.model';
 import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 
@@ -166,5 +166,18 @@ export class FarmResolverV2 extends FarmResolver {
             });
         }
         return this.farmAbi.userTotalFarmPosition(farmAddress, user.address);
+    }
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => [BoostedRewardsModel], { nullable: true })
+    async getFarmBoostedRewardsBatch(
+        @Args('farmsAddresses', { type: () => [String] })
+        farmsAddresses: string[],
+        @AuthUser() user: UserAuthResult,
+    ): Promise<BoostedRewardsModel[]> {
+        return this.farmService.getFarmBoostedRewardsBatch(
+            farmsAddresses,
+            user.address,
+        );
     }
 }

--- a/src/modules/farm/v2/farm.v2.transaction.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.transaction.resolver.ts
@@ -35,4 +35,18 @@ export class FarmTransactionResolverV2 {
             user.address,
         );
     }
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => TransactionModel, {
+        description: 'Generate transaction to claim only boosted rewards',
+    })
+    async claimFarmBoostedRewards(
+        @Args('farmAddress') farmAddress: string,
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TransactionModel> {
+        return this.farmTransaction.claimBoostedRewards(
+            user.address,
+            farmAddress,
+        );
+    }
 }

--- a/src/modules/farm/v2/services/farm.v2.transaction.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.transaction.service.ts
@@ -132,6 +132,21 @@ export class FarmTransactionServiceV2 extends TransactionsFarmService {
             .toPlainObject();
     }
 
+    async claimBoostedRewards(
+        sender: string,
+        farmAddress: string,
+    ): Promise<TransactionModel> {
+        const contract = await this.mxProxy.getFarmSmartContract(farmAddress);
+
+        return contract.methodsExplicit
+            .claimBoostedRewards()
+            .withSender(Address.fromString(sender))
+            .withChainID(mxConfig.chainID)
+            .withGasLimit(gasConfig.farms[FarmVersion.V2].claimBoostedRewards)
+            .buildTransaction()
+            .toPlainObject();
+    }
+
     compoundRewards(
         sender: string,
         args: CompoundRewardsArgs,

--- a/src/modules/position-creator/position.creator.module.ts
+++ b/src/modules/position-creator/position.creator.module.ts
@@ -11,6 +11,7 @@ import { StakingProxyModule } from '../staking-proxy/staking.proxy.module';
 import { StakingModule } from '../staking/staking.module';
 import { TokenModule } from '../tokens/token.module';
 import { PositionCreatorTransactionResolver } from './position.creator.transaction.resolver';
+import { WrappingModule } from '../wrapping/wrap.module';
 
 @Module({
     imports: [
@@ -21,6 +22,7 @@ import { PositionCreatorTransactionResolver } from './position.creator.transacti
         StakingModule,
         StakingProxyModule,
         TokenModule,
+        WrappingModule,
         MXCommunicationModule,
     ],
     providers: [


### PR DESCRIPTION
## Reasoning
- boosted rewards from farms are now split from the base rewards
  
## Proposed Changes
- add query to get only the farm boosted rewards for a user
- add query to generate transaction to claim only boosted rewards

## How to test
```
query FarmBoostedRewards {
	getFarmBoostedRewardsBatch(
		farmsAddresses: [<farm_address_1>, <farm_address_2>]
	) {
		farmAddress
		claimProgress {
			energy {
				amount
			}
			week
		}
		accumulatedRewards
		boostedRewardsWeeklyInfo {
			scAddress
			userAddress
			rewardsForWeek {
				tokenID
				amount
			}
		}
	}
}
```
- query should return an array with all boosted rewards from farms for a user

```
query ClaimBoostedRewards {
	claimFarmBoostedRewards(
		farmAddress: <farm_address>
	) {
		sender
		receiver
		data
		gasLimit
	}
}
```
- query should return transaction to claim boosted rewards