### PR TITLE
[MEX-414] composable tasks with specific swap endpoint

### DIFF
--- a/src/abis/composable-tasks.abi.json
+++ b/src/abis/composable-tasks.abi.json
@@ -1,11 +1,11 @@
 {
     "buildInfo": {
         "rustc": {
-            "version": "1.71.0-nightly",
-            "commitHash": "a2b1646c597329d0a25efa3889b66650f65de1de",
-            "commitDate": "2023-05-25",
+            "version": "1.76.0-nightly",
+            "commitHash": "d86d65bbc19b928387f68427fcc3a0da498d8a19",
+            "commitDate": "2023-12-10",
             "channel": "Nightly",
-            "short": "rustc 1.71.0-nightly (a2b1646c5 2023-05-25)"
+            "short": "rustc 1.76.0-nightly (d86d65bbc 2023-12-10)"
         },
         "contractCrate": {
             "name": "composable-tasks",
@@ -13,7 +13,7 @@
         },
         "framework": {
             "name": "multiversx-sc",
-            "version": "0.44.0"
+            "version": "0.46.1"
         }
     },
     "name": "ComposableTasksContract",
@@ -23,6 +23,12 @@
     },
     "endpoints": [
         {
+            "name": "upgrade",
+            "mutability": "mutable",
+            "inputs": [],
+            "outputs": []
+        },
+        {
             "name": "composeTasks",
             "mutability": "mutable",
             "payableInTokens": [
@@ -30,7 +36,7 @@
             ],
             "inputs": [
                 {
-                    "name": "expected_token_out",
+                    "name": "min_expected_token_out",
                     "type": "EgldOrEsdtTokenPayment"
                 },
                 {
@@ -54,7 +60,7 @@
             "outputs": []
         },
         {
-            "name": "setrouterAddr",
+            "name": "setRouterAddr",
             "onlyOwner": true,
             "mutability": "mutable",
             "inputs": [
@@ -66,9 +72,8 @@
             "outputs": []
         },
         {
-            "name": "setPairAddrForTokens",
-            "onlyOwner": true,
-            "mutability": "mutable",
+            "name": "getPair",
+            "mutability": "readonly",
             "inputs": [
                 {
                     "name": "first_token_id",
@@ -77,16 +82,15 @@
                 {
                     "name": "second_token_id",
                     "type": "TokenIdentifier"
-                },
-                {
-                    "name": "new_addr",
-                    "type": "Address"
                 }
             ],
-            "outputs": []
+            "outputs": [
+                {
+                    "type": "Address"
+                }
+            ]
         }
     ],
-    "events": [],
     "esdtAttributes": [],
     "hasCallback": false,
     "types": {

--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -469,16 +469,19 @@ export class AutoRouterService {
                 return [transaction];
             }
 
-            return await this.pairTransactionService.swapTokensFixedOutput(
-                sender,
-                {
-                    pairAddress: parent.pairs[0].address,
-                    tokenInID: parent.tokenInID,
-                    tokenOutID: parent.tokenOutID,
-                    amountIn: parent.amountIn,
-                    amountOut: parent.amountOut,
-                },
-            );
+            const transaction =
+                await this.pairTransactionService.swapTokensFixedOutput(
+                    sender,
+                    {
+                        pairAddress: parent.pairs[0].address,
+                        tokenInID: parent.tokenInID,
+                        tokenOutID: parent.tokenOutID,
+                        amountIn: parent.amountIn,
+                        amountOut: parent.amountOut,
+                    },
+                );
+
+            return [transaction];
         }
 
         if (

--- a/src/modules/auto-router/specs/auto-router.service.spec.ts
+++ b/src/modules/auto-router/specs/auto-router.service.spec.ts
@@ -281,7 +281,7 @@ describe('AutoRouterService', () => {
                 senderUsername: undefined,
                 gasPrice: 1000000000,
                 gasLimit: gasConfig.composableTasks.default,
-                data: 'Y29tcG9zZVRhc2tzQDAwMDAwMDBiNTU1MzQ0NDMyZDMxMzIzMzM0MzUzNjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNzExNzJhY2UwMjZiMGM0QEBAMDJAMDAwMDAwMGI1NTUzNDQ0MzJkMzEzMjMzMzQzNTM2MDAwMDAwMDcxMTcyYWNlMDI2YjBjNA==',
+                data: 'Y29tcG9zZVRhc2tzQDAwMDAwMDBiNTU1MzQ0NDMyZDMxMzIzMzM0MzUzNjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNzExNzJhY2UwMjZiMGM0QEBAMDJAMDAwMDAwMTQ3Mzc3NjE3MDU0NmY2YjY1NmU3MzQ2Njk3ODY1NjQ0OTZlNzA3NTc0MDAwMDAwMGI1NTUzNDQ0MzJkMzEzMjMzMzQzNTM2MDAwMDAwMDcxMTcyYWNlMDI2YjBjNA==',
                 chainID: 'T',
                 version: 1,
                 options: undefined,

--- a/src/modules/composable-tasks/services/composable.tasks.transaction.ts
+++ b/src/modules/composable-tasks/services/composable.tasks.transaction.ts
@@ -83,10 +83,11 @@ export class ComposableTasksTransactionService {
         return interaction.buildTransaction().toPlainObject();
     }
 
-    async wrapEgldAndSwapFixedInputTransaction(
+    async wrapEgldAndSwapTransaction(
         value: string,
         tokenOutID: string,
         tokenOutAmountMin: string,
+        swapEndpoint: string,
     ): Promise<TransactionModel> {
         const wrapTask: ComposableTask = {
             type: ComposableTaskType.WRAP_EGLD,
@@ -96,6 +97,7 @@ export class ComposableTasksTransactionService {
         const swapTask: ComposableTask = {
             type: ComposableTaskType.SWAP,
             arguments: [
+                new BytesValue(Buffer.from(swapEndpoint, 'utf-8')),
                 new BytesValue(Buffer.from(tokenOutID, 'utf-8')),
                 new BytesValue(
                     Buffer.from(
@@ -120,15 +122,17 @@ export class ComposableTasksTransactionService {
         );
     }
 
-    async swapFixedInputAndUnwrapEgldTransaction(
+    async swapAndUnwrapEgldTransaction(
         payment: EsdtTokenPayment,
         minimumValue: string,
+        swapEndpoint: string,
     ): Promise<TransactionModel> {
         const wrappedEgldTokenID = await this.wrapAbi.wrappedEgldTokenID();
 
         const swapTask: ComposableTask = {
             type: ComposableTaskType.SWAP,
             arguments: [
+                new BytesValue(Buffer.from(swapEndpoint, 'utf-8')),
                 new BytesValue(Buffer.from(wrappedEgldTokenID, 'utf-8')),
                 new BytesValue(
                     Buffer.from(

--- a/src/modules/composable-tasks/specs/composable.tasks.transaction.spec.ts
+++ b/src/modules/composable-tasks/specs/composable.tasks.transaction.spec.ts
@@ -11,6 +11,7 @@ import { EgldOrEsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
 import { ComposableTaskType } from '../models/composable.tasks.model';
 import { Address } from '@multiversx/sdk-core/out';
 import { gasConfig } from 'src/config';
+import { encodeTransactionData } from 'src/helpers/helpers';
 
 describe('Composable Tasks Transaction', () => {
     let module: TestingModule;
@@ -90,15 +91,17 @@ describe('Composable Tasks Transaction', () => {
             ComposableTasksTransactionService,
         );
 
-        const transaction = await service.wrapEgldAndSwapFixedInputTransaction(
+        const transaction = await service.wrapEgldAndSwapTransaction(
             '1000000000000000000',
             'USDC-123456',
             '20000000',
+            'swapTokensFixedInput',
         );
 
         expect(transaction).toEqual({
             chainID: 'T',
-            data: 'Y29tcG9zZVRhc2tzQDAwMDAwMDBiNTU1MzQ0NDMyZDMxMzIzMzM0MzUzNjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNDAxMzEyZDAwQEBAMDJAMDAwMDAwMGI1NTUzNDQ0MzJkMzEzMjMzMzQzNTM2MDAwMDAwMDQwMTMxMmQwMA==',
+            data: 'Y29tcG9zZVRhc2tzQDAwMDAwMDBiNTU1MzQ0NDMyZDMxMzIzMzM0MzUzNjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNDAxMzEyZDAwQEBAMDJAMDAwMDAwMTQ3Mzc3NjE3MDU0NmY2YjY1NmU3MzQ2Njk3ODY1NjQ0OTZlNzA3NTc0MDAwMDAwMGI1NTUzNDQ0MzJkMzEzMjMzMzQzNTM2MDAwMDAwMDQwMTMxMmQwMA==',
+
             gasLimit: gasConfig.composableTasks.default,
             gasPrice: 1000000000,
             guardian: undefined,
@@ -120,19 +123,19 @@ describe('Composable Tasks Transaction', () => {
             ComposableTasksTransactionService,
         );
 
-        const transaction =
-            await service.swapFixedInputAndUnwrapEgldTransaction(
-                new EsdtTokenPayment({
-                    tokenIdentifier: 'USDC-123456',
-                    tokenNonce: 0,
-                    amount: '20000000',
-                }),
-                '1000000000000000000',
-            );
+        const transaction = await service.swapAndUnwrapEgldTransaction(
+            new EsdtTokenPayment({
+                tokenIdentifier: 'USDC-123456',
+                tokenNonce: 0,
+                amount: '20000000',
+            }),
+            '1000000000000000000',
+            'swapTokensFixedInput',
+        );
 
         expect(transaction).toEqual({
             chainID: 'T',
-            data: 'RVNEVFRyYW5zZmVyQDU1NTM0NDQzMmQzMTMyMzMzNDM1MzZAMDEzMTJkMDBANjM2ZjZkNzA2ZjczNjU1NDYxNzM2YjczQDAwMDAwMDA0NDU0NzRjNDQwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDgwZGUwYjZiM2E3NjQwMDAwQDAyQDAwMDAwMDBjNTc0NTQ3NGM0NDJkMzEzMjMzMzQzNTM2MDAwMDAwMDgwZGUwYjZiM2E3NjQwMDAwQDAxQA==',
+            data: 'RVNEVFRyYW5zZmVyQDU1NTM0NDQzMmQzMTMyMzMzNDM1MzZAMDEzMTJkMDBANjM2ZjZkNzA2ZjczNjU1NDYxNzM2YjczQDAwMDAwMDA0NDU0NzRjNDQwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDgwZGUwYjZiM2E3NjQwMDAwQDAyQDAwMDAwMDE0NzM3NzYxNzA1NDZmNmI2NTZlNzM0NjY5Nzg2NTY0NDk2ZTcwNzU3NDAwMDAwMDBjNTc0NTQ3NGM0NDJkMzEzMjMzMzQzNTM2MDAwMDAwMDgwZGUwYjZiM2E3NjQwMDAwQDAxQA==',
             gasLimit: gasConfig.composableTasks.default,
             gasPrice: 1000000000,
             guardian: undefined,

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -329,11 +329,11 @@ export class PairResolver {
     }
 
     @UseGuards(JwtOrNativeAuthGuard)
-    @Query(() => [TransactionModel])
+    @Query(() => TransactionModel)
     async swapTokensFixedOutput(
         @Args() args: SwapTokensFixedOutputArgs,
         @AuthUser() user: UserAuthResult,
-    ): Promise<TransactionModel[]> {
+    ): Promise<TransactionModel> {
         return this.transactionService.swapTokensFixedOutput(
             user.address,
             args,

--- a/src/modules/pair/services/pair.transactions.service.ts
+++ b/src/modules/pair/services/pair.transactions.service.ts
@@ -289,21 +289,23 @@ export class PairTransactionService {
             .integerValue();
 
         if (args.tokenInID === mxConfig.EGLDIdentifier) {
-            return this.composableTasksTransaction.wrapEgldAndSwapFixedInputTransaction(
+            return this.composableTasksTransaction.wrapEgldAndSwapTransaction(
                 args.amountIn,
                 args.tokenOutID,
                 amountOutMin.toFixed(),
+                'swapTokensFixedInput',
             );
         }
 
         if (args.tokenOutID === mxConfig.EGLDIdentifier) {
-            return this.composableTasksTransaction.swapFixedInputAndUnwrapEgldTransaction(
+            return this.composableTasksTransaction.swapAndUnwrapEgldTransaction(
                 new EsdtTokenPayment({
                     tokenIdentifier: args.tokenInID,
                     tokenNonce: 0,
                     amount: args.amountIn,
                 }),
                 amountOutMin.toFixed(),
+                'swapTokensFixedInput',
             );
         }
 

--- a/src/modules/pair/specs/pair.transactions.service.spec.ts
+++ b/src/modules/pair/specs/pair.transactions.service.spec.ts
@@ -460,7 +460,7 @@ describe('TransactionPairService', () => {
 
         expect(transactions).toEqual({
             chainID: 'T',
-            data: 'Y29tcG9zZVRhc2tzQDAwMDAwMDBhNGQ0NTU4MmQzMTMyMzMzNDM1MzYwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwNEBAQDAyQDAwMDAwMDBhNGQ0NTU4MmQzMTMyMzMzNDM1MzYwMDAwMDAwMTA0',
+            data: 'Y29tcG9zZVRhc2tzQDAwMDAwMDBhNGQ0NTU4MmQzMTMyMzMzNDM1MzYwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwNEBAQDAyQDAwMDAwMDE0NzM3NzYxNzA1NDZmNmI2NTZlNzM0NjY5Nzg2NTY0NDk2ZTcwNzU3NDAwMDAwMDBhNGQ0NTU4MmQzMTMyMzMzNDM1MzYwMDAwMDAwMTA0',
             gasLimit: gasConfig.composableTasks.default,
             gasPrice: 1000000000,
             guardian: undefined,
@@ -482,7 +482,7 @@ describe('TransactionPairService', () => {
             PairTransactionService,
         );
 
-        const transactions = await service.swapTokensFixedOutput(
+        const transaction = await service.swapTokensFixedOutput(
             'erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu',
             {
                 pairAddress: Address.fromHex(
@@ -495,49 +495,23 @@ describe('TransactionPairService', () => {
             },
         );
 
-        expect(transactions).toEqual([
-            {
-                nonce: 0,
-                value: '0',
-                receiver: Address.fromHex(
-                    '0000000000000000000000000000000000000000000000000000000000000012',
-                ).bech32(),
-                sender: '',
-                receiverUsername: undefined,
-                senderUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: gasConfig.pairs.swapTokensFixedOutput.default,
-                data: encodeTransactionData(
-                    'ESDTTransfer@MEX-123456@05@swapTokensFixedOutput@WEGLD-123456@05',
-                ),
-                chainID: mxConfig.chainID,
-                version: 1,
-                options: undefined,
-                signature: undefined,
-                guardian: undefined,
-                guardianSignature: undefined,
-            },
-            {
-                nonce: 0,
-                value: '0',
-                receiver:
-                    'erd1qqqqqqqqqqqqqpgqd77fnev2sthnczp2lnfx0y5jdycynjfhzzgq6p3rax',
-                sender: '',
-                receiverUsername: undefined,
-                senderUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: gasConfig.wrapeGLD,
-                data: encodeTransactionData(
-                    'ESDTTransfer@WEGLD-123456@05@unwrapEgld',
-                ),
-                chainID: mxConfig.chainID,
-                version: 1,
-                options: undefined,
-                signature: undefined,
-                guardian: undefined,
-                guardianSignature: undefined,
-            },
-        ]);
+        expect(transaction).toEqual({
+            nonce: 0,
+            value: '0',
+            receiver: Address.Zero().bech32(),
+            sender: '',
+            receiverUsername: undefined,
+            senderUsername: undefined,
+            gasPrice: 1000000000,
+            gasLimit: gasConfig.composableTasks.default,
+            data: 'RVNEVFRyYW5zZmVyQDRkNDU1ODJkMzEzMjMzMzQzNTM2QDA1QDYzNmY2ZDcwNmY3MzY1NTQ2MTczNmI3M0AwMDAwMDAwNDQ1NDc0YzQ0MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDVAMDJAMDAwMDAwMTU3Mzc3NjE3MDU0NmY2YjY1NmU3MzQ2Njk3ODY1NjQ0Zjc1NzQ3MDc1NzQwMDAwMDAwYzU3NDU0NzRjNDQyZDMxMzIzMzM0MzUzNjAwMDAwMDAxMDVAMDFA',
+            chainID: mxConfig.chainID,
+            version: 1,
+            options: undefined,
+            signature: undefined,
+            guardian: undefined,
+            guardianSignature: undefined,
+        });
     });
 
     it('should validate tokens', async () => {


### PR DESCRIPTION
## Reasoning
- swap composable task can now choose which swap endpoint can use
  
## Proposed Changes
- updated the compose swap transaction method to accept the swap endpoint used to perform the swap
- updated the pair swap with fixed output transaction generator to use composable tasks for EGLD

## How to test
```
query SwapTokensFixedOutput {
	swapTokensFixedOutput(
		pairAddress: <address>
		tokenInID: "EGLD"
		tokenOutID: <token_identifier>
		amountIn: <amount_in>
		amountOut: <amount_out>
	) {
		data
	}
}
```
- query should return a`composeTasks` transaction with fixed output swap