### PR TITLE
[SERVICES-2105] improve user nfts request

### DIFF
--- a/src/modules/auth/gql.auth.guard.ts
+++ b/src/modules/auth/gql.auth.guard.ts
@@ -23,20 +23,20 @@ export class GqlAuthGuard implements CanActivate {
         const ctx = GqlExecutionContext.create(context);
         const { req } = ctx.getContext();
         const headers = req.headers;
-        // this.logger.info('request header', [
-        //     {
-        //         requestIP: req.ip,
-        //         headers: {
-        //             host: headers['host'],
-        //             'x-request-id': headers['x-request-id'],
-        //             'x-real-ip': headers['x-real-ip'],
-        //             'x-forwarded-for': headers['x-forwarded-for'],
-        //             'x-forwarded-host': headers['x-forwarded-host'],
-        //             'x-forwarded-port': headers['x-forwarded-port'],
-        //             'user-agent': headers['user-agent'],
-        //         },
-        //     },
-        // ]);
+        this.logger.info('request header', [
+            {
+                requestIP: req.ip,
+                headers: {
+                    host: headers['host'],
+                    'x-request-id': headers['x-request-id'],
+                    'x-real-ip': headers['x-real-ip'],
+                    'x-forwarded-for': headers['x-forwarded-for'],
+                    'x-forwarded-host': headers['x-forwarded-host'],
+                    'x-forwarded-port': headers['x-forwarded-port'],
+                    'user-agent': headers['user-agent'],
+                },
+            },
+        ]);
 
         if (headers !== undefined) {
             this.impersonateAddress = headers['impersonate-address'];

--- a/src/modules/auth/gql.auth.guard.ts
+++ b/src/modules/auth/gql.auth.guard.ts
@@ -23,19 +23,20 @@ export class GqlAuthGuard implements CanActivate {
         const ctx = GqlExecutionContext.create(context);
         const { req } = ctx.getContext();
         const headers = req.headers;
-        this.logger.info('request header', [
-            {
-                requestIP: req.ip, headers: {
-                    'host': headers['host'],
-                    'x-request-id': headers['x-request-id'],
-                    'x-real-ip': headers['x-real-ip'],
-                    'x-forwarded-for': headers['x-forwarded-for'],
-                    'x-forwarded-host': headers['x-forwarded-host'],
-                    'x-forwarded-port': headers['x-forwarded-port'],
-                    'user-agent': headers['user-agent'],
-                }
-            },
-        ]);
+        // this.logger.info('request header', [
+        //     {
+        //         requestIP: req.ip,
+        //         headers: {
+        //             host: headers['host'],
+        //             'x-request-id': headers['x-request-id'],
+        //             'x-real-ip': headers['x-real-ip'],
+        //             'x-forwarded-for': headers['x-forwarded-for'],
+        //             'x-forwarded-host': headers['x-forwarded-host'],
+        //             'x-forwarded-port': headers['x-forwarded-port'],
+        //             'user-agent': headers['user-agent'],
+        //         },
+        //     },
+        // ]);
 
         if (headers !== undefined) {
             this.impersonateAddress = headers['impersonate-address'];
@@ -74,7 +75,6 @@ export class GqlAuthGuard implements CanActivate {
                 });
             });
         } catch (error) {
-            this.logger.error(error);
             return false;
         }
 

