### PR TITLE
[SERVICES-2040] return null if no previous price

### DIFF
--- a/src/modules/tokens/token.resolver.ts
+++ b/src/modules/tokens/token.resolver.ts
@@ -32,7 +32,7 @@ export class TokensResolver extends GenericResolver {
         );
     }
 
-    @ResolveField(() => String)
+    @ResolveField(() => String, { nullable: true })
     async previous24hPrice(@Parent() parent: EsdtToken): Promise<string> {
         return await this.genericFieldResolver(() =>
             this.tokenCompute.tokenPrevious24hPrice(parent.identifier),


### PR DESCRIPTION
## Reasoning
- previous price might not exist if tokens have no swaps
  
## Proposed Changes
- return null for token previous price if no price is available

## How to test
```
query Tokens {
	tokens {
		identifier
		previous24hPrice
	}
}
```
- query should return `null` for `previous24hPrice` for tokens with no previous price