### PR TITLE
[SERVICES-2464] Add hourly values for global TVL from past 24h to AWS query cache warmer

### DIFF
--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -207,7 +207,11 @@ export class AWSQueryCacheWarmerService {
                 series: 'factory',
                 metric: 'totalLockedValueUSD',
             });
-
+        await delay(1000);
+        const totalLockedValueUSD24h = await this.analyticsQuery.getValues24h({
+            series: 'factory',
+            metric: 'totalLockedValueUSD',
+        });
         const factoryKeys = await Promise.all([
             this.analyticsAWSSetter.setSumCompleteValues(
                 'factory',
@@ -223,6 +227,11 @@ export class AWSQueryCacheWarmerService {
                 'factory',
                 'totalLockedValueUSD',
                 totalLockedValueUSD,
+            ),
+            this.analyticsAWSSetter.setValues24h(
+                'factory',
+                'totalLockedValueUSD',
+                totalLockedValueUSD24h,
             ),
         ]);
 


### PR DESCRIPTION
## Reasoning
- running the analytics query `values24h (series: "factory", metric: "totalLockedValueUSD")` returns empy array

  
## Proposed Changes
- add timescaleDB query for missing data in aws query cache warmer

## How to test
Query below should return an array with the values for the past 24h 
```
query {
  values24h (
    series: "factory", 
    metric: "totalLockedValueUSD"
  ) {
    timestamp
    value
  }
}
```
