### PR TITLE
[MEX-417] energy position creator

### DIFF
--- a/src/abis/locked-token-pos-creator.abi.json
+++ b/src/abis/locked-token-pos-creator.abi.json
@@ -1,0 +1,233 @@
+{
+    "buildInfo": {
+        "rustc": {
+            "version": "1.71.0-nightly",
+            "commitHash": "a2b1646c597329d0a25efa3889b66650f65de1de",
+            "commitDate": "2023-05-25",
+            "channel": "Nightly",
+            "short": "rustc 1.71.0-nightly (a2b1646c5 2023-05-25)"
+        },
+        "contractCrate": {
+            "name": "locked-token-pos-creator",
+            "version": "0.0.0"
+        },
+        "framework": {
+            "name": "multiversx-sc",
+            "version": "0.45.1"
+        }
+    },
+    "name": "LockedTokenPosCreatorContract",
+    "constructor": {
+        "inputs": [
+            {
+                "name": "energy_factory_adddress",
+                "type": "Address"
+            },
+            {
+                "name": "egld_wrapper_address",
+                "type": "Address"
+            },
+            {
+                "name": "mex_wegld_lp_pair_address",
+                "type": "Address"
+            },
+            {
+                "name": "mex_wegld_lp_farm_address",
+                "type": "Address"
+            },
+            {
+                "name": "proxy_dex_address",
+                "type": "Address"
+            },
+            {
+                "name": "router_address",
+                "type": "Address"
+            }
+        ],
+        "outputs": []
+    },
+    "endpoints": [
+        {
+            "name": "upgrade",
+            "mutability": "mutable",
+            "inputs": [],
+            "outputs": []
+        },
+        {
+            "name": "createEnergyPosition",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [
+                {
+                    "name": "lock_epochs",
+                    "type": "u64"
+                },
+                {
+                    "name": "min_amount_out",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "swap_operations",
+                    "type": "variadic<multi<Address,bytes,TokenIdentifier,BigUint>>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "EsdtTokenPayment"
+                }
+            ]
+        },
+        {
+            "name": "setEnergyFactoryAddress",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "sc_address",
+                    "type": "Address"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "getEnergyFactoryAddress",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "Address"
+                }
+            ]
+        },
+        {
+            "name": "createPairPosFromSingleToken",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [
+                {
+                    "name": "lock_epochs",
+                    "type": "u64"
+                },
+                {
+                    "name": "add_liq_first_token_min_amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "add_liq_second_token_min_amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "swap_operations",
+                    "type": "variadic<multi<Address,bytes,TokenIdentifier,BigUint>>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "List<EsdtTokenPayment>"
+                }
+            ]
+        },
+        {
+            "name": "createPairPosFromTwoTokens",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [
+                {
+                    "name": "add_liq_first_token_min_amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "add_liq_second_token_min_amount",
+                    "type": "BigUint"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "List<EsdtTokenPayment>"
+                }
+            ]
+        },
+        {
+            "name": "createFarmPosFromSingleToken",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [
+                {
+                    "name": "lock_epochs",
+                    "type": "u64"
+                },
+                {
+                    "name": "add_liq_first_token_min_amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "add_liq_second_token_min_amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "swap_operations",
+                    "type": "variadic<multi<Address,bytes,TokenIdentifier,BigUint>>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "List<EsdtTokenPayment>"
+                }
+            ]
+        },
+        {
+            "name": "createFarmPosFromTwoTokens",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [
+                {
+                    "name": "add_liq_first_token_min_amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "add_liq_second_token_min_amount",
+                    "type": "BigUint"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "List<EsdtTokenPayment>"
+                }
+            ]
+        }
+    ],
+    "esdtAttributes": [],
+    "hasCallback": false,
+    "types": {
+        "EsdtTokenPayment": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "token_identifier",
+                    "type": "TokenIdentifier"
+                },
+                {
+                    "name": "token_nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount",
+                    "type": "BigUint"
+                }
+            ]
+        }
+    }
+}

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -44,6 +44,7 @@
         "lockedTokenWrapper": "erd1qqqqqqqqqqqqqpgq9ej9vcnr38l69rgkc735kgv0qlu2ptrsd8ssu9rwtu",
         "escrow": "erd1qqqqqqqqqqqqqpgqz0wkk0j6y4h0mcxfxsg023j4x5sfgrmz0n4s4swp7a",
         "positionCreator": "erd1qqqqqqqqqqqqqpgqh3zcutxk3wmfvevpyymaehvc3k0knyq70n4sg6qcj6",
