### PR TITLE
[SERVICES-2355] Fix 'where' clause in SumHourly aggregate

### DIFF
--- a/src/services/analytics/timescaledb/entities/timescaledb.entities.ts
+++ b/src/services/analytics/timescaledb/entities/timescaledb.entities.ts
@@ -90,7 +90,7 @@ export class SumDaily {
       time_bucket('1 hour', timestamp) AS time, series, key,
       last(value, timestamp) AS last,sum(value) AS sum
     FROM "hyper_dex_analytics"
-    WHERE key = 'feesUSD' OR key = 'volumeUSD'
+    WHERE key IN ('feesUSD', 'volumeUSD')
     AND timestamp >= NOW() - INTERVAL '1 day'
     GROUP BY time, series, key;
   `,
@@ -253,7 +253,7 @@ export class TokenBurnedWeekly {
 }
 
 @ViewEntity({
-  expression: `
+    expression: `
       SELECT
           time_bucket('1 minute', timestamp) AS time, series, key,
           first(value, timestamp) AS open,
@@ -264,35 +264,35 @@ export class TokenBurnedWeekly {
       WHERE key in ('firstTokenPrice','secondTokenPrice', 'priceUSD')
       GROUP BY time, series, key ORDER BY time ASC;
   `,
-  materialized: true,
-  name: 'price_candle_minute',
+    materialized: true,
+    name: 'price_candle_minute',
 })
 export class PriceCandleMinute {
-  @ViewColumn()
-  @PrimaryColumn()
-  time: Date = new Date();
+    @ViewColumn()
+    @PrimaryColumn()
+    time: Date = new Date();
 
-  @ViewColumn()
-  series: string;
+    @ViewColumn()
+    series: string;
 
-  @ViewColumn()
-  key: string;
+    @ViewColumn()
+    key: string;
 
-  @ViewColumn()
-  open = '0';
+    @ViewColumn()
+    open = '0';
 
-  @ViewColumn()
-  close = '0';
+    @ViewColumn()
+    close = '0';
 
-  @ViewColumn()
-  low = '0';
+    @ViewColumn()
+    low = '0';
 
-  @ViewColumn()
-  high = '0';
+    @ViewColumn()
+    high = '0';
 }
 
 @ViewEntity({
-  expression: `
+    expression: `
       SELECT
           time_bucket('1 hour', time) AS time, series, key,
           first(open, time) AS open,
@@ -302,36 +302,36 @@ export class PriceCandleMinute {
       FROM "price_candle_minute"
       GROUP BY time_bucket('1 hour', time), series, key ORDER BY time ASC;
   `,
-  materialized: true,
-  name: 'price_candle_hourly',
-  dependsOn: ['price_candle_minute'],
+    materialized: true,
+    name: 'price_candle_hourly',
+    dependsOn: ['price_candle_minute'],
 })
 export class PriceCandleHourly {
-  @ViewColumn()
-  @PrimaryColumn()
-  time: Date = new Date();
+    @ViewColumn()
+    @PrimaryColumn()
+    time: Date = new Date();
 
-  @ViewColumn()
-  series: string;
+    @ViewColumn()
+    series: string;
 
-  @ViewColumn()
-  key: string;
+    @ViewColumn()
+    key: string;
 
-  @ViewColumn()
-  open = '0';
+    @ViewColumn()
+    open = '0';
 
-  @ViewColumn()
-  close = '0';
+    @ViewColumn()
+    close = '0';
 
-  @ViewColumn()
-  low = '0';
+    @ViewColumn()
+    low = '0';
 
-  @ViewColumn()
-  high = '0';
+    @ViewColumn()
+    high = '0';
 }
 
 @ViewEntity({
-  expression: `
+    expression: `
       SELECT
           time_bucket('1 day', time) AS time, series, key,
           first(open, time) AS open,
@@ -341,30 +341,30 @@ export class PriceCandleHourly {
       FROM "price_candle_hourly"
       GROUP BY time_bucket('1 day', time), series, key ORDER BY time ASC;
   `,
-  materialized: true,
-  name: 'price_candle_daily',
-  dependsOn: ['pair_candle_hourly'],
+    materialized: true,
+    name: 'price_candle_daily',
+    dependsOn: ['pair_candle_hourly'],
 })
 export class PriceCandleDaily {
-  @ViewColumn()
-  @PrimaryColumn()
-  time: Date = new Date();
+    @ViewColumn()
+    @PrimaryColumn()
+    time: Date = new Date();
 
-  @ViewColumn()
-  series: string;
+    @ViewColumn()
+    series: string;
 
-  @ViewColumn()
-  key: string;
+    @ViewColumn()
+    key: string;
 
-  @ViewColumn()
-  open = '0';
+    @ViewColumn()
+    open = '0';
 
-  @ViewColumn()
-  close = '0';
+    @ViewColumn()
+    close = '0';
 
-  @ViewColumn()
-  low = '0';
+    @ViewColumn()
+    low = '0';
 
-  @ViewColumn()
-  high = '0';
+    @ViewColumn()
+    high = '0';
 }

--- a/src/services/analytics/timescaledb/migration/1715251449059-xExchange.ts
+++ b/src/services/analytics/timescaledb/migration/1715251449059-xExchange.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class XExchange1715251449059 implements MigrationInterface {
+    name = 'XExchange1715251449059';
+    transaction = false;
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+            ['MATERIALIZED_VIEW', 'sum_hourly', 'public'],
+        );
+        await queryRunner.query(`DROP MATERIALIZED VIEW "sum_hourly"`);
+        await queryRunner.query(`CREATE MATERIALIZED VIEW "sum_hourly" WITH (timescaledb.continuous) AS 
+    SELECT
+      time_bucket('1 hour', timestamp) AS time, series, key,
+      last(value, timestamp) AS last,sum(value) AS sum
+    FROM "hyper_dex_analytics"
+    WHERE key IN ('feesUSD', 'volumeUSD')
+    AND timestamp >= NOW() - INTERVAL '1 day'
+    GROUP BY time, series, key;
+  `);
+        await queryRunner.query(
+            `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+            [
+                'public',
+                'MATERIALIZED_VIEW',
+                'sum_hourly',
+                "SELECT\n      time_bucket('1 hour', timestamp) AS time, series, key,\n      last(value, timestamp) AS last,sum(value) AS sum\n    FROM \"hyper_dex_analytics\"\n    WHERE key IN ('feesUSD', 'volumeUSD')\n    AND timestamp >= NOW() - INTERVAL '1 day'\n    GROUP BY time, series, key;",
+            ],
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+            ['MATERIALIZED_VIEW', 'sum_hourly', 'public'],
+        );
+        await queryRunner.query(`DROP MATERIALIZED VIEW "sum_hourly"`);
+        await queryRunner.query(`CREATE MATERIALIZED VIEW "sum_hourly" WITH (timescaledb.continuous) AS SELECT
+      time_bucket('1 hour', timestamp) AS time, series, key,
+      last(value, timestamp) AS last,sum(value) AS sum
+    FROM "hyper_dex_analytics"
+    WHERE key = 'feesUSD' OR key = 'volumeUSD'
+    AND timestamp >= NOW() - INTERVAL '1 day'
+    GROUP BY time, series, key;`);
+        await queryRunner.query(
+            `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+            [
+                'public',
+                'MATERIALIZED_VIEW',
+                'sum_hourly',
+                "SELECT\n      time_bucket('1 hour', timestamp) AS time, series, key,\n      last(value, timestamp) AS last,sum(value) AS sum\n    FROM \"hyper_dex_analytics\"\n    WHERE key = 'feesUSD' OR key = 'volumeUSD'\n    AND timestamp >= NOW() - INTERVAL '1 day'\n    GROUP BY time, series, key;",
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## Reasoning
- the 'where' clause has both `OR` and `AND` operators without properly grouping them 
  

## Proposed Changes
- replace `key = 'x' OR or key = 'y'` operator with `key IN('x', 'y')` inside `where` clause for SumHourly timescaledb entity
- generate migration
- fix formatting


## How to test
N/A
