### PR TITLE
[MEX-466] position creator payment fix

### DIFF
--- a/src/modules/position-creator/models/position.creator.model.ts
+++ b/src/modules/position-creator/models/position.creator.model.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { TransactionModel } from 'src/models/transaction.model';
 import { SwapRouteModel } from 'src/modules/auto-router/models/auto-route.model';
+import { EsdtTokenPaymentModel } from 'src/modules/tokens/models/esdt.token.payment.model';
 
 @ObjectType()
 export class PositionCreatorModel {
@@ -14,6 +15,9 @@ export class PositionCreatorModel {
 
 @ObjectType()
 export class LiquidityPositionSingleTokenModel {
+    @Field(() => EsdtTokenPaymentModel)
+    payment: EsdtTokenPaymentModel;
+
     @Field(() => [SwapRouteModel])
     swaps: SwapRouteModel[];
 
@@ -27,6 +31,9 @@ export class LiquidityPositionSingleTokenModel {
 
 @ObjectType()
 export class FarmPositionSingleTokenModel {
+    @Field(() => EsdtTokenPaymentModel)
+    payment: EsdtTokenPaymentModel;
+
     @Field(() => [SwapRouteModel])
     swaps: SwapRouteModel[];
 
@@ -40,6 +47,9 @@ export class FarmPositionSingleTokenModel {
 
 @ObjectType()
 export class DualFarmPositionSingleTokenModel {
+    @Field(() => EsdtTokenPaymentModel)
+    payment: EsdtTokenPaymentModel;
+
     @Field(() => [SwapRouteModel])
     swaps: SwapRouteModel[];
 
@@ -53,6 +63,9 @@ export class DualFarmPositionSingleTokenModel {
 
 @ObjectType()
 export class StakingPositionSingleTokenModel {
+    @Field(() => EsdtTokenPaymentModel)
+    payment: EsdtTokenPaymentModel;
+
     @Field(() => [SwapRouteModel])
     swaps: SwapRouteModel[];
 
@@ -66,6 +79,9 @@ export class StakingPositionSingleTokenModel {
 
 @ObjectType()
 export class EnergyPositionSingleTokenModel {
+    @Field(() => EsdtTokenPaymentModel)
+    payment: EsdtTokenPaymentModel;
+
     @Field(() => [SwapRouteModel])
     swaps: SwapRouteModel[];
 

--- a/src/modules/position-creator/services/position.creator.compute.ts
+++ b/src/modules/position-creator/services/position.creator.compute.ts
@@ -145,11 +145,17 @@ export class PositionCreatorComputeService {
             ),
         ]);
 
-        const tokenInExchangeRate = new BigNumber(amount1)
+        const tokenInExchangeRate = new BigNumber(10)
+            .pow(tokenOut.decimals)
+            .multipliedBy(amount1)
             .dividedBy(amount0)
+            .integerValue()
             .toFixed();
-        const tokenOutExchangeRate = new BigNumber(amount0)
+        const tokenOutExchangeRate = new BigNumber(10)
+            .pow(tokenIn.decimals)
+            .multipliedBy(amount0)
             .dividedBy(amount1)
+            .integerValue()
             .toFixed();
 
         const priceDeviationPercent =


### PR DESCRIPTION
## Reasoning
- payment for transaction isn't put in the correct format
  
## Proposed Changes
- added payment field for each single token model
- use the payment field for transaction generator

## How to test
```
query CreatePositionSingleToken {
	createPositionSingleToken(
		pairAddress: <address>,
		payment: {
			tokenID: <token_id>,
			nonce: 0,
			amount: <amount>
		},
		tolerance: 0.01
	) {
		payment {
			tokenIdentifier
			tokenNonce
			amount
		}
		swaps {
			swapType
			tokenInID
			tokenOutID
			tokenInExchangeRate
			tokenInExchangeRateDenom
			tokenInPriceUSD
			tokenOutExchangeRate
			tokenOutExchangeRateDenom
			tokenOutPriceUSD
			amountIn
			amountOut
			intermediaryAmounts
			tokenRoute
			fees
			pricesImpact
			maxPriceDeviationPercent
			tokensPriceDeviationPercent
			tolerance
			pairs {
				address
				firstToken {
					identifier
				}
				secondToken {
					identifier
				}
			}
		}
		transactions {
			receiver
			data
			value
		}
	}
}
```