### PR TITLE
[SERVICES-2155] context tracker

### DIFF
--- a/src/helpers/api.config.service.ts
+++ b/src/helpers/api.config.service.ts
@@ -93,6 +93,16 @@ export class ApiConfigService {
         return tracerFlag === 'true';
     }
 
+    isDeephistoryActive(): boolean {
+        const deepHistoryFlag = this.configService.get<string>(
+            'ENABLE_DEEP_HISTORY',
+        );
+        if (!deepHistoryFlag) {
+            return false;
+        }
+        return deepHistoryFlag === 'true';
+    }
+
     getRedisUrl(): string {
         const redisUrl = this.configService.get<string>('REDIS_URL');
         if (!redisUrl) {

--- a/src/helpers/proxy.network.provider.profiler.ts
+++ b/src/helpers/proxy.network.provider.profiler.ts
@@ -6,8 +6,18 @@ import { PerformanceProfiler } from '../utils/performance.profiler';
 import { MetricsCollector } from '../utils/metrics.collector';
 import { IContractQuery } from '@multiversx/sdk-network-providers/out/interface';
 import { ContextTracker } from '@multiversx/sdk-nestjs-common';
+import { AxiosRequestConfig } from 'axios';
+import { ApiConfigService } from './api.config.service';
 
 export class ProxyNetworkProviderProfiler extends ProxyNetworkProvider {
+    constructor(
+        private readonly apiConfigService: ApiConfigService,
+        url: string,
+        config?: AxiosRequestConfig,
+    ) {
+        super(url, config);
+    }
+
     async queryContract(query: IContractQuery): Promise<ContractQueryResponse> {
         const profiler = new PerformanceProfiler();
 
@@ -26,7 +36,11 @@ export class ProxyNetworkProviderProfiler extends ProxyNetworkProvider {
 
     async doPostGeneric(resourceUrl: string, payload: any): Promise<any> {
         const context = ContextTracker.get();
-        if (context && context.deepHistoryTimestamp) {
+        if (
+            this.apiConfigService.isDeephistoryActive() &&
+            context &&
+            context.deepHistoryTimestamp
+        ) {
             resourceUrl = `${resourceUrl}?timestamp=${context.deepHistoryTimestamp}`;
         }
         const response = await super.doPostGeneric(resourceUrl, payload);

--- a/src/helpers/proxy.network.provider.profiler.ts
+++ b/src/helpers/proxy.network.provider.profiler.ts
@@ -5,6 +5,7 @@ import {
 import { PerformanceProfiler } from '../utils/performance.profiler';
 import { MetricsCollector } from '../utils/metrics.collector';
 import { IContractQuery } from '@multiversx/sdk-network-providers/out/interface';
+import { ContextTracker } from '@multiversx/sdk-nestjs-common';
 
 export class ProxyNetworkProviderProfiler extends ProxyNetworkProvider {
     async queryContract(query: IContractQuery): Promise<ContractQueryResponse> {
@@ -21,5 +22,14 @@ export class ProxyNetworkProviderProfiler extends ProxyNetworkProvider {
         );
 
         return result;
+    }
+
+    async doPostGeneric(resourceUrl: string, payload: any): Promise<any> {
+        const context = ContextTracker.get();
+        if (context && context.deepHistoryTimestamp) {
+            resourceUrl = `${resourceUrl}?timestamp=${context.deepHistoryTimestamp}`;
+        }
+        const response = await super.doPostGeneric(resourceUrl, payload);
+        return response;
     }
 }

--- a/src/helpers/proxy.network.provider.profiler.ts
+++ b/src/helpers/proxy.network.provider.profiler.ts
@@ -41,7 +41,9 @@ export class ProxyNetworkProviderProfiler extends ProxyNetworkProvider {
             context &&
             context.deepHistoryTimestamp
         ) {
-            resourceUrl = `${resourceUrl}?timestamp=${context.deepHistoryTimestamp}`;
+            resourceUrl = resourceUrl.includes('?')
+                ? `${resourceUrl}&timestamp=${context.deepHistoryTimestamp}`
+                : `${resourceUrl}?timestamp=${context.deepHistoryTimestamp}`;
         }
         const response = await super.doPostGeneric(resourceUrl, payload);
         return response;

--- a/src/services/multiversx-communication/mx.api.service.ts
+++ b/src/services/multiversx-communication/mx.api.service.ts
@@ -84,7 +84,11 @@ export class MXApiService {
         const profiler = new PerformanceProfiler(`${name} ${resourceUrl}`);
         try {
             const context = ContextTracker.get();
-            if (context && context.deepHistoryTimestamp) {
+            if (
+                this.apiConfigService.isDeephistoryActive() &&
+                context &&
+                context.deepHistoryTimestamp
+            ) {
                 resourceUrl = `${resourceUrl}&timestamp=${context.deepHistoryTimestamp}`;
             }
 

--- a/src/services/multiversx-communication/mx.api.service.ts
+++ b/src/services/multiversx-communication/mx.api.service.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/utils/token.type.compare';
 import { PendingExecutor } from 'src/utils/pending.executor';
 import { MXProxyService } from './mx.proxy.service';
+import { ContextTracker } from '@multiversx/sdk-nestjs-common';
 
 type GenericGetArgs = {
     methodName: string;
@@ -82,6 +83,11 @@ export class MXApiService {
     ): Promise<T> {
         const profiler = new PerformanceProfiler(`${name} ${resourceUrl}`);
         try {
+            const context = ContextTracker.get();
+            if (context && context.deepHistoryTimestamp) {
+                resourceUrl = `${resourceUrl}&timestamp=${context.deepHistoryTimestamp}`;
+            }
+
             const response = await this.getService().doGetGeneric(resourceUrl);
             profiler.stop();
             MetricsCollector.setApiCall(

--- a/src/services/multiversx-communication/mx.api.service.ts
+++ b/src/services/multiversx-communication/mx.api.service.ts
@@ -89,7 +89,9 @@ export class MXApiService {
                 context &&
                 context.deepHistoryTimestamp
             ) {
-                resourceUrl = `${resourceUrl}&timestamp=${context.deepHistoryTimestamp}`;
+                resourceUrl = resourceUrl.includes('?')
+                    ? `${resourceUrl}&timestamp=${context.deepHistoryTimestamp}`
+                    : `${resourceUrl}?timestamp=${context.deepHistoryTimestamp}`;
             }
 
             const response = await this.getService().doGetGeneric(resourceUrl);

--- a/src/services/multiversx-communication/mx.proxy.service.ts
+++ b/src/services/multiversx-communication/mx.proxy.service.ts
@@ -31,6 +31,7 @@ export class MXProxyService {
         const httpsAgent = new HttpsAgent(keepAliveOptions);
 
         this.proxy = new ProxyNetworkProviderProfiler(
+            this.apiConfigService,
             this.apiConfigService.getApiUrl(),
             {
                 timeout: mxConfig.proxyTimeout,

--- a/src/utils/logging.interceptor.ts
+++ b/src/utils/logging.interceptor.ts
@@ -24,12 +24,12 @@ export class LoggingInterceptor implements NestInterceptor {
             const { req } = gqlContext.getContext();
 
             let origin = 'Unknown';
-            let timesamp: number = undefined;
+            let timestamp: number = undefined;
             if (req !== undefined) {
                 origin = req?.headers?.['origin'] ?? 'Unknown';
-                timesamp = req?.headers?.['timestamp'];
+                timestamp = req?.headers?.['timestamp'];
                 ContextTracker.assign({
-                    deepHistoryTimestamp: timesamp,
+                    deepHistoryTimestamp: timestamp,
                 });
             }
 

--- a/src/utils/logging.interceptor.ts
+++ b/src/utils/logging.interceptor.ts
@@ -10,6 +10,7 @@ import { tap } from 'rxjs/operators';
 import { CpuProfiler } from '@multiversx/sdk-nestjs-monitoring';
 import { MetricsCollector } from './metrics.collector';
 import { PerformanceProfiler } from './performance.profiler';
+import { ContextTracker } from '@multiversx/sdk-nestjs-common';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -23,8 +24,13 @@ export class LoggingInterceptor implements NestInterceptor {
             const { req } = gqlContext.getContext();
 
             let origin = 'Unknown';
+            let timesamp: number = undefined;
             if (req !== undefined) {
                 origin = req?.headers?.['origin'] ?? 'Unknown';
+                timesamp = req?.headers?.['timestamp'];
+                ContextTracker.assign({
+                    deepHistoryTimestamp: timesamp,
+                });
             }
 
             const profiler = new PerformanceProfiler();


### PR DESCRIPTION
## Reasoning
- use timestamp to query data from deep history
  
## Proposed Changes
- added context tracker from nestjs-sdk
- use context tracker to propagate timestamp across services
- query data with timestamp

## How to test
- any query with `timestamp` in request headers should return data from the past
