### PR TITLE
[MEX-414] Multi pair swap with swap function

### DIFF
--- a/src/modules/auto-router/specs/auto-router.service.spec.ts
+++ b/src/modules/auto-router/specs/auto-router.service.spec.ts
@@ -330,41 +330,13 @@ describe('AutoRouterService', () => {
             {
                 nonce: 0,
                 value: '0',
-                receiver: Address.fromHex(
-                    '0000000000000000000000000000000000000000000000000000000000000011',
-                ).bech32(),
+                receiver: Address.Zero().bech32(),
                 sender: '',
                 receiverUsername: undefined,
                 senderUsername: undefined,
                 gasPrice: 1000000000,
-                gasLimit: 2 * gasConfig.router.multiPairSwapMultiplier,
-                data: encodeTransactionData(
-                    `ESDTTransfer@USDC-123456@508044325756587816@multiPairSwap@${Address.fromHex(
-                        '0000000000000000000000000000000000000000000000000000000000000013',
-                    ).bech32()}@swapTokensFixedOutput@WEGLD-123456@630015438895@${Address.fromHex(
-                        '0000000000000000000000000000000000000000000000000000000000000012',
-                    ).bech32()}@swapTokensFixedOutput@MEX-123456@500000000000000000`,
-                ),
-                chainID: 'T',
-                version: 1,
-                options: undefined,
-                signature: undefined,
-                guardian: undefined,
-                guardianSignature: undefined,
-            },
-            {
-                nonce: 0,
-                value: '0',
-                receiver:
-                    'erd1qqqqqqqqqqqqqpgqd77fnev2sthnczp2lnfx0y5jdycynjfhzzgq6p3rax',
-                sender: '',
-                receiverUsername: undefined,
-                senderUsername: undefined,
-                gasPrice: 1000000000,
-                gasLimit: gasConfig.wrapeGLD,
-                data: encodeTransactionData(
-                    'ESDTTransfer@WEGLD-123456@500000000000000000@unwrapEgld',
-                ),
+                gasLimit: gasConfig.composableTasks.default,
+                data: 'RVNEVFRyYW5zZmVyQDU1NTM0NDQzMmQzMTMyMzMzNDM1MzZAMDcwY2VmOWY1ZWRmY2YyOEA2MzZmNmQ3MDZmNzM2NTU0NjE3MzZiNzNAMDAwMDAwMDQ0NTQ3NGM0NDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwODA2ZjA1YjU5ZDNiMjAwMDBAMDNAMDAwMDAwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEzMDAwMDAwMTU3Mzc3NjE3MDU0NmY2YjY1NmU3MzQ2Njk3ODY1NjQ0Zjc1NzQ3MDc1NzQwMDAwMDAwYzU3NDU0NzRjNDQyZDMxMzIzMzM0MzUzNjAwMDAwMDA1OTJhZmQ4YjAyZjAwMDAwMDIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMjAwMDAwMDE1NzM3NzYxNzA1NDZmNmI2NTZlNzM0NjY5Nzg2NTY0NGY3NTc0NzA3NTc0MDAwMDAwMGE0ZDQ1NTgyZDMxMzIzMzM0MzUzNjAwMDAwMDA4MDZmMDViNTlkM2IyMDAwMEAwMUA=',
                 chainID: 'T',
                 version: 1,
                 options: undefined,


### PR DESCRIPTION
## Reasoning
- compose tasks accepts both fixed input & fixed output for router swaps
  
## Proposed Changes
- updated composing tasks for multi pair swaps to generate transactions for both fixed input and fixed output swaps
- added multi pair swaps and unwrap EGLD composed tasks

## How to test
```
query EgldSwap {
	swap(
		tokenInID: <token_id>,
		tokenOutID: "EGLD",
		amountOut: "1000000000000000000",
		tolerance: 0.01
	) {
		tokenRoute
		intermediaryAmounts
		transactions {
			data
		}
	}
}
```
- query should return composable task with fixed output transactions