### PR TITLE
[SERVICES-2468] Analytics queries improvements

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -593,7 +593,8 @@
         "trendingScore": {
           "MIN_24H_VOLUME": 10000,
           "MIN_24H_TRADE_COUNT": 100
-        }
+        },
+        "AWS_QUERY_CACHE_WARMER_DELAY": 200
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -594,7 +594,7 @@
           "MIN_24H_VOLUME": 10000,
           "MIN_24H_TRADE_COUNT": 100
         },
-        "AWS_QUERY_CACHE_WARMER_DELAY": 200
+        "AWS_QUERY_CACHE_WARMER_DELAY": 100
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -109,6 +109,8 @@ export class AnalyticsResolver {
         return this.analyticsAWSGetter.getSumCompleteValues(
             args.series,
             args.metric,
+            args.start,
+            args.time,
         );
     }
 

--- a/src/modules/analytics/services/analytics.aws.getter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.getter.service.ts
@@ -29,41 +29,17 @@ export class AnalyticsAWSGetterService {
             series,
             metric,
         );
-        let data = await this.getCachedData<HistoricDataModel[]>(cacheKey);
-        if (data === undefined) {
-            return [];
-        }
+        const data = await this.getCachedData<HistoricDataModel[]>(cacheKey);
 
-        if (start) {
-            const formattedStart = moment.unix(parseInt(start)).utc();
-
-            data = data.filter((historicData) =>
-                moment
-                    .utc(historicData.timestamp)
-                    .isSameOrAfter(formattedStart),
-            );
-
-            if (time) {
-                const [timeAmount, timeUnit] = time.match(/[a-zA-Z]+|[0-9]+/g);
-                const endDate = formattedStart.add(
-                    moment.duration(
-                        timeAmount,
-                        timeUnit as moment.unitOfTime.Base,
-                    ),
-                );
-                data = data.filter((historicData) =>
-                    moment.utc(historicData.timestamp).isSameOrBefore(endDate),
-                );
-            }
-        }
-
-        return data;
+        return this.filterDataByTimeWindow(data, start, time);
     }
 
     @ErrorLoggerAsync()
     async getSumCompleteValues(
         series: string,
         metric: string,
+        start?: string,
+        time?: string,
     ): Promise<HistoricDataModel[]> {
         const cacheKey = this.getAnalyticsCacheKey(
             'sumCompleteValues',
@@ -71,7 +47,41 @@ export class AnalyticsAWSGetterService {
             metric,
         );
         const data = await this.getCachedData<HistoricDataModel[]>(cacheKey);
-        return data !== undefined ? data : [];
+
+        return this.filterDataByTimeWindow(data, start, time);
+    }
+
+    private filterDataByTimeWindow(
+        data: HistoricDataModel[],
+        start?: string,
+        time?: string,
+    ): HistoricDataModel[] {
+        if (data === undefined) {
+            return [];
+        }
+
+        if (!start) {
+            return data;
+        }
+
+        const formattedStart = moment.unix(parseInt(start)).utc();
+
+        const result = data.filter((historicData) =>
+            moment.utc(historicData.timestamp).isSameOrAfter(formattedStart),
+        );
+
+        if (!time) {
+            return result;
+        }
+
+        const [timeAmount, timeUnit] = time.match(/[a-zA-Z]+|[0-9]+/g);
+        const endDate = formattedStart.add(
+            moment.duration(timeAmount, timeUnit as moment.unitOfTime.Base),
+        );
+
+        return result.filter((historicData) =>
+            moment.utc(historicData.timestamp).isSameOrBefore(endDate),
+        );
     }
 
     @ErrorLoggerAsync()

--- a/src/services/analytics/timescaledb/entities/timescaledb.entities.ts
+++ b/src/services/analytics/timescaledb/entities/timescaledb.entities.ts
@@ -124,7 +124,7 @@ export class SumHourly {
       key,
       last(value, timestamp) as last
     FROM "hyper_dex_analytics"
-    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD')
+    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD', 'firstTokenPrice', 'secondTokenPrice')
     GROUP BY time, series, key;
   `,
     materialized: true,
@@ -157,7 +157,7 @@ export class CloseDaily {
       key,
       last(value, timestamp) as last
     FROM "hyper_dex_analytics"
-    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD')
+    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD', 'firstTokenPrice', 'secondTokenPrice')
     AND timestamp >= NOW() - INTERVAL '1 day'
     GROUP BY time, series, key;
   `,

--- a/src/services/analytics/timescaledb/migration/1718807173692-xExchange.ts
+++ b/src/services/analytics/timescaledb/migration/1718807173692-xExchange.ts
@@ -1,0 +1,106 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class XExchange1718807173692 implements MigrationInterface {
+    name = 'XExchange1718807173692';
+    transaction = false;
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+            ['MATERIALIZED_VIEW', 'close_hourly', 'public'],
+        );
+        await queryRunner.query(`DROP MATERIALIZED VIEW "close_hourly"`);
+        await queryRunner.query(
+            `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+            ['MATERIALIZED_VIEW', 'close_daily', 'public'],
+        );
+        await queryRunner.query(`DROP MATERIALIZED VIEW "close_daily"`);
+        await queryRunner.query(`CREATE MATERIALIZED VIEW "close_daily" WITH (timescaledb.continuous) AS
+    SELECT 
+      time_bucket('1 day', timestamp) as time,
+      series,
+      key,
+      last(value, timestamp) as last
+    FROM "hyper_dex_analytics"
+    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD', 'firstTokenPrice', 'secondTokenPrice')
+    GROUP BY time, series, key;
+  `);
+        await queryRunner.query(
+            `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+            [
+                'public',
+                'MATERIALIZED_VIEW',
+                'close_daily',
+                "SELECT \n      time_bucket('1 day', timestamp) as time,\n      series,\n      key,\n      last(value, timestamp) as last\n    FROM \"hyper_dex_analytics\"\n    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD', 'firstTokenPrice', 'secondTokenPrice')\n    GROUP BY time, series, key;",
+            ],
+        );
+        await queryRunner.query(`CREATE MATERIALIZED VIEW "close_hourly" WITH (timescaledb.continuous) AS
+    SELECT 
+      time_bucket('1 hour', timestamp) as time,
+      series,
+      key,
+      last(value, timestamp) as last
+    FROM "hyper_dex_analytics"
+    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD', 'firstTokenPrice', 'secondTokenPrice')
+    AND timestamp >= NOW() - INTERVAL '1 day'
+    GROUP BY time, series, key;
+  `);
+        await queryRunner.query(
+            `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+            [
+                'public',
+                'MATERIALIZED_VIEW',
+                'close_hourly',
+                "SELECT \n      time_bucket('1 hour', timestamp) as time,\n      series,\n      key,\n      last(value, timestamp) as last\n    FROM \"hyper_dex_analytics\"\n    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD', 'firstTokenPrice', 'secondTokenPrice')\n    AND timestamp >= NOW() - INTERVAL '1 day'\n    GROUP BY time, series, key;",
+            ],
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+            ['MATERIALIZED_VIEW', 'close_hourly', 'public'],
+        );
+        await queryRunner.query(`DROP MATERIALIZED VIEW "close_hourly"`);
+        await queryRunner.query(
+            `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+            ['MATERIALIZED_VIEW', 'close_daily', 'public'],
+        );
+        await queryRunner.query(`DROP MATERIALIZED VIEW "close_daily"`);
+        await queryRunner.query(`CREATE MATERIALIZED VIEW "close_daily" WITH (timescaledb.continuous) AS SELECT 
+      time_bucket('1 day', timestamp) as time,
+      series,
+      key,
+      last(value, timestamp) as last
+    FROM "hyper_dex_analytics"
+    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD')
+    GROUP BY time, series, key;`);
+        await queryRunner.query(
+            `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+            [
+                'public',
+                'MATERIALIZED_VIEW',
+                'close_daily',
+                "SELECT \n      time_bucket('1 day', timestamp) as time,\n      series,\n      key,\n      last(value, timestamp) as last\n    FROM \"hyper_dex_analytics\"\n    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD')\n    GROUP BY time, series, key;",
+            ],
+        );
+        await queryRunner.query(`CREATE MATERIALIZED VIEW "close_hourly" WITH (timescaledb.continuous) AS SELECT 
+      time_bucket('1 hour', timestamp) as time,
+      series,
+      key,
+      last(value, timestamp) as last
+    FROM "hyper_dex_analytics"
+    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD')
+    AND timestamp >= NOW() - INTERVAL '1 day'
+    GROUP BY time, series, key;`);
+        await queryRunner.query(
+            `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+            [
+                'public',
+                'MATERIALIZED_VIEW',
+                'close_hourly',
+                "SELECT \n      time_bucket('1 hour', timestamp) as time,\n      series,\n      key,\n      last(value, timestamp) as last\n    FROM \"hyper_dex_analytics\"\n    WHERE key IN ('priceUSD', 'liquidityUSD', 'lockedValueUSD', 'totalLockedValueUSD')\n    AND timestamp >= NOW() - INTERVAL '1 day'\n    GROUP BY time, series, key;",
+            ],
+        );
+    }
+}