--- a/src/modules/auth/jwt.or.native.auth.guard.ts
+++ b/src/modules/auth/jwt.or.native.auth.guard.ts
@@ -34,7 +34,7 @@ export class JwtOrNativeAuthGuard implements CanActivate {
                 try {
                     return guard.canActivate(context);
                 } catch (error) {
-                    this.logger.error(
+                    this.logger.warn(
                         `${JwtOrNativeAuthGuard.name}: ${error.message}`,
                     );
                     return false;

--- a/src/modules/auto-router/specs/auto-router.service.spec.ts
+++ b/src/modules/auto-router/specs/auto-router.service.spec.ts
@@ -31,6 +31,7 @@ import { ConfigModule } from '@nestjs/config';
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('AutoRouterService', () => {
     let service: AutoRouterService;
@@ -78,6 +79,7 @@ describe('AutoRouterService', () => {
                 AutoRouterComputeService,
                 AutoRouterTransactionService,
                 ApiConfigService,
+                MXApiServiceProvider,
             ],
             exports: [],
         }).compile();

--- a/src/modules/fees-collector/specs/fees.collector.compute.service.spec.ts
+++ b/src/modules/fees-collector/specs/fees.collector.compute.service.spec.ts
@@ -32,6 +32,7 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { AnalyticsQueryServiceProvider } from 'src/services/analytics/mocks/analytics.query.service.mock';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('FeesCollectorComputeService', () => {
     let module: TestingModule;
@@ -70,6 +71,7 @@ describe('FeesCollectorComputeService', () => {
                 },
                 AnalyticsQueryServiceProvider,
                 ApiConfigService,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/pair/specs/pair.compute.service.spec.ts
+++ b/src/modules/pair/specs/pair.compute.service.spec.ts
@@ -17,6 +17,7 @@ import { WinstonModule } from 'nest-winston';
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('PairService', () => {
     let module: TestingModule;
@@ -42,6 +43,7 @@ describe('PairService', () => {
                 AnalyticsQueryServiceProvider,
                 ContextGetterServiceProvider,
                 ApiConfigService,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/pair/specs/pair.service.spec.ts
+++ b/src/modules/pair/specs/pair.service.spec.ts
@@ -12,6 +12,7 @@ import { WinstonModule } from 'nest-winston';
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('PairService', () => {
     let module: TestingModule;
@@ -34,6 +35,7 @@ describe('PairService', () => {
                 ContextGetterServiceProvider,
                 RouterAbiServiceProvider,
                 ApiConfigService,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/pair/specs/pair.transactions.service.spec.ts
+++ b/src/modules/pair/specs/pair.transactions.service.spec.ts
@@ -19,6 +19,7 @@ import { RouterAbiServiceProvider } from 'src/modules/router/mocks/router.abi.se
 import { WinstonModule } from 'nest-winston';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('TransactionPairService', () => {
     let module: TestingModule;
@@ -46,6 +47,7 @@ describe('TransactionPairService', () => {
                 WrapService,
                 TokenServiceProvider,
                 PairTransactionService,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/proxy/specs/proxy-pair-transactions.service.spec.ts
+++ b/src/modules/proxy/specs/proxy-pair-transactions.service.spec.ts
@@ -25,6 +25,7 @@ import { encodeTransactionData } from 'src/helpers/helpers';
 import { WinstonModule } from 'nest-winston';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('TransactionProxyPairService', () => {
     let module: TestingModule;
@@ -57,6 +58,7 @@ describe('TransactionProxyPairService', () => {
                 },
                 RouterAbiServiceProvider,
                 ContextGetterServiceProvider,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/router/specs/router.transactions.service.spec.ts
+++ b/src/modules/router/specs/router.transactions.service.spec.ts
@@ -22,6 +22,7 @@ import { WinstonModule } from 'nest-winston';
 import { ConfigModule } from '@nestjs/config';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('RouterService', () => {
     let module: TestingModule;
@@ -54,6 +55,7 @@ describe('RouterService', () => {
                 RouterTransactionService,
                 TokenServiceProvider,
                 RouterService,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/staking/specs/staking.transactions.service.spec.ts
+++ b/src/modules/staking/specs/staking.transactions.service.spec.ts
@@ -14,6 +14,7 @@ import { ConfigModule } from '@nestjs/config';
 import { WinstonModule } from 'nest-winston';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('StakingTransactionService', () => {
     let module: TestingModule;
@@ -34,6 +35,7 @@ describe('StakingTransactionService', () => {
                 MXProxyServiceProvider,
                 MXGatewayService,
                 ApiConfigService,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/tokens/specs/token.compute.service.spec.ts
+++ b/src/modules/tokens/specs/token.compute.service.spec.ts
@@ -15,6 +15,7 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { AnalyticsQueryServiceProvider } from 'src/services/analytics/mocks/analytics.query.service.mock';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('TokenComputeService', () => {
     let module: TestingModule;
@@ -40,6 +41,7 @@ describe('TokenComputeService', () => {
                 TokenComputeService,
                 ApiConfigService,
                 AnalyticsQueryServiceProvider,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/user/services/user.metaEsdt.service.ts
+++ b/src/modules/user/services/user.metaEsdt.service.ts
@@ -52,6 +52,7 @@ import { PriceDiscoveryAbiService } from 'src/modules/price-discovery/services/p
 import { FarmAbiFactory } from 'src/modules/farm/farm.abi.factory';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
+import { ContextGetterService } from 'src/services/context/context.getter.service';
 enum NftTokenType {
     FarmToken,
     LockedAssetToken,
@@ -86,6 +87,7 @@ export class UserMetaEsdtService {
         private readonly energyAbi: EnergyAbiService,
         private readonly lockedTokenWrapperAbi: LockedTokenWrapperAbiService,
         private readonly remoteConfigGetterService: RemoteConfigGetterService,
+        private readonly contextGetter: ContextGetterService,
         @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: Logger,
     ) {}
 
@@ -95,7 +97,7 @@ export class UserMetaEsdtService {
     ): Promise<UserLockedAssetToken[]> {
         const lockedMEXTokenID =
             await this.lockedAssetGetter.getLockedTokenID();
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -121,7 +123,7 @@ export class UserMetaEsdtService {
                 this.farmAbi.useAbi(address).farmTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -148,7 +150,7 @@ export class UserMetaEsdtService {
         const lockedLpTokenID = await this.proxyPairAbi.wrappedLpTokenID(
             scAddress.proxyDexAddress.v1,
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -172,7 +174,7 @@ export class UserMetaEsdtService {
         const lockedFarmTokenID = await this.proxyFarmAbi.wrappedFarmTokenID(
             scAddress.proxyDexAddress.v1,
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -197,7 +199,7 @@ export class UserMetaEsdtService {
         const lockedLpTokenID = await this.proxyPairAbi.wrappedLpTokenID(
             scAddress.proxyDexAddress.v2,
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -223,7 +225,7 @@ export class UserMetaEsdtService {
                 await this.proxyFarmAbi.wrappedFarmTokenID(
                     scAddress.proxyDexAddress.v2,
                 );
-            const nfts = await this.apiService.getNftsForUser(
+            const nfts = await this.contextGetter.getNftsForUser(
                 userAddress,
                 pagination.offset,
                 pagination.limit,
@@ -257,7 +259,7 @@ export class UserMetaEsdtService {
                 this.stakingAbi.farmTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -292,7 +294,7 @@ export class UserMetaEsdtService {
                 this.stakingAbi.farmTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -327,7 +329,7 @@ export class UserMetaEsdtService {
                 this.proxyStakeAbi.dualYieldTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -355,7 +357,7 @@ export class UserMetaEsdtService {
                 this.priceDiscoveryAbi.redeemTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -376,7 +378,7 @@ export class UserMetaEsdtService {
                 this.simpleLockAbi.lockedTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -397,7 +399,7 @@ export class UserMetaEsdtService {
                 this.simpleLockAbi.lpProxyTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -420,7 +422,7 @@ export class UserMetaEsdtService {
                 this.simpleLockAbi.farmProxyTokenID(address),
             ),
         );
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -440,7 +442,7 @@ export class UserMetaEsdtService {
         pagination: PaginationArgs,
     ): Promise<UserLockedTokenEnergy[]> {
         const lockedTokenEnergyID = await this.energyAbi.lockedTokenID();
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -460,7 +462,7 @@ export class UserMetaEsdtService {
     ): Promise<UserWrappedLockedToken[]> {
         const lockedTokenEnergyID =
             await this.lockedTokenWrapperAbi.wrappedTokenId();
-        const nfts = await this.apiService.getNftsForUser(
+        const nfts = await this.contextGetter.getNftsForUser(
             userAddress,
             pagination.offset,
             pagination.limit,
@@ -485,7 +487,7 @@ export class UserMetaEsdtService {
         if (nfts) {
             userNFTs = nfts;
         } else {
-            userNFTs = await this.apiService.getNftsForUser(
+            userNFTs = await this.contextGetter.getNftsForUser(
                 userAddress,
                 pagination.offset,
                 pagination.limit,

--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -3,8 +3,6 @@ import { scAddress } from '../../../../config';
 import { EnergyType } from '@multiversx/sdk-exchange';
 import { ClaimProgress } from '../../../../submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { ContractType, OutdatedContract } from '../../models/user.model';
-import { UserMetaEsdtService } from '../user.metaEsdt.service';
-import { PaginationArgs } from '../../../dex.model';
 import { ProxyService } from '../../../proxy/services/proxy.service';
 import { StakingProxyService } from '../../../staking-proxy/services/staking.proxy.service';
 import { FarmVersion } from '../../../farm/models/farm.model';
@@ -19,8 +17,8 @@ import { FarmServiceV2 } from 'src/modules/farm/v2/services/farm.v2.service';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { EnergyAbiService } from 'src/modules/energy/services/energy.abi.service';
-import { ProxyFarmAbiService } from 'src/modules/proxy/services/proxy-farm/proxy.farm.abi.service';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
+import { ContextGetterService } from 'src/services/context/context.getter.service';
 
 @Injectable()
 export class UserEnergyComputeService {
@@ -34,6 +32,7 @@ export class UserEnergyComputeService {
         private readonly energyAbi: EnergyAbiService,
         private readonly proxyService: ProxyService,
         private readonly apiService: MXApiService,
+        private readonly contextGetter: ContextGetterService,
     ) {}
 
     async getUserOutdatedContracts(
@@ -166,11 +165,14 @@ export class UserEnergyComputeService {
     }
 
     async computeActiveFarmsV2ForUser(userAddress: string): Promise<string[]> {
-        const userNfts = await this.apiService.getNftsForUser(
+        const userNftsCount = await this.contextGetter.getNftsCountForUser(
+            userAddress,
+        );
+
+        const userNfts = await this.contextGetter.getNftsForUser(
             userAddress,
             0,
-            100,
-            'MetaESDT',
+            userNftsCount,
         );
         const stakingProxies = await this.stakeProxyService.getStakingProxies();
         const filterAddresses = [

--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { scAddress } from '../../../../config';
+import { constantsConfig, scAddress } from '../../../../config';
 import { EnergyType } from '@multiversx/sdk-exchange';
 import { ClaimProgress } from '../../../../submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { ContractType, OutdatedContract } from '../../models/user.model';
@@ -165,14 +165,10 @@ export class UserEnergyComputeService {
     }
 
     async computeActiveFarmsV2ForUser(userAddress: string): Promise<string[]> {
-        const userNftsCount = await this.contextGetter.getNftsCountForUser(
-            userAddress,
-        );
-
         const userNfts = await this.contextGetter.getNftsForUser(
             userAddress,
             0,
-            userNftsCount,
+            constantsConfig.MAX_USER_NFTS,
         );
         const stakingProxies = await this.stakeProxyService.getStakingProxies();
         const filterAddresses = [

--- a/src/services/context/context.getter.service.ts
+++ b/src/services/context/context.getter.service.ts
@@ -54,23 +54,6 @@ export class ContextGetterService extends GenericGetterService {
         );
     }
 
-    async getNftsCountForUser(address: string): Promise<number> {
-        const cacheKey = this.getCacheKey('nftsCountForUser', address);
-        const cachedData = await this.cachingService.getRemote<number>(
-            cacheKey,
-        );
-        if (cachedData) {
-            return cachedData;
-        }
-        const count = await this.apiService.getNftsCountForUser(address);
-        await this.cachingService.setRemote(
-            cacheKey,
-            count,
-            Constants.oneSecond() * 6,
-        );
-        return count;
-    }
-
     async getNftsForUser(
         address: string,
         from = 0,

--- a/src/services/context/mocks/context.getter.service.mock.ts
+++ b/src/services/context/mocks/context.getter.service.mock.ts
@@ -1,12 +1,32 @@
+import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { ContextGetterService } from '../context.getter.service';
+import { Injectable } from '@nestjs/common';
+import { NftToken } from 'src/modules/tokens/models/nftToken.model';
 
+@Injectable()
 export class ContextGetterServiceMock {
+    constructor(private readonly mxApi: MXApiService) {}
+
     async getCurrentEpoch(): Promise<number> {
         return 1;
     }
 
     async getShardCurrentBlockNonce(shardID: number): Promise<number> {
         return 111;
+    }
+
+    async getNftsCountForUser(address: string): Promise<number> {
+        return (await this.getNftsForUser(address)).length;
+    }
+
+    async getNftsForUser(
+        address: string,
+        from = 0,
+        size = 100,
+        type = 'MetaESDT',
+        collections?: string[],
+    ): Promise<NftToken[]> {
+        return await this.mxApi.getNftsForUser(address);
     }
 }
 

--- a/src/services/context/mocks/context.getter.service.mock.ts
+++ b/src/services/context/mocks/context.getter.service.mock.ts
@@ -15,10 +15,6 @@ export class ContextGetterServiceMock {
         return 111;
     }
 
-    async getNftsCountForUser(address: string): Promise<number> {
-        return (await this.getNftsForUser(address)).length;
-    }
-
     async getNftsForUser(
         address: string,
         from = 0,

--- a/src/services/crons/metabonding.cache.warmer.service.ts
+++ b/src/services/crons/metabonding.cache.warmer.service.ts
@@ -15,6 +15,10 @@ export class MetabondingCacheWarmerService {
 
     @Cron(CronExpression.EVERY_HOUR)
     async cacheMetabonding(): Promise<void> {
+        if (process.env.NODE_ENV !== 'mainnet') {
+            return;
+        }
+
         const lockedAssetTokenID =
             await this.metabondingAbi.getLockedAssetTokenIDRaw();
         const invalidatedKeys = await Promise.all([
@@ -25,6 +29,10 @@ export class MetabondingCacheWarmerService {
 
     @Cron(CronExpression.EVERY_30_SECONDS)
     async cacheMetabondingInfo(): Promise<void> {
+        if (process.env.NODE_ENV !== 'mainnet') {
+            return;
+        }
+
         const lockedAssetsSupply =
             await this.metabondingAbi.getTotalLockedAssetSupplyRaw();
         const invalidatedKeys = await Promise.all([

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -9,11 +9,11 @@ import { delay } from 'src/helpers/helpers';
 import { AnalyticsQueryService } from '../analytics/services/analytics.query.service';
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { Logger } from 'winston';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 import BigNumber from 'bignumber.js';
 import { constantsConfig } from 'src/config';
 import { Lock } from '@multiversx/sdk-nestjs-common';
+import { Logger } from 'winston';
 
 @Injectable()
 export class PairCacheWarmerService {
@@ -31,7 +31,9 @@ export class PairCacheWarmerService {
     @Cron(CronExpression.EVERY_MINUTE)
     @Lock({ name: 'cachePairs', verbose: true })
     async cachePairs(): Promise<void> {
-        this.logger.info('Start refresh cached pairs');
+        this.logger.info('Start refresh cached pairs', {
+            context: 'CachePairs',
+        });
         const pairsMetadata = await this.routerAbi.pairsMetadata();
         for (const pairMetadata of pairsMetadata) {
             const lpTokenID = await this.pairAbi.getLpTokenIDRaw(
@@ -59,7 +61,9 @@ export class PairCacheWarmerService {
 
             await this.deleteCacheKeys(cachedKeys);
         }
-        this.logger.info('Finished refresh cached pairs');
+        this.logger.info('Finished refresh cached pairs', {
+            context: 'CachePairs',
+        });
     }
 
     @Cron(CronExpression.EVERY_5_MINUTES)

--- a/src/services/multiversx-communication/mx.api.service.ts
+++ b/src/services/multiversx-communication/mx.api.service.ts
@@ -256,23 +256,14 @@ export class MXApiService {
 
     async getNftsForUser(
         address: string,
-        from = 0,
-        size = 100,
         type = 'MetaESDT',
-        collections?: string[],
     ): Promise<NftToken[]> {
         const nfts: NftToken[] = await this.genericGetExecutor.execute({
             methodName: this.getNftsForUser.name,
             resourceUrl: `accounts/${address}/nfts?type=${type}&size=${constantsConfig.MAX_USER_NFTS}&fields=identifier,collection,ticker,decimals,timestamp,attributes,nonce,type,name,creator,royalties,uris,url,tags,balance,assets`,
         });
 
-        const userNfts = collections
-            ? nfts
-                  .filter((nft) => collections.includes(nft.collection))
-                  .slice(from, size)
-            : nfts.slice(from, size);
-
-        for (const nft of userNfts) {
+        for (const nft of nfts) {
             if (!isNftCollectionValid(nft)) {
                 const gatewayCollection = await this.mxProxy
                     .getService()
@@ -281,7 +272,7 @@ export class MXApiService {
             }
         }
 
-        return userNfts;
+        return nfts;
     }
 
     async getNftByTokenIdentifier(

--- a/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
+++ b/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
@@ -22,6 +22,7 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { AnalyticsQueryServiceProvider } from 'src/services/analytics/mocks/analytics.query.service.mock';
+import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 
 describe('WeeklyRewardsSplittingComputeService', () => {
     let module: TestingModule;
@@ -50,6 +51,7 @@ describe('WeeklyRewardsSplittingComputeService', () => {
                 ContextGetterServiceProvider,
                 AnalyticsQueryServiceProvider,
                 ApiConfigService,
+                MXApiServiceProvider,
             ],
         }).compile();
     });

--- a/src/utils/metrics.collector.ts
+++ b/src/utils/metrics.collector.ts
@@ -121,6 +121,21 @@ export class MetricsCollector {
         MetricsCollector.baseMetrics.setRedisDuration(action, duration);
     }
 
+    static setApiCall(
+        endpoint: string,
+        origin: string,
+        status: number,
+        duration: number,
+    ) {
+        MetricsCollector.ensureIsInitialized();
+        MetricsCollector.baseMetrics.setApiCall(
+            endpoint,
+            origin,
+            status,
+            duration,
+        );
+    }
+
     static setExternalCall(system: string, func: string, duration: number) {
         MetricsCollector.ensureIsInitialized();
         MetricsCollector.baseMetrics.setExternalCall(system, duration);


### PR DESCRIPTION
## Reasoning
- request user nfts from multiple places in the same block would not change the actual return from API
  
## Proposed Changes
- add a block time caching for user nfts; multiple requests to the same resource should be retrieved from cache

## How to test
- N/A