### PR TITLE
[SERVICES-2457] Extra fields on Pair model for previous 24h data (fees, volume, liquidity)

### DIFF
--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -80,6 +80,9 @@ export class PairModel {
     lockedValueUSD: string;
 
     @Field()
+    previous24hLockedValueUSD: string;
+
+    @Field()
     firstTokenVolume24h: string;
 
     @Field()
@@ -89,7 +92,13 @@ export class PairModel {
     volumeUSD24h: string;
 
     @Field()
+    previous24hVolumeUSD: string;
+
+    @Field()
     feesUSD24h: string;
+
+    @Field()
+    previous24hFeesUSD: string;
 
     @Field()
     feesAPR: string;

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -99,6 +99,13 @@ export class PairResolver {
     }
 
     @ResolveField()
+    async previous24hLockedValueUSD(
+        @Parent() parent: PairModel,
+    ): Promise<string> {
+        return this.pairCompute.previous24hLockedValueUSD(parent.address);
+    }
+
+    @ResolveField()
     async firstTokenVolume24h(@Parent() parent: PairModel): Promise<string> {
         return this.pairCompute.firstTokenVolume(parent.address, '24h');
     }
@@ -114,8 +121,18 @@ export class PairResolver {
     }
 
     @ResolveField()
+    async previous24hVolumeUSD(@Parent() parent: PairModel): Promise<string> {
+        return this.pairCompute.previous24hVolumeUSD(parent.address);
+    }
+
+    @ResolveField()
     async feesUSD24h(@Parent() parent: PairModel): Promise<string> {
         return this.pairCompute.feesUSD(parent.address, '24h');
+    }
+
+    @ResolveField()
+    async previous24hFeesUSD(@Parent() parent: PairModel): Promise<string> {
+        return this.pairCompute.previous24hFeesUSD(parent.address);
     }
 
     @ResolveField()

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -340,6 +340,29 @@ export class PairComputeService implements IPairComputeService {
     })
     @GetOrSetCache({
         baseKey: 'pair',
+        remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
+        localTtl: CacheTtlInfo.ContractInfo.localTtl,
+    })
+    async previous24hLockedValueUSD(pairAddress: string): Promise<string> {
+        return await this.computePrevious24hLockedValueUSD(pairAddress);
+    }
+
+    async computePrevious24hLockedValueUSD(
+        pairAddress: string,
+    ): Promise<string> {
+        const values24h = await this.analyticsQuery.getValues24h({
+            series: pairAddress,
+            metric: 'lockedValueUSD',
+        });
+
+        return values24h[0]?.value ?? undefined;
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'pair',
         remoteTtl: CacheTtlInfo.Analytics.remoteTtl,
         localTtl: CacheTtlInfo.Analytics.localTtl,
     })
@@ -421,6 +444,26 @@ export class PairComputeService implements IPairComputeService {
         remoteTtl: CacheTtlInfo.Analytics.remoteTtl,
         localTtl: CacheTtlInfo.Analytics.localTtl,
     })
+    async previous24hVolumeUSD(pairAddress: string): Promise<string> {
+        return await this.computePrevious24hVolumeUSD(pairAddress);
+    }
+
+    async computePrevious24hVolumeUSD(pairAddress: string): Promise<string> {
+        const [volume24h, volume48h] = await Promise.all([
+            this.volumeUSD(pairAddress, '24h'),
+            this.volumeUSD(pairAddress, '48h'),
+        ]);
+        return new BigNumber(volume48h).minus(volume24h).toFixed();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'pair',
+        remoteTtl: CacheTtlInfo.Analytics.remoteTtl,
+        localTtl: CacheTtlInfo.Analytics.localTtl,
+    })
     async feesUSD(pairAddress: string, time: string): Promise<string> {
         return await this.computeFeesUSD(pairAddress, time);
     }
@@ -435,6 +478,26 @@ export class PairComputeService implements IPairComputeService {
             metric: 'feesUSD',
             time,
         });
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'pair',
+        remoteTtl: CacheTtlInfo.Analytics.remoteTtl,
+        localTtl: CacheTtlInfo.Analytics.localTtl,
+    })
+    async previous24hFeesUSD(pairAddress: string): Promise<string> {
+        return await this.computePrevious24hFeesUSD(pairAddress);
+    }
+
+    async computePrevious24hFeesUSD(pairAddress: string): Promise<string> {
+        const [fees24h, fees48h] = await Promise.all([
+            this.feesUSD(pairAddress, '24h'),
+            this.feesUSD(pairAddress, '48h'),
+        ]);
+        return new BigNumber(fees48h).minus(fees24h).toFixed();
     }
 
     @ErrorLoggerAsync({


### PR DESCRIPTION
## Reasoning
- compute and display % change over the past 24 hours for pair volume, fees and liquidity

  
## Proposed Changes
- add fields and resolvers on Pair model : `previous24hLockedValueUSD`, `previous24hVolumeUSD`, `previous24hFeesUSD`
- add compute methods and caching for new fields


## How to test
```
query {
  filteredPairs(
    filters:{
    }
    pagination:{
      first:200
    }
    sorting: {
      sortField:TRADES_COUNT
      sortOrder:DESC
    }
  ) {
    edges {
      cursor
      node {
        address
        firstToken {
          identifier
        }
        secondToken {
          identifier
        }
        feesUSD24h
        previous24hFeesUSD
        volumeUSD24h
        previous24hVolumeUSD
        lockedValueUSD
       	previous24hLockedValueUSD
      }
    }
    pageInfo {
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