--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -12,6 +12,7 @@ import { AnalyticsQueryService } from '../analytics/services/analytics.query.ser
 import { PUB_SUB } from '../redis.pubSub.module';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 import { Lock } from '@multiversx/sdk-nestjs-common';
+import { constantsConfig } from 'src/config';
 
 @Injectable()
 export class AWSQueryCacheWarmerService {
@@ -40,35 +41,35 @@ export class AWSQueryCacheWarmerService {
                 series: tokenID,
                 metric: 'priceUSD',
             });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const priceUSDCompleteValues =
                 await this.analyticsQuery.getLatestCompleteValues({
                     series: tokenID,
                     metric: 'priceUSD',
                 });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const lockedValueUSD24h = await this.analyticsQuery.getValues24h({
                 series: tokenID,
                 metric: 'lockedValueUSD',
             });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const lockedValueUSDCompleteValues =
                 await this.analyticsQuery.getLatestCompleteValues({
                     series: tokenID,
                     metric: 'lockedValueUSD',
                 });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const volumeUSD24hSum = await this.analyticsQuery.getValues24hSum({
                 series: tokenID,
                 metric: 'volumeUSD',
             });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const volumeUSDCompleteValuesSum =
                 await this.analyticsQuery.getSumCompleteValues({
                     series: tokenID,
                     metric: 'volumeUSD',
                 });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
 
             const cachedKeys = await Promise.all([
                 this.analyticsAWSSetter.setValues24h(
@@ -125,35 +126,57 @@ export class AWSQueryCacheWarmerService {
                 series: pairAddress,
                 metric: 'lockedValueUSD',
             });
-            delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
+            const firstTokenPrice24h = await this.analyticsQuery.getValues24h({
+                series: pairAddress,
+                metric: 'firstTokenPrice',
+            });
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
+            const secondTokenPrice24h = await this.analyticsQuery.getValues24h({
+                series: pairAddress,
+                metric: 'secondTokenPrice',
+            });
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const lockedValueUSDCompleteValues =
                 await this.analyticsQuery.getLatestCompleteValues({
                     series: pairAddress,
                     metric: 'lockedValueUSD',
                 });
-            delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const feesUSD = await this.analyticsQuery.getValues24hSum({
                 series: pairAddress,
                 metric: 'feesUSD',
             });
-            delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const volumeUSD24hSum = await this.analyticsQuery.getValues24hSum({
                 series: pairAddress,
                 metric: 'volumeUSD',
             });
-            delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const volumeUSDCompleteValuesSum =
                 await this.analyticsQuery.getSumCompleteValues({
                     series: pairAddress,
                     metric: 'volumeUSD',
                 });
-            delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const feesUSDCompleteValuesSum =
                 await this.analyticsQuery.getSumCompleteValues({
                     series: pairAddress,
                     metric: 'feesUSD',
                 });
-            delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
+            const firstTokenPriceCompleteValues =
+                await this.analyticsQuery.getLatestCompleteValues({
+                    series: pairAddress,
+                    metric: 'firstTokenPrice',
+                });
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
+            const secondTokenPriceCompleteValues =
+                await this.analyticsQuery.getLatestCompleteValues({
+                    series: pairAddress,
+                    metric: 'secondTokenPrice',
+                });
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
 
             const cachedKeys = await Promise.all([
                 this.analyticsAWSSetter.setValues24h(
@@ -186,6 +209,26 @@ export class AWSQueryCacheWarmerService {
                     'feesUSD',
                     feesUSDCompleteValuesSum,
                 ),
+                this.analyticsAWSSetter.setValues24h(
+                    pairAddress,
+                    'firstTokenPrice',
+                    firstTokenPrice24h,
+                ),
+                this.analyticsAWSSetter.setValues24h(
+                    pairAddress,
+                    'secondTokenPrice',
+                    secondTokenPrice24h,
+                ),
+                this.analyticsAWSSetter.setLatestCompleteValues(
+                    pairAddress,
+                    'firstTokenPrice',
+                    firstTokenPriceCompleteValues,
+                ),
+                this.analyticsAWSSetter.setLatestCompleteValues(
+                    pairAddress,
+                    'secondTokenPrice',
+                    secondTokenPriceCompleteValues,
+                ),
             ]);
             await this.deleteCacheKeys(cachedKeys);
         }
@@ -195,13 +238,13 @@ export class AWSQueryCacheWarmerService {
                 series: 'erd1%',
                 metric: 'volumeUSD',
             });
-        await delay(1000);
+        await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
         const allPairsVolumeUSD24hSum =
             await this.analyticsQuery.getValues24hSum({
                 series: 'erd1%',
                 metric: 'volumeUSD',
             });
-        await delay(1000);
+        await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
         const totalLockedValueUSD =
             await this.analyticsQuery.getLatestCompleteValues({
                 series: 'factory',

--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -250,7 +250,7 @@ export class AWSQueryCacheWarmerService {
                 series: 'factory',
                 metric: 'totalLockedValueUSD',
             });
-        await delay(1000);
+        await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
         const totalLockedValueUSD24h = await this.analyticsQuery.getValues24h({
             series: 'factory',
             metric: 'totalLockedValueUSD',


### PR DESCRIPTION
## Reasoning
- expose daily and hourly price analytics for pairs tokens
- allow filtering complete daily analtytics by a specific time window
  
## Proposed Changes
- add 'firstTokenPrice' and 'secondTokenPrice' metrics to `CloseDaily` and `CloseHourly` aggregates
- generate postgres migration
- cache complete daily and 24h hourly data for pair tokens prices
- create constant for delay value used in aws query cache warmer
- enable filtering by time window on `sumCompleteValues` query

## How to test
- Run migrations : `npm run typeorm:run-migrations`
- Get last 24h pair token price  :
```
query {
  values24h(
    series: "erd1qqqqqqqqqqqqqpgq4zafu6rzdw7fj07hjh5tkm68jsaj7hl60n4s8py4ra", 
    metric:"firstTokenPrice"
  ) {
    timestamp
    value
  }
}
```
- Get daily pair token price for past 7 days :
```
latestCompleteValues(
    series: "erd1qqqqqqqqqqqqqpgq4zafu6rzdw7fj07hjh5tkm68jsaj7hl60n4s8py4ra", 
    metric: "firstTokenPrice"
    start:"1718289125"
  ) {
    timestamp
    value
  }
```
- Get volume for `RIDE-05b1bb` for the past 7 days :
```
query {
  sumCompleteValues(
    series: "RIDE-05b1bb", 
    metric:"volumeUSD"
    start:"1718299125"
	) {
    timestamp
    value
  }
}
```

