### PR TITLE
[SERVICES-2466] Fix 'hasPreviousPage' field on paginated queries

### DIFF
--- a/src/modules/common/page.response.ts
+++ b/src/modules/common/page.response.ts
@@ -13,6 +13,10 @@ export default class PageResponse {
             arrayLength: count,
             sliceStart: offset || 0,
         });
+
+        page.pageInfo.hasPreviousPage =
+            page.edges.length > 0 && offset > 0 && offset < count;
+        page.pageInfo.hasNextPage = page.edges.length + offset < count;
         return {
             edges: page.edges,
             pageInfo: page.pageInfo,


### PR DESCRIPTION
## Reasoning
- the `hasPreviousPage` field of the PageInfo model on paginated queries is always false
  
## Proposed Changes
- override the values provided by the util function `connectionFromArraySlice` from the [graphql-relay](https://github.com/graphql/graphql-relay-js) package

## How to test
A paginated query (`filteredTokens` / `filteredPairs` / `filteredStakingFarms`) using forward cursor pagination like below, should correctly return `true` for the `hasPreviousPage` field 
```
query {
  filteredTokens(
    filters:{}
    pagination:{
      first:10
      after:"YXJyYXljb25uZWN0aW9uOjk="
    }
  ) {
    edges {
      cursor
      node {
        identifier
        price
      }
    }
    pageInfo {
      hasNextPage
      hasPreviousPage
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
