### PR TITLE
[MEX-376] accept array of addresses for migrate transactions

### DIFF
--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -378,13 +378,17 @@ export class StakingResolver {
     @UseGuards(JwtOrNativeAuthGuard)
     @Query(() => [TransactionModel])
     async migrateTotalStakingPosition(
-        @Args('stakeAddress') stakeAddress: string,
+        @Args('stakeAddresses', { type: () => [String] })
+        stakeAddresses: string[],
         @AuthUser() user: UserAuthResult,
     ): Promise<TransactionModel[]> {
-        return this.stakingTransactionService.migrateTotalStakingPosition(
-            stakeAddress,
-            user.address,
+        const promises = stakeAddresses.map((stakeAddress) =>
+            this.stakingTransactionService.migrateTotalStakingPosition(
+                stakeAddress,
+                user.address,
+            ),
         );
+        return (await Promise.all(promises)).flat();
     }
 
     @UseGuards(JwtOrNativeAdminGuard)


### PR DESCRIPTION
## Reasoning
- easier handling from client side implementation to pass an array of addresses
  
## Proposed Changes
- update migrate total farm position endpoints to accept an array of sc addresses to return the migration transactions

## How to test
- N/A
