### PR TITLE
[MEX-437] no exit amount

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -216,8 +216,8 @@
             },
             "v2": {
                 "enterFarm": {
-                    "default": 15000000,
-                    "withTokenMerge": 16500000
+                    "default": 16500000,
+                    "withTokenMerge": 18000000
                 },
                 "unlockedRewards": {
                     "exitFarm": {

--- a/src/modules/farm/models/farm.args.ts
+++ b/src/modules/farm/models/farm.args.ts
@@ -58,7 +58,12 @@ export class SftFarmInteractionArgs {
 export class ExitFarmArgs extends SftFarmInteractionArgs {
     @Field(() => Boolean, { nullable: true })
     withPenalty = false;
-    @Field({ nullable: true })
+    @Field({
+        nullable: true,
+        deprecationReason:
+            'Exit farm no longer require this value;' +
+            'field is deprecated and will be removed on next release;',
+    })
     exitAmount?: string;
 }
 

--- a/src/modules/farm/v2/services/farm.v2.transaction.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.transaction.service.ts
@@ -1,4 +1,4 @@
-import { Address, BigUIntValue, TokenTransfer } from '@multiversx/sdk-core';
+import { Address, TokenTransfer } from '@multiversx/sdk-core';
 import { Injectable } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { mxConfig, gasConfig } from 'src/config';
@@ -86,7 +86,7 @@ export class FarmTransactionServiceV2 extends TransactionsFarmService {
         );
 
         return contract.methodsExplicit
-            .exitFarm([new BigUIntValue(new BigNumber(args.exitAmount))])
+            .exitFarm()
             .withSingleESDTNFTTransfer(
                 TokenTransfer.metaEsdtFromBigInteger(
                     args.farmTokenID,


### PR DESCRIPTION
## Reasoning
- new farm v2 doesn't require the exit amount argument for `exitFarm` endpoint
  
## Proposed Changes
- removed exit amount argument from `exitFarm` transaction generation

## How to test
- N/A

