### PR TITLE
[MEX-418] claim boosted rewards

### DIFF
--- a/src/abis/farm-staking.abi.json
+++ b/src/abis/farm-staking.abi.json
@@ -1,20 +1,20 @@
 {
     "buildInfo": {
         "rustc": {
-            "version": "1.73.0-nightly",
-            "commitHash": "4c8bb79d9f565115637cc6da739f8389e79f3a29",
-            "commitDate": "2023-07-15",
+            "version": "1.76.0-nightly",
+            "commitHash": "d86d65bbc19b928387f68427fcc3a0da498d8a19",
+            "commitDate": "2023-12-10",
             "channel": "Nightly",
-            "short": "rustc 1.73.0-nightly (4c8bb79d9 2023-07-15)"
+            "short": "rustc 1.76.0-nightly (d86d65bbc 2023-12-10)"
         },
         "contractCrate": {
             "name": "farm-staking",
             "version": "0.0.0",
-            "gitVersion": "v1.6.0-1527-g9534cc41"
+            "gitVersion": "v1.6.0-1579-ge4b95afa"
         },
         "framework": {
             "name": "multiversx-sc",
-            "version": "0.43.3"
+            "version": "0.45.2"
         }
     },
     "name": "FarmStaking",
@@ -214,6 +214,21 @@
                 }
             ],
             "outputs": []
+        },
+        {
+            "name": "getAllowExternalClaimRewards",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "user",
+                    "type": "Address"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "bool"
+                }
+            ]
         },
         {
             "name": "getFarmingTokenId",
@@ -1143,6 +1158,7 @@
             ]
         }
     ],
+    "esdtAttributes": [],
     "hasCallback": true,
     "types": {
         "BoostedYieldsFactors": {

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -392,6 +392,7 @@
             "claimRewards": 17000000,
             "claimRewardsWithNewValue": 17000000,
             "compoundRewards": 17000000,
+            "claimBoostedRewards": 20000000,
             "mergeTokens": 20000000,
             "admin": {
                 "setState": 20000000,

--- a/src/modules/staking/services/staking.transactions.service.ts
+++ b/src/modules/staking/services/staking.transactions.service.ts
@@ -182,6 +182,22 @@ export class StakingTransactionService {
             .toPlainObject();
     }
 
+    async claimBoostedRewards(
+        sender: string,
+        stakeAddress: string,
+    ): Promise<TransactionModel> {
+        const contract = await this.mxProxy.getStakingSmartContract(
+            stakeAddress,
+        );
+        return contract.methodsExplicit
+            .claimBoostedRewards()
+            .withSender(Address.fromString(sender))
+            .withGasLimit(gasConfig.stake.claimBoostedRewards)
+            .withChainID(mxConfig.chainID)
+            .buildTransaction()
+            .toPlainObject();
+    }
+
     async migrateTotalStakingPosition(
         stakingAddress: string,
         userAddress: string,

--- a/src/modules/staking/specs/staking.transactions.service.spec.ts
+++ b/src/modules/staking/specs/staking.transactions.service.spec.ts
@@ -210,6 +210,33 @@ describe('StakingTransactionService', () => {
         });
     });
 
+    it('should get claim boosted rewards transaction', async () => {
+        const service = module.get<StakingTransactionService>(
+            StakingTransactionService,
+        );
+        const transaction = await service.claimBoostedRewards(
+            Address.Zero().bech32(),
+            Address.Zero().bech32(),
+        );
+        expect(transaction).toEqual({
+            nonce: 0,
+            value: '0',
+            receiver: Address.Zero().bech32(),
+            sender: Address.Zero().bech32(),
+            senderUsername: undefined,
+            receiverUsername: undefined,
+            gasPrice: 1000000000,
+            gasLimit: gasConfig.stake.claimBoostedRewards,
+            data: encodeTransactionData('claimBoostedRewards'),
+            chainID: 'T',
+            version: 1,
+            options: undefined,
+            signature: undefined,
+            guardian: undefined,
+            guardianSignature: undefined,
+        });
+    });
+
     it('should get total staking migrate transaction', async () => {
         const service = module.get<StakingTransactionService>(
             StakingTransactionService,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -559,6 +559,18 @@ export class StakingResolver {
         );
     }
 
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Query(() => TransactionModel)
+    async claimStakingBoostedRewards(
+        @Args('stakeAddress') stakeAddress: string,
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TransactionModel> {
+        return this.stakingTransactionService.claimBoostedRewards(
+            user.address,
+            stakeAddress,
+        );
+    }
+
     @UseGuards(JwtOrNativeAdminGuard)
     @Query(() => TransactionModel)
     async topUpRewards(


### PR DESCRIPTION
## Reasoning
- users can claim only boosted rewards from staking contracts
  
## Proposed Changes
- added transaction generation for claiming boosted rewards from staking contracts

## How to test
```
query ClaimStakingBoostedRewards {
	claimStakingBoostedRewards(stakeAddress: <stake_address>) {
		receiver
		data
	}
}
```
- query should return transaction