### PR TITLE
[config] increase gas limit for swap enable

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -99,7 +99,7 @@
             "issueToken": 270000000,
             "setLocalRoles": 270000000,
             "multiPairSwapMultiplier": 110000000,
-            "swapEnableByUser": 200000000,
+            "swapEnableByUser": 250000000,
             "admin": {
                 "setState": 200000000,
                 "setFee": 200000000,


### PR DESCRIPTION
## Reasoning
- not enough gas for enable swaps transaction
  
## Proposed Changes
- increase gas limit for enable swaps

## How to test
- N/A
