### PR TITLE
[SERVICES-2130] staking rewards remaining days

### DIFF
--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -34,6 +34,8 @@ export class StakingModel {
     @Field(() => Int)
     lastRewardBlockNonce: number;
     @Field()
+    rewardsRemainingDays: number;
+    @Field()
     divisionSafetyConstant: string;
     @Field()
     produceRewardsEnabled: boolean;

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -214,6 +214,26 @@ export class StakingComputeService {
                   .toFixed();
     }
 
+    async computeRewardsRemainingDays(stakeAddress: string): Promise<number> {
+        const [perBlockRewardAmount, accumulatedRewards, rewardsCapacity] =
+            await Promise.all([
+                this.stakingAbi.perBlockRewardsAmount(stakeAddress),
+                this.stakingAbi.accumulatedRewards(stakeAddress),
+                this.stakingAbi.rewardCapacity(stakeAddress),
+            ]);
+
+        // 10 blocks per minute * 60 minutes per hour * 24 hours per day
+        const blocksInDay = 10 * 60 * 24;
+
+        return parseFloat(
+            new BigNumber(rewardsCapacity)
+                .minus(accumulatedRewards)
+                .dividedBy(perBlockRewardAmount)
+                .dividedBy(blocksInDay)
+                .toFixed(2),
+        );
+    }
+
     async computeOptimalCompoundFrequency(
         stakeAddress: string,
         positionAmount: string,

--- a/src/modules/staking/specs/staking.compute.service.spec.ts
+++ b/src/modules/staking/specs/staking.compute.service.spec.ts
@@ -197,4 +197,20 @@ describe('StakingComputeService', () => {
             }),
         );
     });
+
+    it('should compute rewards remaining days', async () => {
+        const service = module.get<StakingComputeService>(
+            StakingComputeService,
+        );
+
+        const stakingAbi = module.get<StakingAbiService>(StakingAbiService);
+        jest.spyOn(stakingAbi, 'accumulatedRewards').mockResolvedValue('100');
+        jest.spyOn(stakingAbi, 'rewardCapacity').mockResolvedValue('14500');
+        jest.spyOn(stakingAbi, 'perBlockRewardsAmount').mockResolvedValue('1');
+
+        const rewardsRemainingDays = await service.computeRewardsRemainingDays(
+            Address.Zero().bech32(),
+        );
+        expect(rewardsRemainingDays).toEqual(1);
+    });
 });

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -1,12 +1,5 @@
 import { UseGuards } from '@nestjs/common';
-import {
-    Args,
-    Int,
-    Parent,
-    Query,
-    ResolveField,
-    Resolver,
-} from '@nestjs/graphql';
+import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { TransactionModel } from 'src/models/transaction.model';
@@ -100,6 +93,11 @@ export class StakingResolver {
     @ResolveField()
     async lastRewardBlockNonce(@Parent() parent: StakingModel) {
         return this.stakingAbi.lastRewardBlockNonce(parent.address);
+    }
+
+    @ResolveField()
+    async rewardsRemainingDays(@Parent() parent: StakingModel) {
+        return this.stakingCompute.computeRewardsRemainingDays(parent.address);
     }
 
     @ResolveField()


### PR DESCRIPTION
## Reasoning
- compute the remaining days to distribute all rewards
  
## Proposed Changes
- added a new field for staking model: `rewardsRemainingDays`
- added method to compute remaining days to distribute all rewards

## How to test
```
query Staking {
	stakingFarms {
		address
		rewardsRemainingDays
	}
}
```
- query should return the remaining days to distribute all rewards