### PR TITLE
[SERVICES-2040] Add previous24hPrice to token model

### DIFF
--- a/src/modules/tokens/models/esdtToken.model.ts
+++ b/src/modules/tokens/models/esdtToken.model.ts
@@ -22,6 +22,7 @@ export class EsdtToken implements IEsdtToken {
     decimals: number;
     derivedEGLD: string;
     price?: string;
+    previous24hPrice?: string;
     supply?: string;
     circulatingSupply?: string;
     assets?: AssetsModel;

--- a/src/modules/tokens/token.resolver.ts
+++ b/src/modules/tokens/token.resolver.ts
@@ -33,6 +33,13 @@ export class TokensResolver extends GenericResolver {
     }
 
     @ResolveField(() => String)
+    async previous24hPrice(@Parent() parent: EsdtToken): Promise<string> {
+        return await this.genericFieldResolver(() =>
+            this.tokenCompute.tokenPrevious24hPrice(parent.identifier),
+        );
+    }
+
+    @ResolveField(() => String)
     async type(@Parent() parent: EsdtToken): Promise<string> {
         return await this.genericFieldResolver(() =>
             this.tokenService.getEsdtTokenType(parent.identifier),


### PR DESCRIPTION
## Reasoning
- display token price change from multiple dApps
  
## Proposed Changes
- add new field for EsdtToken model: `previous24hPrice`
- add resolver for new field

## How to test
```
query Tokens {
	tokens {
		identifier
		decimals
		price
		previous24hPrice
	}
}
```
- query should return previous tokens price