### PR TITLE
[MEX-466] position creator swap information

### DIFF
--- a/src/modules/auto-router/auto-router.module.ts
+++ b/src/modules/auto-router/auto-router.module.ts
@@ -9,7 +9,7 @@ import { AutoRouterComputeService } from './services/auto-router.compute.service
 import { WrappingModule } from '../wrapping/wrap.module';
 import { RouterModule } from '../router/router.module';
 import { AutoRouterTransactionService } from './services/auto-router.transactions.service';
-import { AutoRouterResolver } from './auto-router.resolver';
+import { AutoRouterResolver, SwapRouteResolver } from './auto-router.resolver';
 import { PairTransactionService } from '../pair/services/pair.transactions.service';
 import { RemoteConfigModule } from '../remote-config/remote-config.module';
 import { TokenModule } from '../tokens/token.module';
@@ -29,6 +29,7 @@ import { ComposableTasksModule } from '../composable-tasks/composable.tasks.modu
         RemoteConfigModule,
     ],
     providers: [
+        SwapRouteResolver,
         AutoRouterResolver,
         AutoRouterService,
         AutoRouterComputeService,

--- a/src/modules/auto-router/auto-router.resolver.ts
+++ b/src/modules/auto-router/auto-router.resolver.ts
@@ -1,7 +1,7 @@
 import { Resolver, Query, ResolveField, Args, Parent } from '@nestjs/graphql';
 import { AutoRouterService } from '../auto-router/services/auto-router.service';
 import { AutoRouterArgs } from '../auto-router/models/auto-router.args';
-import { AutoRouteModel } from './models/auto-route.model';
+import { AutoRouteModel, SwapRouteModel } from './models/auto-route.model';
 import { TransactionModel } from 'src/models/transaction.model';
 import { UseGuards } from '@nestjs/common';
 import { AuthUser } from '../auth/auth.user';
@@ -10,10 +10,33 @@ import { JwtOrNativeAuthGuard } from '../auth/jwt.or.native.auth.guard';
 import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 
-@Resolver(() => AutoRouteModel)
-export class AutoRouterResolver {
-    constructor(private readonly autoRouterService: AutoRouterService) {}
+@Resolver(() => SwapRouteModel)
+export class SwapRouteResolver {
+    constructor(protected readonly autoRouterService: AutoRouterService) {}
 
+    @ResolveField(() => [String])
+    fees(@Parent() parent: AutoRouteModel): string[] {
+        const fees = this.autoRouterService.getFeesDenom(
+            parent.intermediaryAmounts,
+            parent.tokenRoute,
+            parent.pairs,
+        );
+
+        return fees;
+    }
+
+    @ResolveField(() => [String])
+    pricesImpact(@Parent() parent: AutoRouteModel): string[] {
+        return this.autoRouterService.getPriceImpactPercents(
+            parent.intermediaryAmounts,
+            parent.tokenRoute,
+            parent.pairs,
+        );
+    }
+}
+
+@Resolver(() => AutoRouteModel)
+export class AutoRouterResolver extends SwapRouteResolver {
     @Query(() => AutoRouteModel)
     async swap(@Args() args: AutoRouterArgs): Promise<AutoRouteModel> {
         try {
@@ -32,24 +55,6 @@ export class AutoRouterResolver {
                 },
             });
         }
-    }
-
-    @ResolveField(() => [String])
-    fees(@Parent() parent: AutoRouteModel): string[] {
-        return this.autoRouterService.getFeesDenom(
-            parent.intermediaryAmounts,
-            parent.tokenRoute,
-            parent.pairs,
-        );
-    }
-
-    @ResolveField(() => [String])
-    pricesImpact(@Parent() parent: AutoRouteModel): string[] {
-        return this.autoRouterService.getPriceImpactPercents(
-            parent.intermediaryAmounts,
-            parent.tokenRoute,
-            parent.pairs,
-        );
     }
 
     @UseGuards(JwtOrNativeAuthGuard)

--- a/src/modules/auto-router/models/auto-route.model.ts
+++ b/src/modules/auto-router/models/auto-route.model.ts
@@ -1,8 +1,9 @@
 import { ObjectType, Field } from '@nestjs/graphql';
 import { TransactionModel } from 'src/models/transaction.model';
 import { PairModel } from 'src/modules/pair/models/pair.model';
+
 @ObjectType()
-export class AutoRouteModel {
+export class SwapRouteModel {
     @Field()
     swapType: SWAP_TYPE;
 
@@ -60,6 +61,13 @@ export class AutoRouteModel {
     @Field()
     tolerance: number;
 
+    constructor(init?: Partial<SwapRouteModel>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class AutoRouteModel extends SwapRouteModel {
     @Field(() => [TransactionModel], { nullable: true })
     transactions: TransactionModel[];
 
@@ -67,6 +75,7 @@ export class AutoRouteModel {
     noAuthTransactions: TransactionModel[];
 
     constructor(init?: Partial<AutoRouteModel>) {
+        super(init);
         Object.assign(this, init);
     }
 }

--- a/src/modules/position-creator/models/position.creator.model.ts
+++ b/src/modules/position-creator/models/position.creator.model.ts
@@ -13,10 +13,40 @@ export class PositionCreatorModel {
 }
 
 @ObjectType()
-export class PositionCreatorTransactionModel {
+export class LiquidityPositionSingleTokenModel {
     @Field(() => [SwapRouteModel])
     swaps: SwapRouteModel[];
 
     @Field(() => [TransactionModel], { nullable: true })
-    transactions: TransactionModel[];
+    transactions?: TransactionModel[];
+
+    constructor(init: Partial<LiquidityPositionSingleTokenModel>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class FarmPositionSingleTokenModel {
+    @Field(() => [SwapRouteModel])
+    swaps: SwapRouteModel[];
+
+    @Field(() => [TransactionModel], { nullable: true })
+    transactions?: TransactionModel[];
+
+    constructor(init: Partial<FarmPositionSingleTokenModel>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class DualFarmPositionSingleTokenModel {
+    @Field(() => [SwapRouteModel])
+    swaps: SwapRouteModel[];
+
+    @Field(() => [TransactionModel], { nullable: true })
+    transactions?: TransactionModel[];
+
+    constructor(init: Partial<DualFarmPositionSingleTokenModel>) {
+        Object.assign(this, init);
+    }
 }

--- a/src/modules/position-creator/models/position.creator.model.ts
+++ b/src/modules/position-creator/models/position.creator.model.ts
@@ -1,4 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
+import { TransactionModel } from 'src/models/transaction.model';
+import { SwapRouteModel } from 'src/modules/auto-router/models/auto-route.model';
 
 @ObjectType()
 export class PositionCreatorModel {
@@ -8,4 +10,13 @@ export class PositionCreatorModel {
     constructor(init: Partial<PositionCreatorModel>) {
         Object.assign(this, init);
     }
+}
+
+@ObjectType()
+export class PositionCreatorTransactionModel {
+    @Field(() => [SwapRouteModel])
+    swaps: SwapRouteModel[];
+
+    @Field(() => [TransactionModel], { nullable: true })
+    transactions: TransactionModel[];
 }

--- a/src/modules/position-creator/models/position.creator.model.ts
+++ b/src/modules/position-creator/models/position.creator.model.ts
@@ -50,3 +50,29 @@ export class DualFarmPositionSingleTokenModel {
         Object.assign(this, init);
     }
 }
+
+@ObjectType()
+export class StakingPositionSingleTokenModel {
+    @Field(() => [SwapRouteModel])
+    swaps: SwapRouteModel[];
+
+    @Field(() => [TransactionModel], { nullable: true })
+    transactions?: TransactionModel[];
+
+    constructor(init: Partial<StakingPositionSingleTokenModel>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class EnergyPositionSingleTokenModel {
+    @Field(() => [SwapRouteModel])
+    swaps: SwapRouteModel[];
+
+    @Field(() => [TransactionModel], { nullable: true })
+    transactions?: TransactionModel[];
+
+    constructor(init: Partial<EnergyPositionSingleTokenModel>) {
+        Object.assign(this, init);
+    }
+}

--- a/src/modules/position-creator/position.creator.module.ts
+++ b/src/modules/position-creator/position.creator.module.ts
@@ -12,9 +12,11 @@ import { StakingModule } from '../staking/staking.module';
 import { TokenModule } from '../tokens/token.module';
 import {
     DualFarmPositionSingleTokenResolver,
+    EnergyPositionSingleTokenResolver,
     FarmPositionSingleTokenResolver,
     LiquidityPositionSingleTokenResolver,
     PositionCreatorTransactionResolver,
+    StakingPositionSingleTokenResolver,
 } from './position.creator.transaction.resolver';
 import { WrappingModule } from '../wrapping/wrap.module';
 import { ProxyFarmModule } from '../proxy/services/proxy-farm/proxy.farm.module';
@@ -42,6 +44,8 @@ import { EnergyModule } from '../energy/energy.module';
         FarmPositionSingleTokenResolver,
         LiquidityPositionSingleTokenResolver,
         DualFarmPositionSingleTokenResolver,
+        StakingPositionSingleTokenResolver,
+        EnergyPositionSingleTokenResolver,
     ],
     exports: [],
 })

--- a/src/modules/position-creator/position.creator.module.ts
+++ b/src/modules/position-creator/position.creator.module.ts
@@ -10,7 +10,12 @@ import { FarmModuleV2 } from '../farm/v2/farm.v2.module';
 import { StakingProxyModule } from '../staking-proxy/staking.proxy.module';
 import { StakingModule } from '../staking/staking.module';
 import { TokenModule } from '../tokens/token.module';
-import { PositionCreatorTransactionResolver } from './position.creator.transaction.resolver';
+import {
+    DualFarmPositionSingleTokenResolver,
+    FarmPositionSingleTokenResolver,
+    LiquidityPositionSingleTokenResolver,
+    PositionCreatorTransactionResolver,
+} from './position.creator.transaction.resolver';
 import { WrappingModule } from '../wrapping/wrap.module';
 import { ProxyFarmModule } from '../proxy/services/proxy-farm/proxy.farm.module';
 import { EnergyModule } from '../energy/energy.module';
@@ -34,6 +39,9 @@ import { EnergyModule } from '../energy/energy.module';
         PositionCreatorTransactionService,
         PositionCreatorResolver,
         PositionCreatorTransactionResolver,
+        FarmPositionSingleTokenResolver,
+        LiquidityPositionSingleTokenResolver,
+        DualFarmPositionSingleTokenResolver,
     ],
     exports: [],
 })

--- a/src/modules/position-creator/position.creator.transaction.resolver.ts
+++ b/src/modules/position-creator/position.creator.transaction.resolver.ts
@@ -16,7 +16,7 @@ import { PositionCreatorComputeService } from './services/position.creator.compu
 import { FarmAbiServiceV2 } from '../farm/v2/services/farm.v2.abi.service';
 import { StakingProxyAbiService } from '../staking-proxy/services/staking.proxy.abi.service';
 import { GraphQLError } from 'graphql';
-import { ApolloServerErrorCode } from '@apollo/server/dist/esm/errors';
+import { ApolloServerErrorCode } from '@apollo/server/errors';
 
 @Resolver(() => LiquidityPositionSingleTokenModel)
 export class LiquidityPositionSingleTokenResolver {

--- a/src/modules/position-creator/position.creator.transaction.resolver.ts
+++ b/src/modules/position-creator/position.creator.transaction.resolver.ts
@@ -7,6 +7,7 @@ import { PositionCreatorTransactionService } from './services/position.creator.t
 import { InputTokenModel } from 'src/models/inputToken.model';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { AuthUser } from '../auth/auth.user';
+import { PositionCreatorTransactionModel } from './models/position.creator.model';
 
 @Resolver()
 @UseGuards(JwtOrNativeAuthGuard)
@@ -15,14 +16,14 @@ export class PositionCreatorTransactionResolver {
         private readonly posCreatorTransaction: PositionCreatorTransactionService,
     ) {}
 
-    @Query(() => TransactionModel)
+    @Query(() => PositionCreatorTransactionModel)
     async createPositionSingleToken(
         @AuthUser() user: UserAuthResult,
         @Args('pairAddress') pairAddress: string,
         @Args('payment') payment: InputTokenModel,
         @Args('tolerance') tolerance: number,
         @Args('lockEpochs', { nullable: true }) lockEpochs: number,
-    ): Promise<TransactionModel> {
+    ): Promise<PositionCreatorTransactionModel> {
         return this.posCreatorTransaction.createLiquidityPositionSingleToken(
             user.address,
             pairAddress,
@@ -36,7 +37,7 @@ export class PositionCreatorTransactionResolver {
         );
     }
 
-    @Query(() => [TransactionModel])
+    @Query(() => PositionCreatorTransactionModel)
     async createFarmPositionSingleToken(
         @AuthUser() user: UserAuthResult,
         @Args('farmAddress') farmAddress: string,
@@ -44,7 +45,7 @@ export class PositionCreatorTransactionResolver {
         payments: InputTokenModel[],
         @Args('tolerance') tolerance: number,
         @Args('lockEpochs', { nullable: true }) lockEpochs: number,
-    ): Promise<TransactionModel[]> {
+    ): Promise<PositionCreatorTransactionModel> {
         return this.posCreatorTransaction.createFarmPositionSingleToken(
             user.address,
             farmAddress,
@@ -61,14 +62,14 @@ export class PositionCreatorTransactionResolver {
         );
     }
 
-    @Query(() => [TransactionModel])
+    @Query(() => PositionCreatorTransactionModel)
     async createDualFarmPositionSingleToken(
         @AuthUser() user: UserAuthResult,
         @Args('dualFarmAddress') dualFarmAddress: string,
         @Args('payments', { type: () => [InputTokenModel] })
         payments: InputTokenModel[],
         @Args('tolerance') tolerance: number,
-    ): Promise<TransactionModel[]> {
+    ): Promise<PositionCreatorTransactionModel> {
         return this.posCreatorTransaction.createDualFarmPositionSingleToken(
             user.address,
             dualFarmAddress,

--- a/src/modules/position-creator/services/position.creator.compute.ts
+++ b/src/modules/position-creator/services/position.creator.compute.ts
@@ -4,15 +4,20 @@ import { PerformanceProfiler } from '@multiversx/sdk-nestjs-monitoring';
 import { Injectable } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { constantsConfig } from 'src/config';
-import { SWAP_TYPE } from 'src/modules/auto-router/models/auto-route.model';
+import {
+    SWAP_TYPE,
+    SwapRouteModel,
+} from 'src/modules/auto-router/models/auto-route.model';
 import { AutoRouterService } from 'src/modules/auto-router/services/auto-router.service';
 import { AutoRouterTransactionService } from 'src/modules/auto-router/services/auto-router.transactions.service';
+import { PairModel } from 'src/modules/pair/models/pair.model';
 import { PairAbiService } from 'src/modules/pair/services/pair.abi.service';
+import { PairComputeService } from 'src/modules/pair/services/pair.compute.service';
 import { PairService } from 'src/modules/pair/services/pair.service';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 
 export type PositionCreatorSingleTokenPairInput = {
-    swapRouteArgs: TypedValue[];
+    swapRoutes: SwapRouteModel[];
     amount0Min: BigNumber;
     amount1Min: BigNumber;
 };
@@ -27,6 +32,7 @@ export class PositionCreatorComputeService {
     constructor(
         private readonly pairAbi: PairAbiService,
         private readonly pairService: PairService,
+        private readonly pairCompute: PairComputeService,
         private readonly routerAbi: RouterAbiService,
         private readonly autoRouterService: AutoRouterService,
         private readonly autoRouterTransaction: AutoRouterTransactionService,
@@ -59,32 +65,50 @@ export class PositionCreatorComputeService {
         const acceptedPairedTokensIDs =
             await this.routerAbi.commonTokensForUserPairs();
 
-        const [firstTokenID, secondTokenID, lpTokenID] = await Promise.all([
-            this.pairAbi.firstTokenID(pairAddress),
-            this.pairAbi.secondTokenID(pairAddress),
+        const [
+            firstToken,
+            secondToken,
+            lpTokenID,
+            firstTokenPriceUSD,
+            secondTokenPriceUSD,
+            reserves,
+            totalFeePercent,
+        ] = await Promise.all([
+            this.pairService.getFirstToken(pairAddress),
+            this.pairService.getSecondToken(pairAddress),
             this.pairAbi.lpTokenID(pairAddress),
+            this.pairCompute.firstTokenPriceUSD(pairAddress),
+            this.pairCompute.secondTokenPriceUSD(pairAddress),
+            this.pairAbi.pairInfoMetadata(pairAddress),
+            this.pairAbi.totalFeePercent(pairAddress),
         ]);
 
         if (payment.tokenIdentifier === lpTokenID) {
             return {
-                swapRouteArgs: [],
+                swapRoutes: [],
                 amount0Min: new BigNumber(0),
                 amount1Min: new BigNumber(0),
             };
         }
 
-        const swapToTokenID = acceptedPairedTokensIDs.includes(firstTokenID)
-            ? firstTokenID
-            : secondTokenID;
+        const [tokenInID, tokenOutID] = acceptedPairedTokensIDs.includes(
+            firstToken.identifier,
+        )
+            ? [firstToken.identifier, secondToken.identifier]
+            : [secondToken.identifier, firstToken.identifier];
 
         const profiler = new PerformanceProfiler();
+
+        const swapRoutes = [];
 
         const swapRoute = await this.autoRouterService.swap({
             tokenInID: payment.tokenIdentifier,
             amountIn: payment.amount,
-            tokenOutID: swapToTokenID,
+            tokenOutID: tokenInID,
             tolerance,
         });
+
+        swapRoutes.push(swapRoute);
 
         profiler.stop('swap route', true);
 
@@ -100,31 +124,67 @@ export class PositionCreatorComputeService {
         let [amount0, amount1] = await Promise.all([
             await this.computeSwap(
                 pairAddress,
-                swapRoute.tokenOutID,
-                firstTokenID,
+                tokenInID,
+                tokenInID,
                 halfPayment,
             ),
             await this.computeSwap(
                 pairAddress,
-                swapRoute.tokenOutID,
-                secondTokenID,
+                tokenInID,
+                tokenOutID,
                 remainingPayment,
             ),
         ]);
 
+        swapRoutes.push(
+            new SwapRouteModel({
+                swapType: SWAP_TYPE.fixedInput,
+                tokenInID,
+                tokenOutID,
+                amountIn: amount0.toFixed(),
+                amountOut: amount1.toFixed(),
+                tokenRoute: [tokenInID, tokenOutID],
+                pairs: [
+                    new PairModel({
+                        address: pairAddress,
+                        firstToken,
+                        secondToken,
+                        info: reserves,
+                        totalFeePercent,
+                    }),
+                ],
+                intermediaryAmounts: [amount0.toFixed(), amount1.toFixed()],
+                tolerance: tolerance,
+                tokenInExchangeRate: new BigNumber(amount1)
+                    .dividedBy(amount0)
+                    .toFixed(),
+                tokenOutExchangeRate: new BigNumber(amount0)
+                    .dividedBy(amount1)
+                    .toFixed(),
+                tokenInPriceUSD:
+                    tokenInID === firstToken.identifier
+                        ? firstTokenPriceUSD
+                        : secondTokenPriceUSD,
+                tokenOutPriceUSD:
+                    tokenOutID === firstToken.identifier
+                        ? firstTokenPriceUSD
+                        : secondTokenPriceUSD,
+            }),
+        );
+
         amount0 =
-            swapToTokenID === firstTokenID
+            tokenInID === firstToken.identifier
                 ? await this.pairService.getEquivalentForLiquidity(
                       pairAddress,
-                      secondTokenID,
+                      secondToken.identifier,
                       amount1.toFixed(),
                   )
                 : amount0;
         amount1 =
-            swapToTokenID === secondTokenID
+            tokenInID === secondToken.identifier
                 ? await this.pairService.getEquivalentForLiquidity(
                       pairAddress,
-                      firstTokenID,
+                      firstToken.identifier,
                       amount0.toFixed(),
                   )
                 : amount1;
@@ -132,19 +192,8 @@ export class PositionCreatorComputeService {
         const amount0Min = amount0.multipliedBy(1 - tolerance).integerValue();
         const amount1Min = amount1.multipliedBy(1 - tolerance).integerValue();
 
-        const swapRouteArgs =
-            this.autoRouterTransaction.multiPairFixedInputSwaps({
-                tokenInID: swapRoute.tokenInID,
-                tokenOutID: swapRoute.tokenOutID,
-                swapType: SWAP_TYPE.fixedInput,
-                tolerance,
-                addressRoute: swapRoute.pairs.map((pair) => pair.address),
-                intermediaryAmounts: swapRoute.intermediaryAmounts,
-                tokenRoute: swapRoute.tokenRoute,
-            });
-
         return {
-            swapRouteArgs,
+            swapRoutes,
             amount0Min,
             amount1Min,
         };

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -69,15 +69,19 @@ export class PositionCreatorTransactionService {
         }
 
         const swapRouteArgs =
-            this.autoRouterTransaction.multiPairFixedInputSwaps({
-                tokenInID: swapRoutes[0].tokenInID,
-                tokenOutID: swapRoutes[0].tokenOutID,
-                swapType: SWAP_TYPE.fixedInput,
-                tolerance,
-                addressRoute: swapRoutes[0].pairs.map((pair) => pair.address),
-                intermediaryAmounts: swapRoutes[0].intermediaryAmounts,
-                tokenRoute: swapRoutes[0].tokenRoute,
-            });
+            swapRoutes.length < 2
+                ? []
+                : this.autoRouterTransaction.multiPairFixedInputSwaps({
+                      tokenInID: swapRoutes[0].tokenInID,
+                      tokenOutID: swapRoutes[0].tokenOutID,
+                      swapType: SWAP_TYPE.fixedInput,
+                      tolerance,
+                      addressRoute: swapRoutes[0].pairs.map(
+                          (pair) => pair.address,
+                      ),
+                      intermediaryAmounts: swapRoutes[0].intermediaryAmounts,
+                      tokenRoute: swapRoutes[0].tokenRoute,
+                  });
 
         const [amount0Min, amount1Min] =
             await this.getMinimumAmountsForLiquidity(
@@ -170,15 +174,19 @@ export class PositionCreatorTransactionService {
         }
 
         const swapRouteArgs =
-            this.autoRouterTransaction.multiPairFixedInputSwaps({
-                tokenInID: swapRoutes[0].tokenInID,
-                tokenOutID: swapRoutes[0].tokenOutID,
-                swapType: SWAP_TYPE.fixedInput,
-                tolerance,
-                addressRoute: swapRoutes[0].pairs.map((pair) => pair.address),
-                intermediaryAmounts: swapRoutes[0].intermediaryAmounts,
-                tokenRoute: swapRoutes[0].tokenRoute,
-            });
+            swapRoutes.length < 2
+                ? []
+                : this.autoRouterTransaction.multiPairFixedInputSwaps({
+                      tokenInID: swapRoutes[0].tokenInID,
+                      tokenOutID: swapRoutes[0].tokenOutID,
+                      swapType: SWAP_TYPE.fixedInput,
+                      tolerance,
+                      addressRoute: swapRoutes[0].pairs.map(
+                          (pair) => pair.address,
+                      ),
+                      intermediaryAmounts: swapRoutes[0].intermediaryAmounts,
+                      tokenRoute: swapRoutes[0].tokenRoute,
+                  });
 
         const [amount0Min, amount1Min] =
             await this.getMinimumAmountsForLiquidity(
@@ -282,15 +290,19 @@ export class PositionCreatorTransactionService {
         }
 
         const swapRouteArgs =
-            this.autoRouterTransaction.multiPairFixedInputSwaps({
-                tokenInID: swapRoutes[0].tokenInID,
-                tokenOutID: swapRoutes[0].tokenOutID,
-                swapType: SWAP_TYPE.fixedInput,
-                tolerance,
-                addressRoute: swapRoutes[0].pairs.map((pair) => pair.address),
-                intermediaryAmounts: swapRoutes[0].intermediaryAmounts,
-                tokenRoute: swapRoutes[0].tokenRoute,
-            });
+            swapRoutes.length < 2
+                ? []
+                : this.autoRouterTransaction.multiPairFixedInputSwaps({
+                      tokenInID: swapRoutes[0].tokenInID,
+                      tokenOutID: swapRoutes[0].tokenOutID,
+                      swapType: SWAP_TYPE.fixedInput,
+                      tolerance,
+                      addressRoute: swapRoutes[0].pairs.map(
+                          (pair) => pair.address,
+                      ),
+                      intermediaryAmounts: swapRoutes[0].intermediaryAmounts,
+                      tokenRoute: swapRoutes[0].tokenRoute,
+                  });
 
         const [amount0Min, amount1Min] =
             await this.getMinimumAmountsForLiquidity(


### PR DESCRIPTION
## Reasoning
- position creator transactions perform swaps on the input tokens to create the final position; no information about swaps were exposed to frontend
  
## Proposed Changes
- added models for each position creator with single token actions to expose swap information
- updated position creator query to work for non-authenticated requests
- made the transaction generation of position creator to work only for authenticated requests

## How to test
```
query CreateDualFarmPositionSingleToken {
	createDualFarmPositionSingleToken(
		dualFarmAddress: <dual_farm_address>,
		payment: {
			tokenID: <token_id>,
			nonce: 0,
			amount: <amount>
		},
		tolerance: <tolerance>
	) {
			swaps {
				swapType
				tokenInID
				tokenOutID
				tokenInExchangeRate
				tokenOutExchangeRateDenom
				tokenInPriceUSD
				tokenOutPriceUSD
				amountIn
				amountOut
				intermediaryAmounts
				tokenRoute
				fees
				pricesImpact
				tolerance
		}
		transactions (
			dualFarmAddress: <dual_farm_address>,
		) {
				receiver
				data
		}
	}
}
```
- query should return swap information if request is not authenticated and return null for transaction
- query should return transaction if the request is authenticated