+        "lockedTokenPositionCreator": "erd1qqqqqqqqqqqqqpgqh3zcutxk3wmfvevpyymaehvc3k0knyq70n4sg6qcj6",
         "composableTasks": "erd1qqqqqqqqqqqqqpgq7ykazrzd905zvnlr88dpfw06677lxe9w0n4suz00uh"
     },
     "tokenProviderUSD": "WEGLD-71e90a",
@@ -496,7 +497,8 @@
             "vote": 50000000
         },
         "positionCreator": {
-            "singleToken": 50000000
+            "singleToken": 50000000,
+            "energyPosition": 20000000
         },
         "composableTasks": {
             "default": 30000000
@@ -543,6 +545,7 @@
             "tokenSnapshot": "./src/abis/governance-v2-merkle-proof.abi.json"
         },
         "positionCreator": "./src/abis/auto-pos-creator.abi.json",
+        "lockedTokenPositionCreator": "./src/abis/locked-token-pos-creator.abi.json",
         "composableTasks": "./src/abis/composable-tasks.abi.json"
     },
     "cron": {

--- a/src/modules/position-creator/position.creator.module.ts
+++ b/src/modules/position-creator/position.creator.module.ts
@@ -12,6 +12,8 @@ import { StakingModule } from '../staking/staking.module';
 import { TokenModule } from '../tokens/token.module';
 import { PositionCreatorTransactionResolver } from './position.creator.transaction.resolver';
 import { WrappingModule } from '../wrapping/wrap.module';
+import { ProxyFarmModule } from '../proxy/services/proxy-farm/proxy.farm.module';
+import { EnergyModule } from '../energy/energy.module';
 
 @Module({
     imports: [
@@ -23,6 +25,8 @@ import { WrappingModule } from '../wrapping/wrap.module';
         StakingProxyModule,
         TokenModule,
         WrappingModule,
+        ProxyFarmModule,
+        EnergyModule,
         MXCommunicationModule,
     ],
     providers: [

--- a/src/modules/position-creator/position.creator.transaction.resolver.ts
+++ b/src/modules/position-creator/position.creator.transaction.resolver.ts
@@ -167,4 +167,23 @@ export class PositionCreatorTransactionResolver {
             tolerance,
         );
     }
+
+    @Query(() => TransactionModel)
+    async createEnergyPosition(
+        @AuthUser() user: UserAuthResult,
+        @Args('payment') payment: InputTokenModel,
+        @Args('lockEpochs') lockEpochs: number,
+        @Args('tolerance') tolerance: number,
+    ): Promise<TransactionModel> {
+        return this.posCreatorTransaction.createEnergyPosition(
+            user.address,
+            new EsdtTokenPayment({
+                tokenIdentifier: payment.tokenID,
+                tokenNonce: payment.nonce,
+                amount: payment.amount,
+            }),
+            lockEpochs,
+            tolerance,
+        );
+    }
 }

--- a/src/modules/position-creator/position.creator.transaction.resolver.ts
+++ b/src/modules/position-creator/position.creator.transaction.resolver.ts
@@ -21,6 +21,7 @@ export class PositionCreatorTransactionResolver {
         @Args('pairAddress') pairAddress: string,
         @Args('payment') payment: InputTokenModel,
         @Args('tolerance') tolerance: number,
+        @Args('lockEpochs', { nullable: true }) lockEpochs: number,
     ): Promise<TransactionModel> {
         return this.posCreatorTransaction.createLiquidityPositionSingleToken(
             user.address,
@@ -31,6 +32,7 @@ export class PositionCreatorTransactionResolver {
                 amount: payment.amount,
             }),
             tolerance,
+            lockEpochs,
         );
     }
 
@@ -41,6 +43,7 @@ export class PositionCreatorTransactionResolver {
         @Args('payments', { type: () => [InputTokenModel] })
         payments: InputTokenModel[],
         @Args('tolerance') tolerance: number,
+        @Args('lockEpochs', { nullable: true }) lockEpochs: number,
     ): Promise<TransactionModel[]> {
         return this.posCreatorTransaction.createFarmPositionSingleToken(
             user.address,
@@ -54,6 +57,7 @@ export class PositionCreatorTransactionResolver {
                     }),
             ),
             tolerance,
+            lockEpochs,
         );
     }
 
