### PR TITLE
[SERVICES-2406] Filtered tokens query

### DIFF
--- a/src/modules/common/page.data.ts
+++ b/src/modules/common/page.data.ts
@@ -1,4 +1,4 @@
-import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { Field, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
 
 @ObjectType()
 export default class PageData {
@@ -11,3 +11,10 @@ export default class PageData {
     @Field(() => Int)
     public offset: number;
 }
+
+export enum SortingOrder {
+    ASC = 'ascending',
+    DESC = 'descending',
+}
+
+registerEnumType(SortingOrder, { name: 'SortingOrder' });

--- a/src/modules/tokens/models/tokens.filter.args.ts
+++ b/src/modules/tokens/models/tokens.filter.args.ts
@@ -1,4 +1,4 @@
-import { ArgsType, Field, InputType } from '@nestjs/graphql';
+import { ArgsType, Field, InputType, registerEnumType } from '@nestjs/graphql';
 import { SortingOrder } from 'src/modules/common/page.data';
 
 export enum TokensSortableFields {
@@ -8,6 +8,8 @@ export enum TokensSortableFields {
     PREVIOUS_24_VOLUME = 'previous_24h_volume',
     LIQUIDITY = 'liquidity',
 }
+
+registerEnumType(TokensSortableFields, { name: 'TokensSortableFields' });
 
 @ArgsType()
 export class TokensFiltersArgs {

--- a/src/modules/tokens/models/tokens.filter.args.ts
+++ b/src/modules/tokens/models/tokens.filter.args.ts
@@ -1,4 +1,13 @@
-import { ArgsType, Field } from '@nestjs/graphql';
+import { ArgsType, Field, InputType } from '@nestjs/graphql';
+import { SortingOrder } from 'src/modules/common/page.data';
+
+export enum TokensSortableFields {
+    PRICE = 'price',
+    PREVIOUS_24H_PRICE = 'previous_24h_price',
+    PREVIOUS_7D_PRICE = 'previous_7d_price',
+    PREVIOUS_24_VOLUME = 'previous_24h_volume',
+    LIQUIDITY = 'liquidity',
+}
 
 @ArgsType()
 export class TokensFiltersArgs {
@@ -8,4 +17,23 @@ export class TokensFiltersArgs {
     type: string;
     @Field({ defaultValue: false })
     enabledSwaps: boolean;
+}
+
+@InputType()
+export class TokensFilter {
+    @Field(() => [String], { nullable: true })
+    identifiers: string[];
+    @Field({ nullable: true })
+    type: string;
+    @Field({ defaultValue: false })
+    enabledSwaps: boolean;
+}
+
+@InputType()
+export class TokenSortingArgs {
+    @Field(() => TokensSortableFields, { nullable: true })
+    sortField?: string;
+
+    @Field(() => SortingOrder, { defaultValue: SortingOrder.ASC })
+    sortOrder: string;
 }

--- a/src/modules/tokens/models/tokens.response.ts
+++ b/src/modules/tokens/models/tokens.response.ts
@@ -1,0 +1,6 @@
+import { ObjectType } from '@nestjs/graphql';
+import relayTypes from 'src/utils/relay.types';
+import { EsdtToken } from './esdtToken.model';
+
+@ObjectType()
+export class TokensResponse extends relayTypes<EsdtToken>(EsdtToken) {}

--- a/src/modules/tokens/services/token.filtering.service.ts
+++ b/src/modules/tokens/services/token.filtering.service.ts
@@ -1,0 +1,44 @@
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
+import { TokenService } from './token.service';
+import { TokensFilter } from '../models/tokens.filter.args';
+
+@Injectable()
+export class TokenFilteringService {
+    constructor(
+        @Inject(forwardRef(() => TokenService))
+        private readonly tokenService: TokenService,
+    ) {}
+
+    tokensByIdentifier(
+        tokensFilter: TokensFilter,
+        tokenIDs: string[],
+    ): string[] {
+        if (
+            !tokensFilter.identifiers ||
+            tokensFilter.identifiers.length === 0
+        ) {
+            return tokenIDs;
+        }
+
+        return tokenIDs.filter((tokenID) =>
+            tokensFilter.identifiers.includes(tokenID),
+        );
+    }
+
+    async tokensByType(
+        tokensFilter: TokensFilter,
+        tokenIDs: string[],
+    ): Promise<string[]> {
+        if (!tokensFilter.type) {
+            return tokenIDs;
+        }
+
+        const filteredIDs = [];
+        for (const tokenID of tokenIDs) {
+            const tokenType = await this.tokenService.getEsdtTokenType(tokenID);
+
+            if (tokenType === tokensFilter.type) filteredIDs.push(tokenID);
+        }
+        return filteredIDs;
+    }
+}

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -220,6 +220,13 @@ export class TokenService {
                     ),
                 );
                 break;
+            case TokensSortableFields.LIQUIDITY:
+                sortFieldData = await Promise.all(
+                    tokenIDs.map((tokenID) =>
+                        this.tokenCompute.tokenLiquidityUSD(tokenID),
+                    ),
+                );
+                break;
 
             default:
                 break;

--- a/src/modules/tokens/specs/token.service.spec.ts
+++ b/src/modules/tokens/specs/token.service.spec.ts
@@ -12,6 +12,7 @@ import { MXApiService } from 'src/services/multiversx-communication/mx.api.servi
 import { Tokens } from 'src/modules/pair/mocks/pair.constants';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { TokenComputeServiceProvider } from '../mocks/token.compute.service.mock';
 
 describe('TokenService', () => {
     let module: TestingModule;
@@ -32,6 +33,7 @@ describe('TokenService', () => {
                 MXApiServiceProvider,
                 TokenService,
                 ApiConfigService,
+                TokenComputeServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/tokens/specs/token.service.spec.ts
+++ b/src/modules/tokens/specs/token.service.spec.ts
@@ -13,6 +13,7 @@ import { Tokens } from 'src/modules/pair/mocks/pair.constants';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { TokenComputeServiceProvider } from '../mocks/token.compute.service.mock';
+import { TokenFilteringService } from '../services/token.filtering.service';
 
 describe('TokenService', () => {
     let module: TestingModule;
@@ -34,6 +35,7 @@ describe('TokenService', () => {
                 TokenService,
                 ApiConfigService,
                 TokenComputeServiceProvider,
+                TokenFilteringService,
             ],
         }).compile();
     });

--- a/src/modules/tokens/token.module.ts
+++ b/src/modules/tokens/token.module.ts
@@ -14,6 +14,7 @@ import { NftCollectionResolver } from './nftCollection.resolver';
 import { NftTokenResolver } from './nftToken.resolver';
 import { AnalyticsModule } from 'src/services/analytics/analytics.module';
 import { ElasticService } from 'src/helpers/elastic.service';
+import { TokenFilteringService } from './services/token.filtering.service';
 
 @Module({
     imports: [
@@ -35,12 +36,14 @@ import { ElasticService } from 'src/helpers/elastic.service';
         NftCollectionResolver,
         NftTokenResolver,
         ElasticService,
+        TokenFilteringService,
     ],
     exports: [
         TokenRepositoryService,
         TokenService,
         TokenSetterService,
         TokenComputeService,
+        TokenFilteringService,
     ],
 })
 export class TokenModule {}

--- a/src/modules/tokens/token.resolver.ts
+++ b/src/modules/tokens/token.resolver.ts
@@ -2,12 +2,21 @@ import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AssetsModel } from './models/assets.model';
 import { EsdtToken } from './models/esdtToken.model';
 import { RolesModel } from './models/roles.model';
-import { TokensFiltersArgs } from './models/tokens.filter.args';
+import {
+    TokenSortingArgs,
+    TokensFilter,
+    TokensFiltersArgs,
+} from './models/tokens.filter.args';
 import { TokenService } from './services/token.service';
 import { GenericResolver } from '../../services/generics/generic.resolver';
 import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 import { TokenComputeService } from './services/token.compute.service';
+import { TokensResponse } from './models/tokens.response';
+import ConnectionArgs, {
+    getPagingParameters,
+} from '../common/filters/connection.args';
+import PageResponse from '../common/page.response';
 
 @Resolver(() => EsdtToken)
 export class TokensResolver extends GenericResolver {
@@ -95,5 +104,40 @@ export class TokensResolver extends GenericResolver {
                 },
             });
         }
+    }
+
+    @Query(() => TokensResponse)
+    async filteredTokens(
+        @Args({ name: 'filters', type: () => TokensFilter, nullable: true })
+        filters: TokensFilter,
+        @Args({
+            name: 'pagination',
+            type: () => ConnectionArgs,
+            nullable: true,
+        })
+        pagination: ConnectionArgs,
+        @Args({
+            name: 'sorting',
+            type: () => TokenSortingArgs,
+            nullable: true,
+        })
+        sorting: TokenSortingArgs,
+    ): Promise<TokensResponse> {
+        const { limit, offset } = getPagingParameters(pagination);
+
+        const response = await this.tokenService.getFilteredTokens(
+            offset,
+            limit,
+            filters,
+            sorting,
+        );
+
+        return PageResponse.mapResponse<EsdtToken>(
+            response?.items || [],
+            pagination ?? new ConnectionArgs(),
+            response?.count || 0,
+            offset,
+            limit,
+        );
     }
 }


### PR DESCRIPTION
## Reasoning
- provide a [Relay](https://relay.dev/)-compliant query for fetching tokens data 

  
## Proposed Changes
- create new `filterableTokens` query that follows the GraphQL "Connections" specification
- extract tokens filtering logic in a separate service

## How to test
```
query {
  filteredTokens(
    filters:{
      type:"Core"
      enabledSwaps:false
    }
    pagination:{
      first:150
    }
    sorting: {
      sortField:PREVIOUS_7D_PRICE
      sortOrder:DESC
    }
  ) {
    edges {
      cursor
      node {
        name
        identifier
        ticker
        type
        price
      	liquidityUSD
        previous7dPrice
      }
    }
    pageInfo {
      startCursor
      endCursor
      hasNextPage
      hasPreviousPage
    }
    pageData {
      count
      limit
      offset
    }
  }
}

```