### PR TITLE
[SERVICES-2312] Cache warm total daily+hourly pairs volumes

### DIFF
--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -25,8 +25,7 @@ export class AWSQueryCacheWarmerService {
         @Inject(WINSTON_MODULE_PROVIDER) protected readonly logger: Logger,
     ) {}
 
-    // @Cron(CronExpression.EVERY_5_MINUTES)
-    @Cron(CronExpression.EVERY_MINUTE)
+    @Cron(CronExpression.EVERY_5_MINUTES)
     @Lock({ name: 'updateHistoricTokensData', verbose: true })
     async updateHistoricTokensData(): Promise<void> {
         if (!this.apiConfig.isAWSTimestreamRead()) {

--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -104,31 +104,6 @@ export class AWSQueryCacheWarmerService {
             ]);
             await this.deleteCacheKeys(cachedKeys);
         }
-
-        const allTokensVolumeUSDCompleteValuesSum = await this.analyticsQuery.getSumCompleteValues({
-            series: '%-%',
-            metric: 'volumeUSD',
-        });
-        await delay(1000);
-        const allTokensVolumeUSD24hSum = await this.analyticsQuery.getValues24hSum({
-            series: '%-%',
-            metric: 'volumeUSD',
-        });
-
-        const allTokensVolumesKeys = await Promise.all([
-            this.analyticsAWSSetter.setSumCompleteValues(
-              'factory',
-              'volumeUSD',
-              allTokensVolumeUSDCompleteValuesSum,
-            ),
-            this.analyticsAWSSetter.setValues24hSum(
-              'factory',
-              'volumeUSD',
-              allTokensVolumeUSD24hSum,
-            ),
-        ]) 
-        await this.deleteCacheKeys(allTokensVolumesKeys);
-
         profiler.stop();
         this.logger.info(
             `Finish refresh tokens analytics in ${profiler.duration}`,
@@ -214,6 +189,33 @@ export class AWSQueryCacheWarmerService {
             ]);
             await this.deleteCacheKeys(cachedKeys);
         }
+
+        const allPairsVolumeUSDCompleteValuesSum =
+            await this.analyticsQuery.getSumCompleteValues({
+                series: 'erd1%',
+                metric: 'volumeUSD',
+            });
+        await delay(1000);
+        const allPairsVolumeUSD24hSum =
+            await this.analyticsQuery.getValues24hSum({
+                series: 'erd1%',
+                metric: 'volumeUSD',
+            });
+
+        const allPairsVolumesKeys = await Promise.all([
+            this.analyticsAWSSetter.setSumCompleteValues(
+                'factory',
+                'volumeUSD',
+                allPairsVolumeUSDCompleteValuesSum,
+            ),
+            this.analyticsAWSSetter.setValues24hSum(
+                'factory',
+                'volumeUSD',
+                allPairsVolumeUSD24hSum,
+            ),
+        ]);
+        await this.deleteCacheKeys(allPairsVolumesKeys);
+
         profiler.stop();
         this.logger.info(
             `Finish refresh pairs analytics in ${profiler.duration}`,


### PR DESCRIPTION
## Reasoning
- query total volumes for all pairs

  
## Proposed Changes
- allow wildcard (%) pattern for series in timescaledb queries on sumDaily and sumHourly aggregates
- add queries for total pairs (pattern `erd1%`) volumes in aws cache warmer and persist in cache under key `factory`


## How to test
```
query SumComplete {
  sumCompleteValues(series: "factory", metric:"volumeUSD") {
    timestamp
    value
  }
}

query Last24hSum {
  values24hSum(series: "factory", metric:"volumeUSD") {
    timestamp
    value
  }
}
```