### PR TITLE
[MEX-410] dual yield position from lp token

### DIFF
--- a/src/modules/position-creator/services/position.creator.compute.ts
+++ b/src/modules/position-creator/services/position.creator.compute.ts
@@ -59,10 +59,19 @@ export class PositionCreatorComputeService {
         const acceptedPairedTokensIDs =
             await this.routerAbi.commonTokensForUserPairs();
 
-        const [firstTokenID, secondTokenID] = await Promise.all([
+        const [firstTokenID, secondTokenID, lpTokenID] = await Promise.all([
             this.pairAbi.firstTokenID(pairAddress),
             this.pairAbi.secondTokenID(pairAddress),
+            this.pairAbi.lpTokenID(pairAddress),
         ]);
+
+        if (payment.tokenIdentifier === lpTokenID) {
+            return {
+                swapRouteArgs: [],
+                amount0Min: new BigNumber(0),
+                amount1Min: new BigNumber(0),
+            };
+        }
 
         const swapToTokenID = acceptedPairedTokensIDs.includes(firstTokenID)
             ? firstTokenID

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -230,8 +230,11 @@ export class PositionCreatorTransactionService {
             this.wrapAbi.wrappedEgldTokenID(),
         ]);
 
+        const lpTokenID = await this.pairAbi.lpTokenID(pairAddress);
+
         if (
             !uniqueTokensIDs.includes(payments[0].tokenIdentifier) &&
+            payments[0].tokenIdentifier !== lpTokenID &&
             payments[0].tokenIdentifier !== mxConfig.EGLDIdentifier
         ) {
             throw new Error('Invalid ESDT token payment');
@@ -269,7 +272,6 @@ export class PositionCreatorTransactionService {
                 new BigUIntValue(singleTokenPairInput.amount1Min),
                 ...singleTokenPairInput.swapRouteArgs,
             ])
-
             .withSender(Address.fromBech32(sender))
             .withGasLimit(gasConfig.positionCreator.singleToken)
             .withChainID(mxConfig.chainID);

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -834,6 +834,60 @@ describe('PositionCreatorTransaction', () => {
                 },
             ]);
         });
+
+        it('should return transaction with LP token and merge dual farm tokens', async () => {
+            const service = module.get<PositionCreatorTransactionService>(
+                PositionCreatorTransactionService,
+            );
+            const stakingProxyAbi = module.get<StakingProxyAbiService>(
+                StakingProxyAbiService,
+            );
+            jest.spyOn(stakingProxyAbi, 'pairAddress').mockResolvedValue(
+                Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000012',
+                ).bech32(),
+            );
+
+            const transaction = await service.createDualFarmPositionSingleToken(
+                Address.Zero().bech32(),
+                Address.Zero().bech32(),
+                [
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'EGLDMEXLP-abcdef',
+                        tokenNonce: 0,
+                        amount: '100000000000000000000',
+                    }),
+                    new EsdtTokenPayment({
+                        tokenIdentifier: 'METASTAKE-1234',
+                        tokenNonce: 1,
+                        amount: '100000000000000000000',
+                    }),
+                ],
+                0.01,
+            );
+
+            expect(transaction).toEqual([
+                {
+                    nonce: 0,
+                    value: '0',
+                    receiver: Address.Zero().bech32(),
+                    sender: Address.Zero().bech32(),
+                    senderUsername: undefined,
+                    receiverUsername: undefined,
+                    gasPrice: 1000000000,
+                    gasLimit: 50000000,
+                    data: encodeTransactionData(
+                        'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@EGLDMEXLP-abcdef@@100000000000000000000@METASTAKE-1234@01@100000000000000000000@createMetastakingPosFromSingleToken@0000000000000000000000000000000000000000000000000000000000000000@@',
+                    ),
+                    chainID: 'T',
+                    version: 1,
+                    options: undefined,
+                    guardian: undefined,
+                    signature: undefined,
+                    guardianSignature: undefined,
+                },
+            ]);
+        });
     });
 
     describe('Create staking position single token', () => {


### PR DESCRIPTION
## Reasoning
- position creator SC accepts lp token to convert it into a dual yield position
  
## Proposed Changes
- update createDualFarmPositionSingleToken to create transaction from lp token

## How to test
```
query CreateDualFarmPositionSingleToken {
	createDualFarmPositionSingleToken(
		dualFarmAddress: <dual_farm_address>,
		payments: [{
			tokenID: <lp_token_id>,
			nonce: 0,
			amount: <amount>
		}],
		tolerance: 0.01
	) {
		receiver
		data
	}
}
```
- query should return transaction if valid lp token is used