### PR TITLE
[SERVICES-2204] cache first timestamp for analytics series

### DIFF
--- a/src/services/analytics/timescaledb/timescaledb.module.ts
+++ b/src/services/analytics/timescaledb/timescaledb.module.ts
@@ -13,10 +13,12 @@ import {
     TokenBurnedWeekly,
     XExchangeAnalyticsEntity,
 } from './entities/timescaledb.entities';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 
 @Module({
     imports: [
         CommonAppModule,
+        DynamicModuleUtils.getCacheModule(),
         TypeOrmModule.forRootAsync({
             imports: [CommonAppModule],
             useFactory: (apiConfig: ApiConfigService) => ({


### PR DESCRIPTION
## Reasoning
- too many queries to get the first timestamp for same series
  
## Proposed Changes
- cache the first available timestamp for a series to be used for time bucket queries on daily aggregates

## How to test
- N/A
