### PR TITLE
[SERVICES-2035] escrow check sender & receiver

### DIFF
--- a/src/modules/escrow/services/escrow.transaction.service.ts
+++ b/src/modules/escrow/services/escrow.transaction.service.ts
@@ -43,6 +43,10 @@ export class EscrowTransactionService {
         receiverAddress: string,
         payments: InputTokenModel[],
     ): Promise<TransactionModel> {
+        if (senderAddress === receiverAddress) {
+            throw new Error('Sender and receiver cannot be the same');
+        }
+
         const contract = await this.mxProxy.getEscrowContract();
 
         return contract.methodsExplicit


### PR DESCRIPTION
## Reasoning
- sender should not be able to send fund to himself
  
## Proposed Changes
- throw error if sender and receiver address for `lockFunds` are the same

## How to test
```
query TransferFunds {
	escrowTransfer(
		receiver: <sender_address>,
		inputTokens: [
			{
				tokenID: <token_id>,
				nonce: 1,
				amount: <amount>
			},
		]
	) {
		receiver
		gasLimit
		data
	}
}
```
- query should return error