@@ -103,14 +107,14 @@ export class PositionCreatorTransactionResolver {
         );
     }
 
-    @Query(() => TransactionModel)
+    @Query(() => [TransactionModel])
     async createFarmPositionDualTokens(
         @AuthUser() user: UserAuthResult,
         @Args('farmAddress') farmAddress: string,
         @Args('payments', { type: () => [InputTokenModel] })
         payments: InputTokenModel[],
         @Args('tolerance') tolerance: number,
-    ): Promise<TransactionModel> {
+    ): Promise<TransactionModel[]> {
         return this.posCreatorTransaction.createFarmPositionDualTokens(
             user.address,
             farmAddress,

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -641,7 +641,7 @@ export class PositionCreatorTransactionService {
         const contract =
             await this.mxProxy.getLockedTokenPositionCreatorContract();
 
-        const interaction = contract.methodsExplicit
+        let interaction = contract.methodsExplicit
             .createEnergyPosition([
                 new U64Value(new BigNumber(lockEpochs)),
                 new BigUIntValue(singleTokenInput.amountOutMin),
@@ -652,9 +652,9 @@ export class PositionCreatorTransactionService {
             .withChainID(mxConfig.chainID);
 
         if (payment.tokenIdentifier === mxConfig.EGLDIdentifier) {
-            interaction.withValue(new BigNumber(payment.amount));
+            interaction = interaction.withValue(new BigNumber(payment.amount));
         } else {
-            interaction.withSingleESDTTransfer(
+            interaction = interaction.withSingleESDTTransfer(
                 TokenTransfer.fungibleFromBigInteger(
                     payment.tokenIdentifier,
                     new BigNumber(payment.amount),

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -409,7 +409,7 @@ export class PositionCreatorTransactionService {
                 xmexTokenID,
             )
         ) {
-            throw new Error('Invalid Locked tokens payments');
+            throw new Error('Invalid locked tokens payments');
         }
 
         if (

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -143,6 +143,90 @@ describe('PositionCreatorTransaction', () => {
         });
     });
 
+    describe('Create liquidity position locked token', () => {
+        it('should return transaction with ESDT payment', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const transaction =
+                await service.createLiquidityPositionSingleToken(
+                    Address.Zero().bech32(),
+                    Address.fromHex(
+                        '0000000000000000000000000000000000000000000000000000000000000012',
+                    ).bech32(),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'USDC-123456',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                    0.01,
+                    1440,
+                );
+
+            expect(transaction).toEqual({
+                nonce: 0,
+                value: '0',
+                receiver:
+                    'erd1qqqqqqqqqqqqqpgqh3zcutxk3wmfvevpyymaehvc3k0knyq70n4sg6qcj6',
+                sender: Address.Zero().bech32(),
+                senderUsername: undefined,
+                receiverUsername: undefined,
+                gasPrice: 1000000000,
+                gasLimit: 50000000,
+                data: encodeTransactionData(
+                    `ESDTTransfer@USDC-123456@100000000000000000000@createPairPosFromSingleToken@1440@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327`,
+                ),
+                chainID: 'T',
+                version: 1,
+                options: undefined,
+                guardian: undefined,
+                signature: undefined,
+                guardianSignature: undefined,
+            });
+        });
+
+        it('should return transaction with EGLD payment', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const transaction =
+                await service.createLiquidityPositionSingleToken(
+                    Address.Zero().bech32(),
+                    Address.fromHex(
+                        '0000000000000000000000000000000000000000000000000000000000000012',
+                    ).bech32(),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'EGLD',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                    0.01,
+                    1440,
+                );
+
+            expect(transaction).toEqual({
+                nonce: 0,
+                value: '100000000000000000000',
+                receiver:
+                    'erd1qqqqqqqqqqqqqpgqh3zcutxk3wmfvevpyymaehvc3k0knyq70n4sg6qcj6',
+                sender: Address.Zero().bech32(),
+                senderUsername: undefined,
+                receiverUsername: undefined,
+                gasPrice: 1000000000,
+                gasLimit: 50000000,
+                data: encodeTransactionData(
+                    `createPairPosFromSingleToken@1440@49500000000000000000@47008144020574367766823`,
+                ),
+                chainID: 'T',
+                version: 1,
+                options: undefined,
+                guardian: undefined,
+                signature: undefined,
+                guardianSignature: undefined,
+            });
+        });
+    });
+
     describe('Create farm position single token', () => {
         it('should return error on ESDT token', async () => {
             const service = module.get<PositionCreatorTransactionService>(
@@ -271,6 +355,95 @@ describe('PositionCreatorTransaction', () => {
                     gasLimit: 50000000,
                     data: encodeTransactionData(
                         `MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@USDC-123456@@100000000000000000000@EGLDMEXFL-abcdef@01@100000000000000000000@createFarmPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000021@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327`,
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
+        });
+    });
+
+    describe('Create farm position single token with locked token', () => {
+        it('should return transaction with ESDT payment', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const transaction = await service.createFarmPositionSingleToken(
+                Address.Zero().bech32(),
+                Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000021',
+                ).bech32(),
+                [
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'USDC-123456',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                ],
+                0.01,
+                1440,
+            );
+
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        `MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@01@USDC-123456@@100000000000000000000@createFarmPosFromSingleToken@1440@494999999950351053163@329339339317295273252718@0000000000000000000000000000000000000000000000000000000000000013@swapTokensFixedInput@WEGLD-123456@989999999900702106327`,
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
+        });
+
+        it('should return transaction with EGLD payment', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const transaction = await service.createFarmPositionSingleToken(
+                Address.Zero().bech32(),
+                Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000021',
+                ).bech32(),
+                [
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'EGLD',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                ],
+                0.01,
+                1440,
+            );
+
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '100000000000000000000',
+                    receiver:
+                        'erd1qqqqqqqqqqqqqpgqh3zcutxk3wmfvevpyymaehvc3k0knyq70n4sg6qcj6',
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        `createFarmPosFromSingleToken@1440@49500000000000000000@47008144020574367766823`,
                     ),
                     chainID: 'T',
                     version: 1,

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -1244,4 +1244,101 @@ describe('PositionCreatorTransaction', () => {
             });
         });
     });
+
+    describe('Energy position creator', () => {
+        it('should return error on invalid ESDT payment', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+
+            expect(
+                service.createEnergyPosition(
+                    Address.Zero().bech32(),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'WEGLD-abcdef',
+                        tokenNonce: 0,
+                        amount: '1000000000000000000',
+                    }),
+                    1440,
+                    0.01,
+                ),
+            ).rejects.toThrowError('Invalid ESDT token payment');
+        });
+
+        it('should return transaction with ESDT payment', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+
+            const transaction = await service.createEnergyPosition(
+                Address.Zero().bech32(),
+                new EsdtTokenPayment({
+                    tokenIdentifier: 'WEGLD-123456',
+                    tokenNonce: 0,
+                    amount: '1000000000000000000',
+                }),
+                1440,
+                0.01,
+            );
+
+            expect(transaction).toEqual({
+                chainID: 'T',
+                data: encodeTransactionData(
+                    'ESDTTransfer@WEGLD-123456@1000000000000000000@createEnergyPosition@1440@986046911229504184328@0000000000000000000000000000000000000000000000000000000000000012@swapTokensFixedInput@MEX-123456@986046911229504184328',
+                ),
+                gasLimit: 50000000,
+                gasPrice: 1000000000,
+                guardian: undefined,
+                guardianSignature: undefined,
+                nonce: 0,
+                options: undefined,
+                receiver:
+                    'erd1qqqqqqqqqqqqqpgqh3zcutxk3wmfvevpyymaehvc3k0knyq70n4sg6qcj6',
+                receiverUsername: undefined,
+                sender: 'erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu',
+                senderUsername: undefined,
+                signature: undefined,
+                value: '0',
+                version: 1,
+            });
+        });
+
+        it('should return transaction with EGLD payment', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+
+            const transaction = await service.createEnergyPosition(
+                Address.Zero().bech32(),
+                new EsdtTokenPayment({
+                    tokenIdentifier: 'EGLD',
+                    tokenNonce: 0,
+                    amount: '1000000000000000000',
+                }),
+                1440,
+                0.01,
+            );
+
+            expect(transaction).toEqual({
+                chainID: 'T',
+                data: encodeTransactionData(
+                    'createEnergyPosition@1440@986046911229504184328@0000000000000000000000000000000000000000000000000000000000000012@swapTokensFixedInput@MEX-123456@986046911229504184328',
+                ),
+                gasLimit: 50000000,
+                gasPrice: 1000000000,
+                guardian: undefined,
+                guardianSignature: undefined,
+                nonce: 0,
+                options: undefined,
+                receiver:
+                    'erd1qqqqqqqqqqqqqpgqh3zcutxk3wmfvevpyymaehvc3k0knyq70n4sg6qcj6',
+                receiverUsername: undefined,
+                sender: 'erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu',
+                senderUsername: undefined,
+                signature: undefined,
+                value: '1000000000000000000',
+                version: 1,
+            });
+        });
+    });
 });

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -31,6 +31,8 @@ import { encodeTransactionData } from 'src/helpers/helpers';
 import exp from 'constants';
 import { StakingProxyAbiService } from 'src/modules/staking-proxy/services/staking.proxy.abi.service';
 import { ComposableTasksTransactionService } from 'src/modules/composable-tasks/services/composable.tasks.transaction';
