### PR TITLE
[SERVICES-2469] Sorting pairs by APRs

### DIFF
--- a/src/modules/farm/v2/services/farm.v2.compute.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.compute.service.ts
@@ -29,6 +29,7 @@ export class FarmComputeServiceV2
         protected readonly farmAbi: FarmAbiServiceV2,
         @Inject(forwardRef(() => FarmServiceV2))
         protected readonly farmService: FarmServiceV2,
+        @Inject(forwardRef(() => PairService))
         protected readonly pairService: PairService,
         @Inject(forwardRef(() => PairComputeService))
         protected readonly pairCompute: PairComputeService,

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -23,6 +23,8 @@ import { MXApiService } from 'src/services/multiversx-communication/mx.api.servi
 import { FarmVersion } from 'src/modules/farm/models/farm.model';
 import { FarmAbiServiceV2 } from 'src/modules/farm/v2/services/farm.v2.abi.service';
 import { TransactionStatus } from 'src/utils/transaction.utils';
+import { FarmComputeServiceV2 } from 'src/modules/farm/v2/services/farm.v2.compute.service';
+import { StakingComputeService } from 'src/modules/staking/services/staking.compute.service';
 
 @Injectable()
 export class PairComputeService implements IPairComputeService {
@@ -42,6 +44,8 @@ export class PairComputeService implements IPairComputeService {
         private readonly stakingProxyAbiService: StakingProxyAbiService,
         private readonly elasticService: ElasticService,
         private readonly apiService: MXApiService,
+        private readonly farmCompute: FarmComputeServiceV2,
+        private readonly stakingCompute: StakingComputeService,
     ) {}
 
     async getTokenPrice(pairAddress: string, tokenID: string): Promise<string> {
@@ -770,5 +774,57 @@ export class PairComputeService implements IPairComputeService {
         return await this.stakingProxyAbiService.stakingFarmAddress(
             stakingProxyAddresses[stakingProxyIndex],
         );
+    }
+
+    async computeCompoundedApr(pairAddress: string): Promise<string> {
+        const [feesAPR, farmAddress, stakingFarmAddress] = await Promise.all([
+            this.feesAPR(pairAddress),
+            this.getPairFarmAddress(pairAddress),
+            this.getPairStakingFarmAddress(pairAddress),
+        ]);
+
+        let feesAprBN = new BigNumber(feesAPR);
+        let farmBaseAprBN = new BigNumber('0');
+        let farmBoostedAprBN = new BigNumber('0');
+        let dualFarmBaseAprBN = new BigNumber('0');
+
+        if (farmAddress) {
+            const [farmBaseAPR, farmBoostedAPR] = await Promise.all([
+                this.farmCompute.farmBaseAPR(farmAddress),
+                this.farmCompute.maxBoostedApr(farmAddress),
+            ]);
+
+            farmBaseAprBN = new BigNumber(farmBaseAPR);
+            farmBoostedAprBN = new BigNumber(farmBoostedAPR);
+
+            if (farmBaseAprBN.isNaN() || !farmBaseAprBN.isFinite()) {
+                farmBaseAprBN = new BigNumber(0);
+            }
+            if (farmBoostedAprBN.isNaN() || !farmBoostedAprBN.isFinite()) {
+                farmBoostedAprBN = new BigNumber(0);
+            }
+        }
+
+        if (stakingFarmAddress) {
+            const dualFarmBaseAPR = await this.stakingCompute.stakeFarmAPR(
+                stakingFarmAddress,
+            );
+
+            dualFarmBaseAprBN = new BigNumber(dualFarmBaseAPR);
+
+            if (dualFarmBaseAprBN.isNaN() || !dualFarmBaseAprBN.isFinite()) {
+                dualFarmBaseAprBN = new BigNumber(0);
+            }
+        }
+
+        if (feesAprBN.isNaN() || !feesAprBN.isFinite()) {
+            feesAprBN = new BigNumber(0);
+        }
+
+        return feesAprBN
+            .plus(farmBaseAprBN)
+            .plus(farmBoostedAprBN)
+            .plus(dualFarmBaseAprBN)
+            .toFixed();
     }
 }

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -787,6 +787,7 @@ export class PairComputeService implements IPairComputeService {
         let farmBaseAprBN = new BigNumber('0');
         let farmBoostedAprBN = new BigNumber('0');
         let dualFarmBaseAprBN = new BigNumber('0');
+        let dualFarmBoostedAprBN = new BigNumber('0');
 
         if (farmAddress) {
             const [farmBaseAPR, farmBoostedAPR] = await Promise.all([
@@ -806,14 +807,22 @@ export class PairComputeService implements IPairComputeService {
         }
 
         if (stakingFarmAddress) {
-            const dualFarmBaseAPR = await this.stakingCompute.stakeFarmAPR(
-                stakingFarmAddress,
-            );
+            const [dualFarmBaseAPR, dualFarmBoostedAPR] = await Promise.all([
+                this.stakingCompute.stakeFarmAPR(stakingFarmAddress),
+                this.stakingCompute.boostedApr(stakingFarmAddress),
+            ]);
 
             dualFarmBaseAprBN = new BigNumber(dualFarmBaseAPR);
+            dualFarmBoostedAprBN = new BigNumber(dualFarmBoostedAPR);
 
             if (dualFarmBaseAprBN.isNaN() || !dualFarmBaseAprBN.isFinite()) {
                 dualFarmBaseAprBN = new BigNumber(0);
+            }
+            if (
+                dualFarmBoostedAprBN.isNaN() ||
+                !dualFarmBoostedAprBN.isFinite()
+            ) {
+                dualFarmBoostedAprBN = new BigNumber(0);
             }
         }
 
@@ -825,6 +834,7 @@ export class PairComputeService implements IPairComputeService {
             .plus(farmBaseAprBN)
             .plus(farmBoostedAprBN)
             .plus(dualFarmBaseAprBN)
+            .plus(dualFarmBoostedAprBN)
             .toFixed();
     }
 }

--- a/src/modules/pair/specs/pair.compute.service.spec.ts
+++ b/src/modules/pair/specs/pair.compute.service.spec.ts
@@ -28,6 +28,17 @@ import { RemoteConfigGetterServiceProvider } from 'src/modules/remote-config/moc
 import { StakingProxyAbiServiceProvider } from 'src/modules/staking-proxy/mocks/staking.proxy.abi.service.mock';
 import { FarmAbiServiceProviderV2 } from 'src/modules/farm/mocks/farm.v2.abi.service.mock';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { FarmComputeServiceV2 } from 'src/modules/farm/v2/services/farm.v2.compute.service';
+import { StakingComputeService } from 'src/modules/staking/services/staking.compute.service';
+import { FarmServiceV2 } from 'src/modules/farm/v2/services/farm.v2.service';
+import { WeekTimekeepingComputeService } from 'src/submodules/week-timekeeping/services/week-timekeeping.compute.service';
+import { WeeklyRewardsSplittingAbiServiceProvider } from 'src/submodules/weekly-rewards-splitting/mocks/weekly.rewards.splitting.abi.mock';
+import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
+import { WeekTimekeepingAbiServiceProvider } from 'src/submodules/week-timekeeping/mocks/week.timekeeping.abi.service.mock';
+import { StakingAbiServiceProvider } from 'src/modules/staking/mocks/staking.abi.service.mock';
+import { StakingService } from 'src/modules/staking/services/staking.service';
+import { StakingFilteringService } from 'src/modules/staking/services/staking.filtering.service';
+import { EnergyAbiServiceProvider } from 'src/modules/energy/mocks/energy.abi.service.mock';
 
 describe('PairService', () => {
     let module: TestingModule;
@@ -59,6 +70,17 @@ describe('PairService', () => {
                 FarmAbiServiceProviderV2,
                 RemoteConfigGetterServiceProvider,
                 StakingProxyAbiServiceProvider,
+                FarmComputeServiceV2,
+                FarmServiceV2,
+                WeekTimekeepingComputeService,
+                WeekTimekeepingAbiServiceProvider,
+                WeeklyRewardsSplittingAbiServiceProvider,
+                WeeklyRewardsSplittingComputeService,
+                StakingComputeService,
+                StakingService,
+                StakingAbiServiceProvider,
+                StakingFilteringService,
+                EnergyAbiServiceProvider,
             ],
         }).compile();
     });

--- a/src/modules/router/models/filter.args.ts
+++ b/src/modules/router/models/filter.args.ts
@@ -7,6 +7,7 @@ export enum PairSortableFields {
     VOLUME_24 = 'volume_24h',
     FEES_24 = 'fees_24h',
     DEPLOYED_AT = 'deployed_at',
+    APR = 'apr',
 }
 
 registerEnumType(PairSortableFields, { name: 'PairSortableFields' });

--- a/src/modules/router/services/router.service.ts
+++ b/src/modules/router/services/router.service.ts
@@ -323,6 +323,13 @@ export class RouterService {
                     ),
                 );
                 break;
+            case PairSortableFields.APR:
+                sortFieldData = await Promise.all(
+                    pairsMetadata.map((pair) =>
+                        this.pairCompute.computeCompoundedApr(pair.address),
+                    ),
+                );
+                break;
             default:
                 break;
         }

--- a/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
+++ b/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { EsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
 import { TokenDistributionModel } from '../models/weekly-rewards-splitting.model';
@@ -20,7 +20,9 @@ export class WeeklyRewardsSplittingComputeService
     constructor(
         private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
         private readonly energyAbi: EnergyAbiService,
+        @Inject(forwardRef(() => TokenComputeService))
         private readonly tokenCompute: TokenComputeService,
+        @Inject(forwardRef(() => TokenService))
         private readonly tokenService: TokenService,
     ) {}
 


### PR DESCRIPTION
## Reasoning
- allow the result of `filteredPairs` query to be sorted by compoundedAPR

  
## Proposed Changes
- add sorting by compounded APR to filteredPairs query


## How to test
```
query CompoundedAPR {
  filteredPairs(
    filters:{}
    pagination:{
      first:200
    }
    sorting: {
      sortField:APR
      sortOrder:DESC
    }
  ) {
    edges {
      cursor
      node {
        address
        firstToken {
          identifier
        }
        secondToken {
          identifier
        }
        compoundedAPR{
          feesAPR
          farmBaseAPR
          farmBoostedAPR
          dualFarmBaseAPR
          dualFarmBoostedAPR
        }
      }
    }
    pageInfo {
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
