### PR TITLE
[MEX-443]: use specific gas limit

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -508,10 +508,11 @@
             },
             "dualTokens": {
                 "farmPosition": 30000000,
+                "farmPositionProxy": 50000000,
                 "dualFarmPosition": 67000000,
                 "exitFarm": 50000000
             },
-            "energyPosition": 20000000
+            "energyPosition": 30000000
         },
         "composableTasks": {
             "default": 30000000

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -509,6 +509,10 @@ export class PositionCreatorTransactionService {
                   new BigUIntValue(amount1Min),
               ];
 
+        const gasLimit = isLockedToken
+            ? gasConfig.positionCreator.dualTokens.farmPositionProxy
+            : gasConfig.positionCreator.dualTokens.farmPosition;
+
         const contract = isLockedToken
             ? await this.mxProxy.getLockedTokenPositionCreatorContract()
             : await this.mxProxy.getPostitionCreatorContract();
@@ -536,7 +540,7 @@ export class PositionCreatorTransactionService {
                     ),
             ])
             .withSender(Address.fromBech32(sender))
-            .withGasLimit(gasConfig.positionCreator.dualTokens.farmPosition)
+            .withGasLimit(gasLimit)
             .withChainID(mxConfig.chainID)
             .buildTransaction()
             .toPlainObject();

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -1524,7 +1524,8 @@ describe('PositionCreatorTransaction', () => {
                     senderUsername: undefined,
                     receiverUsername: undefined,
                     gasPrice: 1000000000,
-                    gasLimit: gasConfig.positionCreator.dualTokens.farmPosition,
+                    gasLimit:
+                        gasConfig.positionCreator.dualTokens.farmPositionProxy,
                     data: encodeTransactionData(
                         'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@02@WEGLD-123456@@100000000000000000000@ELKMEX-123456@01@100000000000000000000@createFarmPosFromTwoTokens@99000000000000000000@99000000000000000000',
                     ),
@@ -1576,7 +1577,8 @@ describe('PositionCreatorTransaction', () => {
                     senderUsername: undefined,
                     receiverUsername: undefined,
                     gasPrice: 1000000000,
-                    gasLimit: gasConfig.positionCreator.dualTokens.farmPosition,
+                    gasLimit:
+                        gasConfig.positionCreator.dualTokens.farmPositionProxy,
                     data: encodeTransactionData(
                         'MultiESDTNFTTransfer@00000000000000000500bc458e2cd68bb69665812137dcdd988d9f69901e7ceb@03@WEGLD-123456@@100000000000000000000@ELKMEX-123456@01@100000000000000000000@LKFARM-123456@01@100000000000000000000@createFarmPosFromTwoTokens@99000000000000000000@99000000000000000000',
                     ),


### PR DESCRIPTION
## Reasoning
- use specific gas limit for position creator on farm position with dual tokens and locked tokens
  
## Proposed Changes
- added new gas config for farmPositionProxy

## How to test
- N/A

