### PR TITLE
[MEX-372] user total boosted position

### DIFF
--- a/src/modules/farm/models/farm.model.ts
+++ b/src/modules/farm/models/farm.model.ts
@@ -60,6 +60,18 @@ export class BoostedRewardsModel {
 }
 
 @ObjectType()
+export class UserTotalBoostedPosition {
+    @Field()
+    address: string;
+    @Field()
+    boostedTokensAmount: string;
+
+    constructor(init?: Partial<UserTotalBoostedPosition>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
 export class ExitFarmTokensModel {
     @Field()
     farmingTokens: string;

--- a/src/modules/farm/v2/farm.v2.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.resolver.ts
@@ -14,7 +14,11 @@ import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard'
 import { UserAuthResult } from 'src/modules/auth/user.auth.result';
 import { AuthUser } from 'src/modules/auth/auth.user';
 import { farmVersion } from 'src/utils/farm.utils';
-import { BoostedRewardsModel, FarmVersion } from '../models/farm.model';
+import {
+    BoostedRewardsModel,
+    FarmVersion,
+    UserTotalBoostedPosition,
+} from '../models/farm.model';
 import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 
@@ -151,21 +155,36 @@ export class FarmResolverV2 extends FarmResolver {
     }
 
     @UseGuards(JwtOrNativeAuthGuard)
-    @Query(() => String, {
+    @Query(() => [UserTotalBoostedPosition], {
         description: 'Returns the total farm position of the user in the farm',
     })
     async userTotalFarmPosition(
-        @Args('farmAddress') farmAddress: string,
+        @Args('farmsAddresses', { type: () => [String] })
+        farmsAddresses: string[],
         @AuthUser() user: UserAuthResult,
-    ): Promise<string> {
-        if (farmVersion(farmAddress) !== FarmVersion.V2) {
-            throw new GraphQLError('Farm version is not supported', {
-                extensions: {
-                    code: ApolloServerErrorCode.BAD_USER_INPUT,
-                },
+    ): Promise<UserTotalBoostedPosition[]> {
+        farmsAddresses.forEach((farmAddress) => {
+            if (farmVersion(farmAddress) !== FarmVersion.V2) {
+                throw new GraphQLError('Farm version is not supported', {
+                    extensions: {
+                        code: ApolloServerErrorCode.BAD_USER_INPUT,
+                    },
+                });
+            }
+        });
+
+        const positions = await Promise.all(
+            farmsAddresses.map((farmAddress) =>
+                this.farmAbi.userTotalFarmPosition(farmAddress, user.address),
+            ),
+        );
+
+        return farmsAddresses.map((farmAddress, index) => {
+            return new UserTotalBoostedPosition({
+                address: farmAddress,
+                boostedTokensAmount: positions[index],
             });
-        }
-        return this.farmAbi.userTotalFarmPosition(farmAddress, user.address);
+        });
     }
 
     @UseGuards(JwtOrNativeAuthGuard)

--- a/src/modules/staking/validators/stake.address.validator.ts
+++ b/src/modules/staking/validators/stake.address.validator.ts
@@ -7,16 +7,20 @@ import { Address } from '@multiversx/sdk-core/out';
 export class StakeAddressValidationPipe implements PipeTransform {
     constructor(private readonly remoteConfig: RemoteConfigGetterService) {}
 
-    async transform(value: string, metadata: ArgumentMetadata) {
+    async transform(value: string | string[], metadata: ArgumentMetadata) {
         let address: Address;
-        try {
-            address = Address.fromBech32(value);
-        } catch (error) {
-            throw new UserInputError('Invalid address');
-        }
+        const values = Array.isArray(value) ? value : [value];
         const stakingAddresses = await this.remoteConfig.getStakingAddresses();
-        if (!stakingAddresses.includes(address.bech32())) {
-            throw new UserInputError('Invalid staking address');
+
+        for (const entry of values) {
+            try {
+                address = Address.fromBech32(entry);
+            } catch (error) {
+                throw new UserInputError('Invalid address');
+            }
+            if (!stakingAddresses.includes(address.bech32())) {
+                throw new UserInputError('Invalid staking address');
+            }
         }
 
         return value;


### PR DESCRIPTION
## Reasoning
- easier way for clients to get a list of all boosted positions amounts from all farms or staking
  
## Proposed Changes
- added a new model to return sc address and user boosted position
- updated queries to return an array of user boosted position from an array of sc addresses as input
- 

## How to test
```
query UserTotalFarmPosition {
	userTotalFarmPosition(farmsAddresses:
		[<farm_address>]
	){
		address
		boostedTokensAmount
	}
}
```
- query should return an array of boosted positions amounts