### PR TITLE
[MEX-480] energy position creator gas limit

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -390,7 +390,7 @@
             },
             "unstakeFarm": 18500000,
             "unbondFarm": 8000000,
-            "claimRewards": 10000000,
+            "claimRewards": 15000000,
             "claimBoostedRewards": 20000000,
             "claimRewardsWithNewValue": 7500000,
             "compoundRewards": 10000000,
@@ -512,7 +512,7 @@
                 "dualFarmPosition": 67000000,
                 "exitFarm": 50000000
             },
-            "energyPosition": 45000000
+            "energyPosition": 10000000
         },
         "composableTasks": {
             "default": 1000000

--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -709,6 +709,10 @@ export class PositionCreatorTransactionService {
             .integerValue();
 
         const swapRouteArgs = this.serializeSwapRouteArgs(swapRoute);
+        const gasLimit =
+            gasConfig.positionCreator.energyPosition +
+            gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
+                swapRoute.pairs.length;
 
         const contract =
             await this.mxProxy.getLockedTokenPositionCreatorContract();
@@ -720,7 +724,7 @@ export class PositionCreatorTransactionService {
                 ...swapRouteArgs,
             ])
             .withSender(Address.fromBech32(sender))
-            .withGasLimit(gasConfig.positionCreator.energyPosition)
+            .withGasLimit(gasLimit)
             .withChainID(mxConfig.chainID);
 
         if (payment.tokenIdentifier === mxConfig.EGLDIdentifier) {

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -2268,7 +2268,7 @@ describe('PositionCreatorTransaction', () => {
                     data: encodeTransactionData(
                         'ESDTTransfer@WEGLD-123456@1000000000000000000@createEnergyPosition@1440@986046911229504184328@0000000000000000000000000000000000000000000000000000000000000012@swapTokensFixedInput@MEX-123456@986046911229504184328',
                     ),
-                    gasLimit: gasConfig.positionCreator.energyPosition,
+                    gasLimit: 40000000,
                     gasPrice: 1000000000,
                     guardian: undefined,
                     guardianSignature: undefined,
@@ -2320,7 +2320,7 @@ describe('PositionCreatorTransaction', () => {
                     data: encodeTransactionData(
                         'createEnergyPosition@1440@986046911229504184328@0000000000000000000000000000000000000000000000000000000000000012@swapTokensFixedInput@MEX-123456@986046911229504184328',
                     ),
-                    gasLimit: gasConfig.positionCreator.energyPosition,
+                    gasLimit: 40000000,
                     gasPrice: 1000000000,
                     guardian: undefined,
                     guardianSignature: undefined,


### PR DESCRIPTION
## Reasoning
- transaction generation for energy position creator used a default gas limit value
  
## Proposed Changes
- computed energy position creator transaction gas limit based on swap routes

## How to test
```
query EnergyPosition {
    createEnergyPosition(
        payment: {
            tokenID: "EGLD",
            nonce: 0,
            amount: "1000000000000000000"
        },
        tolerance: 0.01
    ) {
        transactions {
            gasLimit
            data
        }
    }
}
```
- query should return a gas limit based on default gas(10,000,000) + swapRoutes * 30,000,000