+import { ProxyFarmAbiServiceProvider } from 'src/modules/proxy/mocks/proxy.abi.service.mock';
+import { EnergyAbiServiceProvider } from 'src/modules/energy/mocks/energy.abi.service.mock';
 
 describe('PositionCreatorTransaction', () => {
     let module: TestingModule;
@@ -65,6 +67,8 @@ describe('PositionCreatorTransaction', () => {
                 TokenServiceProvider,
                 RemoteConfigGetterServiceProvider,
                 ComposableTasksTransactionService,
+                ProxyFarmAbiServiceProvider,
+                EnergyAbiServiceProvider,
                 MXProxyServiceProvider,
                 ConfigService,
                 ApiConfigService,
@@ -625,7 +629,7 @@ describe('PositionCreatorTransaction', () => {
             const service = module.get<PositionCreatorTransactionService>(
                 PositionCreatorTransactionService,
             );
-            const transaction = await service.createFarmPositionDualTokens(
+            const transactions = await service.createFarmPositionDualTokens(
                 Address.Zero().bech32(),
                 Address.fromHex(
                     '0000000000000000000000000000000000000000000000000000000000000021',
@@ -645,32 +649,34 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@WEGLD-123456@@100000000000000000000@MEX-123456@@100000000000000000000@createFarmPosFromTwoTokens@0000000000000000000000000000000000000000000000000000000000000021@99000000000000000000@99000000000000000000',
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            expect(transactions).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@WEGLD-123456@@100000000000000000000@MEX-123456@@100000000000000000000@createFarmPosFromTwoTokens@0000000000000000000000000000000000000000000000000000000000000021@99000000000000000000@99000000000000000000',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
 
         it('should return transaction no merge farm tokens', async () => {
             const service = module.get<PositionCreatorTransactionService>(
                 PositionCreatorTransactionService,
             );
-            const transaction = await service.createFarmPositionDualTokens(
+            const transactions = await service.createFarmPositionDualTokens(
                 Address.Zero().bech32(),
                 Address.fromHex(
                     '0000000000000000000000000000000000000000000000000000000000000021',
@@ -695,25 +701,303 @@ describe('PositionCreatorTransaction', () => {
                 0.01,
             );
 
-            expect(transaction).toEqual({
-                nonce: 0,
-                value: '0',
-                receiver: Address.Zero().bech32(),
-                sender: Address.Zero().bech32(),
-                senderUsername: undefined,
-                receiverUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: 50000000,
-                data: encodeTransactionData(
-                    'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@03@WEGLD-123456@@100000000000000000000@MEX-123456@@100000000000000000000@EGLDMEXFL-abcdef@01@100000000000000000000@createFarmPosFromTwoTokens@0000000000000000000000000000000000000000000000000000000000000021@99000000000000000000@99000000000000000000',
+            expect(transactions).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@03@WEGLD-123456@@100000000000000000000@MEX-123456@@100000000000000000000@EGLDMEXFL-abcdef@01@100000000000000000000@createFarmPosFromTwoTokens@0000000000000000000000000000000000000000000000000000000000000021@99000000000000000000@99000000000000000000',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
+        });
+
+        it('should return transactions with egld wrap', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const transactions = await service.createFarmPositionDualTokens(
+                Address.Zero().bech32(),
+                Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000021',
+                ).bech32(),
+                [
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'EGLD',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'MEX-123456',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'EGLDMEXFL-abcdef',
+                        tokenNonce: 1,
+                        amount: '100000000000000000000',
+                    }),
+                ],
+                0.01,
+            );
+
+            expect(transactions).toEqual([
+                {
+                    nonce: 0,
+                    value: '100000000000000000000',
+                    receiver:
+                        'erd1qqqqqqqqqqqqqpgqd77fnev2sthnczp2lnfx0y5jdycynjfhzzgq6p3rax',
+                    sender: '',
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 4200000,
+                    data: encodeTransactionData('wrapEgld'),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@03@WEGLD-123456@@100000000000000000000@MEX-123456@@100000000000000000000@EGLDMEXFL-abcdef@01@100000000000000000000@createFarmPosFromTwoTokens@0000000000000000000000000000000000000000000000000000000000000021@99000000000000000000@99000000000000000000',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
+        });
+    });
+
+    describe('Create farm position dual token with locked token', () => {
+        it('should return error on invalid locked token', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+
+            expect(
+                service.createFarmPositionDualTokens(
+                    Address.Zero().bech32(),
+                    Address.fromHex(
+                        '0000000000000000000000000000000000000000000000000000000000000021',
+                    ).bech32(),
+                    [
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'WEGLD-123456',
+                            tokenNonce: 0,
+                            amount: '100000000000000000000',
+                        }),
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'ELKMEX-123456',
+                            tokenNonce: 0,
+                            amount: '100000000000000000000',
+                        }),
+                    ],
+                    0.01,
                 ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                guardian: undefined,
-                signature: undefined,
-                guardianSignature: undefined,
-            });
+            ).rejects.toThrowError('Invalid locked tokens payments');
+
+            expect(
+                service.createFarmPositionDualTokens(
+                    Address.Zero().bech32(),
+                    Address.fromHex(
+                        '0000000000000000000000000000000000000000000000000000000000000021',
+                    ).bech32(),
+                    [
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'ELKMEX-123456',
+                            tokenNonce: 1,
+                            amount: '100000000000000000000',
+                        }),
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'WEGLD-123456',
+                            tokenNonce: 1,
+                            amount: '100000000000000000000',
+                        }),
+                    ],
+                    0.01,
+                ),
+            ).rejects.toThrowError('Invalid locked tokens payments');
+
+            expect(
+                service.createFarmPositionDualTokens(
+                    Address.Zero().bech32(),
+                    Address.fromHex(
+                        '0000000000000000000000000000000000000000000000000000000000000021',
+                    ).bech32(),
+                    [
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'ELKMEX-123456',
+                            tokenNonce: 1,
+                            amount: '100000000000000000000',
+                        }),
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'USDC-123456',
+                            tokenNonce: 0,
+                            amount: '100000000000000000000',
+                        }),
+                    ],
+                    0.01,
+                ),
+            ).rejects.toThrowError('Invalid locked tokens payments');
+        });
+
+        it('should return error on wrapped farm token', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+
+            expect(
+                service.createFarmPositionDualTokens(
+                    Address.Zero().bech32(),
+                    Address.fromHex(
+                        '0000000000000000000000000000000000000000000000000000000000000021',
+                    ).bech32(),
+                    [
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'ELKMEX-123456',
+                            tokenNonce: 1,
+                            amount: '100000000000000000000',
+                        }),
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'WEGLD-123456',
+                            tokenNonce: 0,
+                            amount: '100000000000000000000',
+                        }),
+                        new EsdtTokenPayment({
+                            tokenIdentifier: 'LKFARM-abcdef',
+                            tokenNonce: 0,
+                            amount: '100000000000000000000',
+                        }),
+                    ],
+                    0.01,
+                ),
+            ).rejects.toThrowError('Invalid wrapped farm token payment');
+        });
+
+        it('should return transaction without consolidate', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const transactions = await service.createFarmPositionDualTokens(
+                Address.Zero().bech32(),
+                Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000021',
+                ).bech32(),
+                [
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'ELKMEX-123456',
+                        tokenNonce: 1,
+                        amount: '100000000000000000000',
+                    }),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'WEGLD-123456',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                ],
+                0.01,
+            );
+
+            expect(transactions).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@WEGLD-123456@@100000000000000000000@ELKMEX-123456@01@100000000000000000000@createFarmPosFromTwoTokens@99000000000000000000@99000000000000000000',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
+        });
+
+        it('should return transaction with consolidate', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const transactions = await service.createFarmPositionDualTokens(
+                Address.Zero().bech32(),
+                Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000021',
+                ).bech32(),
+                [
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'ELKMEX-123456',
+                        tokenNonce: 1,
+                        amount: '100000000000000000000',
+                    }),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'WEGLD-123456',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'LKFARM-123456',
+                        tokenNonce: 1,
+                        amount: '100000000000000000000',
+                    }),
+                ],
+                0.01,
+            );
+
+            expect(transactions).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@03@WEGLD-123456@@100000000000000000000@ELKMEX-123456@01@100000000000000000000@LKFARM-123456@01@100000000000000000000@createFarmPosFromTwoTokens@99000000000000000000@99000000000000000000',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
         });
     });
 

