### PR TITLE
[SERVICES-2290] check for maximum liquidity locked permanently in pair

### DIFF
--- a/src/modules/pair/mocks/pair.compute.service.mock.ts
+++ b/src/modules/pair/mocks/pair.compute.service.mock.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { IPairComputeService } from '../interfaces';
 import { PairAbiService } from '../services/pair.abi.service';
 import { PairComputeService } from '../services/pair.compute.service';
@@ -84,6 +85,12 @@ export class PairComputeServiceMock implements IPairComputeService {
 
     async computeLpTokenPriceUSD(pairAddress: string): Promise<string> {
         return await this.lpTokenPriceUSD(pairAddress);
+    }
+
+    async computePermanentLockedValueUSD(
+        pairAddress: string,
+    ): Promise<BigNumber> {
+        return new BigNumber('0.000001');
     }
 }
 

--- a/src/modules/pair/specs/pair.transactions.service.spec.ts
+++ b/src/modules/pair/specs/pair.transactions.service.spec.ts
@@ -61,8 +61,8 @@ describe('TransactionPairService', () => {
     });
 
     it('should get add initial liquidity batch transaction', async () => {
-        const firstTokenAmount = '10';
-        const secondTokenAmount = '9';
+        const firstTokenAmount = '10000000000000000000';
+        const secondTokenAmount = '9000000000000000000';
 
         const service = module.get<PairTransactionService>(
             PairTransactionService,
@@ -120,7 +120,7 @@ describe('TransactionPairService', () => {
             data: encodeTransactionData(
                 `MultiESDTNFTTransfer@${Address.fromHex(
                     '0000000000000000000000000000000000000000000000000000000000000012',
-                ).bech32()}@2@WEGLD-123456@@9@MEX-123456@@10@addInitialLiquidity`,
+                ).bech32()}@2@WEGLD-123456@@9000000000000000000@MEX-123456@@10000000000000000000@addInitialLiquidity`,
             ),
             chainID: mxConfig.chainID,
             version: 1,
@@ -130,8 +130,8 @@ describe('TransactionPairService', () => {
     });
 
     it('should get add initial liquidity transaction', async () => {
-        const firstTokenAmount = '10';
-        const secondTokenAmount = '9';
+        const firstTokenAmount = '10000000000000000000';
+        const secondTokenAmount = '9000000000000000000';
 
         const service = module.get<PairTransactionService>(
             PairTransactionService,
@@ -169,7 +169,7 @@ describe('TransactionPairService', () => {
             data: encodeTransactionData(
                 `MultiESDTNFTTransfer@${Address.fromHex(
                     '0000000000000000000000000000000000000000000000000000000000000012',
-                ).bech32()}@02@WEGLD-123456@@10@MEX-123456@@09@addInitialLiquidity`,
+                ).bech32()}@02@WEGLD-123456@@10000000000000000000@MEX-123456@@9000000000000000000@addInitialLiquidity`,
             ),
             chainID: mxConfig.chainID,
             version: 1,


### PR DESCRIPTION
## Reasoning
- permanently liquidity locked remaining in a pair should not be grater than 1 USD
  
## Proposed Changes
- added method to compute permanently liquidity locked in pair when initial adding liquidity
- added check in addInitialLiquidity method for minimum amounts
- added check in addInitialLiquidity method for maximum permanently liquidity locked

## How to test
```
query AddInitialLiquidity {
	addInitialLiquidityBatch(
		pairAddress: <pair_address>
		tokens: [
			{ tokenID: <token_identifier>, nonce: 0, amount: <amount>}
			{ tokenID: <token_identifier>, nonce: 0, amount: <amount> }
		]
		tolerance: 0.1
	) {
		data
	}
}
```
- query should return error if any of the 2 amounts are less than 1000 units
- query should return error if the liquidity locked permanently is grater than 1 USD