### PR TITLE
[MEX-416] get boosted rewards

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -239,7 +239,8 @@
                         }
                     },
                     "claimRewards": 17000000
-                }
+                },
+                "claimBoostedRewards": 20000000
             },
             "admin": {
                 "end_produce_rewards": 200000000,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -32,6 +32,7 @@ import { constantsConfig } from 'src/config';
 import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
 import { StakeAddressValidationPipe } from './validators/stake.address.validator';
 import { BoostedYieldsFactors } from '../farm/models/farm.v2.model';
+import { BoostedRewardsModel } from '../farm/models/farm.model';
 
 @Resolver(() => StakingModel)
 export class StakingResolver {
@@ -264,6 +265,21 @@ export class StakingResolver {
         return this.stakingService.getBatchRewardsForPosition(
             args.farmsPositions,
             computeBoosted,
+        );
+    }
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => [BoostedRewardsModel], {
+        description: 'Returns staking boosted rewards for the user',
+    })
+    async getStakingBoostedRewardsBatch(
+        @Args('stakingAddresses', { type: () => [String] })
+        stakingAddresses: string[],
+        @AuthUser() user: UserAuthResult,
+    ): Promise<BoostedRewardsModel[]> {
+        return this.stakingService.getStakingBoostedRewardsBatch(
+            stakingAddresses,
+            user.address,
         );
     }
 


### PR DESCRIPTION
## Reasoning
- boosted rewards for staking can now be split between base rewards and boosted rewards
  
## Proposed Changes
- add query to get only boosted rewards for an user from multiple staking contracts

## How to test
```
query StakingBoostedRewardsBatch {
	getStakingBoostedRewardsBatch(
		stakingAddresses: [""]
	) {
		farmAddress
		accumulatedRewards
	}
}
```