--- a/src/services/multiversx-communication/mx.proxy.service.ts
+++ b/src/services/multiversx-communication/mx.proxy.service.ts
@@ -231,6 +231,14 @@ export class MXProxyService {
         );
     }
 
+    async getLockedTokenPositionCreatorContract(): Promise<SmartContract> {
+        return this.getSmartContract(
+            scAddress.lockedTokenPositionCreator,
+            abiConfig.lockedTokenPositionCreator,
+            'LockedTokenPosCreatorContract',
+        );
+    }
+
     async getComposableTasksSmartContract(): Promise<SmartContract> {
         return this.getSmartContract(
             scAddress.composableTasks,


### PR DESCRIPTION
## Reasoning
- create xMEX positions with any token
- create xMEX liquidity position with any token
- create xMEX farm position with any token
  
## Proposed Changes
- add query to generate transaction for create xMEX position from any token
- update create liquidity and farm position to accept lockEpochs and generate transaction for energy position creator
- update farm position with two tokens to accept xMEX tokens and generate transaction for energy position creator

## How to test
- create energy position
```
query CreateEnergyPosition {
	createEnergyPosition(
		payment: {
			tokenID: <token_id>,
			nonce: 0,
			amount: <amount>
		},
		lockEpochs: 1440,
		tolerance: 0.01
	) {
		data
	}
}
```
- create locked position single token
```
query CreatePositionSingleToken {
	createPositionSingleToken(
		pairAddress: <pair_address>,
		payment: {
			tokenID: <token_id>,
			nonce: 0,
			amount: <amount>
		},
		tolerance: 0.1,
                lockEpochs: 1440
	) {
		receiver
		data
	}
}
```