### PR TITLE
[MEX-418] fix handler for claim multi rewards event on staking contracts

### DIFF
--- a/src/modules/staking/services/staking.setter.service.ts
+++ b/src/modules/staking/services/staking.setter.service.ts
@@ -4,6 +4,7 @@ import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
+import { EsdtTokenPayment } from '@multiversx/sdk-exchange';
 
 @Injectable()
 export class StakingSetterService extends GenericSetterService {
@@ -191,6 +192,25 @@ export class StakingSetterService extends GenericSetterService {
             value,
             CacheTtlInfo.ContractInfo.remoteTtl,
             CacheTtlInfo.ContractInfo.localTtl,
+        );
+    }
+
+    async userRewardsForWeek(
+        scAddress: string,
+        userAddress: string,
+        week: number,
+        value: EsdtTokenPayment[],
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey(
+                'userRewardsForWeek',
+                scAddress,
+                userAddress,
+                week,
+            ),
+            value,
+            CacheTtlInfo.ContractBalance.remoteTtl,
+            CacheTtlInfo.ContractBalance.localTtl,
         );
     }
 }


### PR DESCRIPTION
## Reasoning
- staking contracts with boosted rewards now creates the same `claim_multi_event`
  
## Proposed Changes
- add check in `getSetter` from `WeeklyRewardsSplittingHandlerService` for staking contract and return specific setter service

## How to test
- N/A

