### PR TITLE
[SERVICES-2310] filter pairs by minimum liquidityUSD

### DIFF
--- a/src/modules/router/models/filter.args.ts
+++ b/src/modules/router/models/filter.args.ts
@@ -16,4 +16,6 @@ export class PairFilterArgs {
     minVolume: number;
     @Field({ nullable: true })
     feeState: boolean;
+    @Field({ nullable: true })
+    minLockedValueUSD: number;
 }

--- a/src/modules/router/specs/router.service.spec.ts
+++ b/src/modules/router/specs/router.service.spec.ts
@@ -101,7 +101,8 @@ describe('RouterService', () => {
             secondTokenID: null,
             state: null,
             feeState: null,
-            minVolume: null
+            minVolume: null,
+            minLockedValueUSD: null,
         });
         expect(filteredPairs).toEqual([
             new PairModel({
@@ -137,12 +138,65 @@ describe('RouterService', () => {
             secondTokenID: null,
             state: null,
             feeState: false,
-            minVolume: 1000
+            minVolume: 1000,
+            minLockedValueUSD: null,
         });
         expect(filteredPairs).toEqual([
             new PairModel({
                 address: Address.fromHex(
                     '0000000000000000000000000000000000000000000000000000000000000015',
+                ).bech32(),
+            }),
+        ]);
+    });
+
+    it('should get pairs filtered by minimum locked value USD', async () => {
+        const service = module.get<RouterService>(RouterService);
+
+        const filteredPairs = await service.getAllPairs(0, Number.MAX_VALUE, {
+            firstTokenID: null,
+            issuedLpToken: true,
+            address: null,
+            secondTokenID: null,
+            state: null,
+            feeState: null,
+            minVolume: null,
+            minLockedValueUSD: 300,
+        });
+        expect(filteredPairs).toEqual([
+            new PairModel({
+                address: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000012',
+                ).bech32(),
+            }),
+            new PairModel({
+                address: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000013',
+                ).bech32(),
+            }),
+            new PairModel({
+                address: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000014',
+                ).bech32(),
+            }),
+            new PairModel({
+                address: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000015',
+                ).bech32(),
+            }),
+            new PairModel({
+                address: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000017',
+                ).bech32(),
+            }),
+            new PairModel({
+                address: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000018',
+                ).bech32(),
+            }),
+            new PairModel({
+                address: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000019',
                 ).bech32(),
             }),
         ]);


### PR DESCRIPTION
## Reasoning
- filter out pairs with low liqudity
  
## Proposed Changes
- added new filter method in router service to exclude pairs with liquidity in USD below specified threshold

## How to test
```
query Pairs {
	pairs(offset: 0, limit: 250, minLockedValueUSD: 300) {
		address
        }
}
```
- query should return pairs with liquidity in USD > 300 USD