### PR TITLE
[SERVICES-2347] Token volume previous 24h

### DIFF
--- a/src/modules/tokens/models/esdtToken.model.ts
+++ b/src/modules/tokens/models/esdtToken.model.ts
@@ -24,7 +24,7 @@ export class EsdtToken implements IEsdtToken {
     price?: string;
     previous24hPrice?: string;
     previous7dPrice?: string;
-    volumeUSD?: string;
+    volumeUSD24h?: string;
     previous24hVolume?: string;
     liquidityUSD?: string;
     supply?: string;

--- a/src/modules/tokens/models/esdtToken.model.ts
+++ b/src/modules/tokens/models/esdtToken.model.ts
@@ -24,7 +24,8 @@ export class EsdtToken implements IEsdtToken {
     price?: string;
     previous24hPrice?: string;
     previous7dPrice?: string;
-    volumeUSD24h?: string;
+    volumeUSD?: string;
+    previous24hVolume: string;
     liquidityUSD?: string;
     supply?: string;
     circulatingSupply?: string;

--- a/src/modules/tokens/models/esdtToken.model.ts
+++ b/src/modules/tokens/models/esdtToken.model.ts
@@ -25,7 +25,7 @@ export class EsdtToken implements IEsdtToken {
     previous24hPrice?: string;
     previous7dPrice?: string;
     volumeUSD?: string;
-    previous24hVolume: string;
+    previous24hVolume?: string;
     liquidityUSD?: string;
     supply?: string;
     circulatingSupply?: string;

--- a/src/modules/tokens/models/tokens.filter.args.ts
+++ b/src/modules/tokens/models/tokens.filter.args.ts
@@ -3,9 +3,10 @@ import { SortingOrder } from 'src/modules/common/page.data';
 
 export enum TokensSortableFields {
     PRICE = 'price',
+    VOLUME = 'volume',
     PREVIOUS_24H_PRICE = 'previous_24h_price',
     PREVIOUS_7D_PRICE = 'previous_7d_price',
-    PREVIOUS_24_VOLUME = 'previous_24h_volume',
+    PREVIOUS_24H_VOLUME = 'previous_24h_volume',
     LIQUIDITY = 'liquidity',
 }
 

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -274,11 +274,11 @@ export class TokenComputeService implements ITokenComputeService {
         remoteTtl: CacheTtlInfo.Token.remoteTtl,
         localTtl: CacheTtlInfo.Token.localTtl,
     })
-    async tokenVolumeUSD(tokenID: string): Promise<string> {
-        return await this.computeTokenVolumeUSD(tokenID);
+    async tokenVolumeUSD24h(tokenID: string): Promise<string> {
+        return await this.computeTokenVolumeUSD24h(tokenID);
     }
 
-    async computeTokenVolumeUSD(tokenID: string): Promise<string> {
+    async computeTokenVolumeUSD24h(tokenID: string): Promise<string> {
         const valuesLast2Days = await this.tokenLast2DaysVolumeUSD(tokenID);
         return valuesLast2Days.current;
     }

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -227,6 +227,20 @@ export class TokenService {
                     ),
                 );
                 break;
+            case TokensSortableFields.VOLUME:
+                sortFieldData = await Promise.all(
+                    tokenIDs.map((tokenID) =>
+                        this.tokenCompute.tokenVolumeUSD(tokenID),
+                    ),
+                );
+                break;
+            case TokensSortableFields.PREVIOUS_24H_VOLUME:
+                sortFieldData = await Promise.all(
+                    tokenIDs.map((tokenID) =>
+                        this.tokenCompute.tokenPrevious24hVolumeUSD(tokenID),
+                    ),
+                );
+                break;
 
             default:
                 break;

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -228,7 +228,7 @@ export class TokenService {
             case TokensSortableFields.VOLUME:
                 sortFieldData = await Promise.all(
                     tokenIDs.map((tokenID) =>
-                        this.tokenCompute.tokenVolumeUSD(tokenID),
+                        this.tokenCompute.tokenVolumeUSD24h(tokenID),
                     ),
                 );
                 break;

--- a/src/modules/tokens/services/token.setter.service.ts
+++ b/src/modules/tokens/services/token.setter.service.ts
@@ -67,6 +67,45 @@ export class TokenSetterService extends GenericSetterService {
         );
     }
 
+    async setVolumeLast2D(
+        tokenID: string,
+        value: { current: string; previous: string },
+    ): Promise<string> {
+        return await this.setData(
+            `token.tokenLast2DaysVolumeUSD.${tokenID}`,
+            value,
+            CacheTtlInfo.Token.remoteTtl,
+            CacheTtlInfo.Token.localTtl,
+        );
+    }
+
+    async setPricePrevious24h(tokenID: string, value: string): Promise<string> {
+        return await this.setData(
+            `token.tokenPrevious24hPrice.${tokenID}`,
+            value,
+            CacheTtlInfo.Price.remoteTtl,
+            CacheTtlInfo.Price.localTtl,
+        );
+    }
+
+    async setPricePrevious7d(tokenID: string, value: string): Promise<string> {
+        return await this.setData(
+            `token.tokenPrevious7dPrice.${tokenID}`,
+            value,
+            CacheTtlInfo.Price.remoteTtl,
+            CacheTtlInfo.Price.localTtl,
+        );
+    }
+
+    async setLiquidityUSD(tokenID: string, value: string): Promise<string> {
+        return await this.setData(
+            `token.tokenLiquidityUSD.${tokenID}`,
+            value,
+            CacheTtlInfo.Price.remoteTtl,
+            CacheTtlInfo.Price.localTtl,
+        );
+    }
+
     private getTokenCacheKey(tokenID: string, ...args: any): string {
         return generateCacheKeyFromParams('token', tokenID, args);
     }

--- a/src/modules/tokens/services/token.setter.service.ts
+++ b/src/modules/tokens/services/token.setter.service.ts
@@ -67,7 +67,7 @@ export class TokenSetterService extends GenericSetterService {
         );
     }
 
-    async setVolumeLast2D(
+    async setVolumeLast2Days(
         tokenID: string,
         value: { current: string; previous: string },
     ): Promise<string> {

--- a/src/modules/tokens/token.resolver.ts
+++ b/src/modules/tokens/token.resolver.ts
@@ -73,9 +73,16 @@ export class TokensResolver extends GenericResolver {
     }
 
     @ResolveField(() => String, { nullable: true })
-    async volumeUSD24h(@Parent() parent: EsdtToken): Promise<string> {
+    async volumeUSD(@Parent() parent: EsdtToken): Promise<string> {
         return await this.genericFieldResolver(() =>
-            this.tokenCompute.tokenVolumeUSD24h(parent.identifier),
+            this.tokenCompute.tokenVolumeUSD(parent.identifier),
+        );
+    }
+
+    @ResolveField(() => String, { nullable: true })
+    async previous24hVolume(@Parent() parent: EsdtToken): Promise<string> {
+        return await this.genericFieldResolver(() =>
+            this.tokenCompute.tokenPrevious24hVolumeUSD(parent.identifier),
         );
     }
 

--- a/src/modules/tokens/token.resolver.ts
+++ b/src/modules/tokens/token.resolver.ts
@@ -73,9 +73,9 @@ export class TokensResolver extends GenericResolver {
     }
 
     @ResolveField(() => String, { nullable: true })
-    async volumeUSD(@Parent() parent: EsdtToken): Promise<string> {
+    async volumeUSD24h(@Parent() parent: EsdtToken): Promise<string> {
         return await this.genericFieldResolver(() =>
-            this.tokenCompute.tokenVolumeUSD(parent.identifier),
+            this.tokenCompute.tokenVolumeUSD24h(parent.identifier),
         );
     }
 

--- a/src/services/analytics/interfaces/analytics.query.interface.ts
+++ b/src/services/analytics/interfaces/analytics.query.interface.ts
@@ -19,6 +19,8 @@ export interface AnalyticsQueryInterface {
 
     getValues24hSum(args: AnalyticsQueryArgs): Promise<HistoricDataModel[]>;
 
+    getHourlySumValues(args: AnalyticsQueryArgs): Promise<HistoricDataModel[]>;
+
     getPDlatestValue({
         series,
         metric,

--- a/src/services/analytics/mocks/analytics.query.service.mock.ts
+++ b/src/services/analytics/mocks/analytics.query.service.mock.ts
@@ -43,6 +43,9 @@ export class AnalyticsQueryServiceMock implements AnalyticsQueryInterface {
     getValues24hSum(args: AnalyticsQueryArgs): Promise<HistoricDataModel[]> {
         throw new Error('Method not implemented.');
     }
+    getHourlySumValues(args: AnalyticsQueryArgs): Promise<HistoricDataModel[]> {
+        throw new Error('Method not implemented.');
+    }
     getPriceCandles({
         series,
         metric,

--- a/src/services/analytics/services/analytics.query.service.ts
+++ b/src/services/analytics/services/analytics.query.service.ts
@@ -54,6 +54,16 @@ export class AnalyticsQueryService implements AnalyticsQueryInterface {
         return await service.getValues24hSum(args);
     }
 
+    async getHourlySumValues(args: {
+        series: any;
+        metric: any;
+        time?: any;
+        start?: any;
+    }): Promise<HistoricDataModel[]> {
+        const service = await this.getService();
+        return await service.getHourlySumValues(args);
+    }
+
     async getPDlatestValue({
         series,
         metric,

--- a/src/services/cache.warmer.module.ts
+++ b/src/services/cache.warmer.module.ts
@@ -35,6 +35,7 @@ import { ElasticService } from 'src/helpers/elastic.service';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { GovernanceCacheWarmerService } from './crons/governance.cache.warmer.service';
 import { GovernanceModule } from '../modules/governance/governance.module';
+import { TokensCacheWarmerService } from './crons/tokens.cache.warmer.service';
 
 @Module({
     imports: [
@@ -77,6 +78,7 @@ import { GovernanceModule } from '../modules/governance/governance.module';
         TransactionProcessorService,
         LogsProcessorService,
         ElasticService,
+        TokensCacheWarmerService,
     ],
 })
 export class CacheWarmerModule {}

--- a/src/services/crons/tokens.cache.warmer.service.ts
+++ b/src/services/crons/tokens.cache.warmer.service.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Lock } from '@multiversx/sdk-nestjs-common';
+import { PUB_SUB } from '../redis.pubSub.module';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { TokenService } from 'src/modules/tokens/services/token.service';
+import { PerformanceProfiler } from 'src/utils/performance.profiler';
+import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
+import { TokenSetterService } from 'src/modules/tokens/services/token.setter.service';
+
+@Injectable()
+export class TokensCacheWarmerService {
+    constructor(
+        private readonly tokenService: TokenService,
+        private readonly tokenComputeService: TokenComputeService,
+        private readonly tokenSetterService: TokenSetterService,
+        @Inject(PUB_SUB) private pubSub: RedisPubSub,
+        @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
+    ) {}
+
+    @Cron(CronExpression.EVERY_5_MINUTES)
+    @Lock({ name: 'cacheTokens', verbose: true })
+    async cacheTokens(): Promise<void> {
+        this.logger.info('Start refresh cached tokens data', {
+            context: 'CacheTokens',
+        });
+
+        const tokens = await this.tokenService.getUniqueTokenIDs(false);
+        const profiler = new PerformanceProfiler();
+
+        for (const tokenID of tokens) {
+            const [
+                volumeLast2D,
+                pricePrevious24h,
+                pricePrevious7D,
+                liquidityUSD,
+            ] = await Promise.all([
+                this.tokenComputeService.computeTokenLast2DaysVolumeUSD(
+                    tokenID,
+                ),
+                this.tokenComputeService.computeTokenPrevious24hPrice(tokenID),
+                this.tokenComputeService.computeTokenPrevious7dPrice(tokenID),
+                this.tokenComputeService.computeTokenLiquidityUSD(tokenID),
+            ]);
+
+            const cachedKeys = await Promise.all([
+                this.tokenSetterService.setVolumeLast2D(tokenID, volumeLast2D),
+                this.tokenSetterService.setPricePrevious24h(
+                    tokenID,
+                    pricePrevious24h,
+                ),
+                this.tokenSetterService.setPricePrevious7d(
+                    tokenID,
+                    pricePrevious7D,
+                ),
+                this.tokenSetterService.setLiquidityUSD(tokenID, liquidityUSD),
+            ]);
+            await this.deleteCacheKeys(cachedKeys);
+        }
+
+        profiler.stop();
+        this.logger.info(`Finish refresh tokens data in ${profiler.duration}`);
+    }
+
+    private async deleteCacheKeys(invalidatedKeys: string[]) {
+        await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
+    }
+}

--- a/src/services/crons/tokens.cache.warmer.service.ts
+++ b/src/services/crons/tokens.cache.warmer.service.ts
@@ -46,7 +46,10 @@ export class TokensCacheWarmerService {
             ]);
 
             const cachedKeys = await Promise.all([
-                this.tokenSetterService.setVolumeLast2D(tokenID, volumeLast2D),
+                this.tokenSetterService.setVolumeLast2Days(
+                    tokenID,
+                    volumeLast2D,
+                ),
                 this.tokenSetterService.setPricePrevious24h(
                     tokenID,
                     pricePrevious24h,


### PR DESCRIPTION
## Reasoning
- token volume and previous 24h volume is needed for trending score computation

  
## Proposed Changes
- add `previous24hVolume` field and resolver
- add getHourlySumValues timescaledb query accepting custom interval parameters
- compute volume for the 2 time windows using a single timescaledb query for the past 2 days, and splitting the results afterwards
- create tokens cache warmer cron service


## How to test
## How to test
```
query {
  tokens(
    identifiers: ["HTM-f51d55"],
  ) {
    identifier
    volumeUSD
    previous24hVolume
  }
}
```
