### PR TITLE
[MEX-437] remove exit amount from staking proxy unstake farm tokens

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -500,7 +500,7 @@
             "vote": 50000000
         },
         "positionCreator": {
-            "singleToken": 70000000,
+            "singleToken": 85000000,
             "energyPosition": 20000000
         },
         "composableTasks": {

--- a/src/modules/staking-proxy/services/staking.proxy.transactions.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.transactions.service.ts
@@ -7,11 +7,9 @@ import { ruleOfThree } from 'src/helpers/helpers';
 import { InputTokenModel } from 'src/models/inputToken.model';
 import { TransactionModel } from 'src/models/transaction.model';
 import { FarmFactoryService } from 'src/modules/farm/farm.factory';
-import { FarmVersion } from 'src/modules/farm/models/farm.model';
 import { PairService } from 'src/modules/pair/services/pair.service';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { MXProxyService } from 'src/services/multiversx-communication/mx.proxy.service';
-import { farmVersion } from 'src/utils/farm.utils';
 import { generateLogMessage } from 'src/utils/generate-log-message';
 import { tokenIdentifier } from 'src/utils/token.converters';
 import { Logger } from 'winston';
@@ -180,10 +178,6 @@ export class StakingProxyTransactionService {
             new BigUIntValue(amount0Min),
             new BigUIntValue(amount1Min),
         ];
-
-        if (farmVersion(farmAddress) === FarmVersion.V2) {
-            endpointArgs.push(new BigUIntValue(liquidityPositionAmount));
-        }
 
         return contract.methodsExplicit
             .unstakeFarmTokens(endpointArgs)


### PR DESCRIPTION
## Reasoning
- staking proxy no longer require exit amount on unstake farm tokens transction
  
## Proposed Changes
- removed exit amount from staking proxy unstake farm tokens

## How to test
- N/A
