### PR TITLE
[MEX-416] Missing field for staking BoostedRewardsModel

### DIFF
--- a/src/modules/staking/services/staking.service.ts
+++ b/src/modules/staking/services/staking.service.ts
@@ -262,6 +262,7 @@ export class StakingService {
             );
 
         return new BoostedRewardsModel({
+            farmAddress: stakingAddress,
             boostedRewardsWeeklyInfo: modelsList,
             claimProgress: currentClaimProgress,
             accumulatedRewards: userAccumulatedRewards,


### PR DESCRIPTION
## Reasoning
- missing field for returned BoostedRewardsModel
  
## Proposed Changes
- added `farmAddress` field

## How to test
```
query StakingBoostedRewardsBatch {
	getStakingBoostedRewardsBatch(
		stakingAddresses: [<address>]
	) {
		farmAddress
		accumulatedRewards
	}
}
```
- query should return an address for `farmAddress` field