### PR TITLE
[SERVICES-2465] Fix tokens previous 7 days price

### DIFF
--- a/src/modules/tokens/models/tokens.filter.args.ts
+++ b/src/modules/tokens/models/tokens.filter.args.ts
@@ -7,6 +7,7 @@ export enum TokensSortableFields {
     PREVIOUS_24H_PRICE = 'previous_24h_price',
     PREVIOUS_7D_PRICE = 'previous_7d_price',
     PREVIOUS_24H_VOLUME = 'previous_24h_volume',
+    PRICE_CHANGE_7D = 'price_change_7d',
     PRICE_CHANGE_24H = 'price_change_24h',
     VOLUME_CHANGE_24H = 'volume_change_24h',
     TRADES_COUNT_CHANGE_24H = 'trades_count_change_24h',

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -291,7 +291,6 @@ export class TokenComputeService implements ITokenComputeService {
         const previous7dPriceBN = new BigNumber(previous7dPrice);
 
         if (previous7dPriceBN.isZero()) {
-            console.log(tokenID, 0);
             return 0;
         }
 

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -281,6 +281,23 @@ export class TokenComputeService implements ITokenComputeService {
         return currentPriceBN.dividedBy(previous24hPrice).toNumber();
     }
 
+    async computeTokenPriceChange7d(tokenID: string): Promise<number> {
+        const [currentPrice, previous7dPrice] = await Promise.all([
+            this.tokenPriceDerivedUSD(tokenID),
+            this.tokenPrevious7dPrice(tokenID),
+        ]);
+
+        const currentPriceBN = new BigNumber(currentPrice);
+        const previous7dPriceBN = new BigNumber(previous7dPrice);
+
+        if (previous7dPriceBN.isZero()) {
+            console.log(tokenID, 0);
+            return 0;
+        }
+
+        return currentPriceBN.dividedBy(previous7dPriceBN).toNumber();
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -228,6 +228,13 @@ export class TokenService {
                     ),
                 );
                 break;
+            case TokensSortableFields.PRICE_CHANGE_7D:
+                sortFieldData = await Promise.all(
+                    tokenIDs.map((tokenID) =>
+                        this.tokenCompute.computeTokenPriceChange7d(tokenID),
+                    ),
+                );
+                break;
             case TokensSortableFields.PRICE_CHANGE_24H:
                 sortFieldData = await Promise.all(
                     tokenIDs.map((tokenID) =>

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -127,7 +127,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
                 .select("time_bucket_gapfill('1 day', time) as day")
                 .addSelect(
                     `locf(last(last, time) ${
-                        start ? `, (${previousValue.getQuery()})` : ''
+                        start || time ? `, (${previousValue.getQuery()})` : ''
                     }) as last`,
                 )
                 .where('series = :series', { series })


### PR DESCRIPTION
## Reasoning
- the `previous7dPrice` field on the EsdtToken model is currently returning 0 for all tokens
- sorting by 7 days price change is required by the front-end 
  
## Proposed Changes
- fix `getLatestCompleteValues` timescaledb query (it should use a subquery when `start` or `time` parameters are provided) 
- add compute method for price change over the last 7 days
- add sorting by the price change over 7 days to `filteredTokens` query

## How to test
- Query should correctly order the tokens, and the field `previous7dPrice` should have non-zero values on core tokens 
```
query {
  filteredTokens(
    filters:{}
    pagination:{
      first:200
    }
    sorting: {
      sortField:PRICE_CHANGE_7D
      sortOrder:DESC
    }
  ) {
    edges {
      cursor
      node {
        identifier
        price
        previous7dPrice
      }
    }
    pageInfo {
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
