### PR TITLE
[SERVICES-2474] Filtered staking proxies query implementing "Connections" spec

### DIFF
--- a/src/modules/staking-proxy/models/staking.proxies.response.ts
+++ b/src/modules/staking-proxy/models/staking.proxies.response.ts
@@ -1,0 +1,8 @@
+import { ObjectType } from '@nestjs/graphql';
+import relayTypes from 'src/utils/relay.types';
+import { StakingProxyModel } from './staking.proxy.model';
+
+@ObjectType()
+export class StakingProxiesResponse extends relayTypes<StakingProxyModel>(
+    StakingProxyModel,
+) {}

--- a/src/modules/staking-proxy/models/staking.proxy.args.model.ts
+++ b/src/modules/staking-proxy/models/staking.proxy.args.model.ts
@@ -32,5 +32,13 @@ export class UnstakeFarmTokensArgs {
 @InputType()
 export class StakingProxiesFilter {
     @Field({ nullable: true })
+    address: string;
+    @Field({ nullable: true })
     pairAddress: string;
+    @Field({ nullable: true })
+    stakingFarmAddress: string;
+    @Field({ nullable: true })
+    lpFarmAddress: string;
+    @Field(() => String, { nullable: true })
+    searchToken?: string;
 }

--- a/src/modules/staking-proxy/models/staking.proxy.args.model.ts
+++ b/src/modules/staking-proxy/models/staking.proxy.args.model.ts
@@ -1,4 +1,4 @@
-import { ArgsType, Field } from '@nestjs/graphql';
+import { ArgsType, Field, InputType } from '@nestjs/graphql';
 import { InputTokenModel } from 'src/models/inputToken.model';
 
 @ArgsType()
@@ -27,4 +27,10 @@ export class UnstakeFarmTokensArgs {
     attributes: string;
     @Field()
     tolerance: number;
+}
+
+@InputType()
+export class StakingProxiesFilter {
+    @Field({ nullable: true })
+    pairAddress: string;
 }

--- a/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { StakingProxiesFilter } from '../models/staking.proxy.args.model';
 import { StakingProxyAbiService } from './staking.proxy.abi.service';
 import { StakingProxyService } from './staking.proxy.service';
+import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
+import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 
 @Injectable()
 export class StakingProxyFilteringService {
@@ -97,19 +99,55 @@ export class StakingProxyFilteringService {
             ),
         );
 
+        const farmTokens = await Promise.all(
+            stakingProxyAddresses.map((address) =>
+                this.stakingProxyService.getFarmToken(address),
+            ),
+        );
+
+        const dualYieldTokens = await Promise.all(
+            stakingProxyAddresses.map((address) =>
+                this.stakingProxyService.getDualYieldToken(address),
+            ),
+        );
+
+        const lpFarmTokens = await Promise.all(
+            stakingProxyAddresses.map((address) =>
+                this.stakingProxyService.getLpFarmToken(address),
+            ),
+        );
+
         const filteredAddresses: string[] = [];
         for (const [index, address] of stakingProxyAddresses.entries()) {
             const stakingToken = stakingTokens[index];
+            const farmToken = farmTokens[index];
+            const dualYieldToken = dualYieldTokens[index];
+            const lpFarmToken = lpFarmTokens[index];
 
             if (
-                stakingToken.name.toUpperCase().includes(searchTerm) ||
-                stakingToken.identifier.toUpperCase().includes(searchTerm) ||
-                stakingToken.ticker.toUpperCase().includes(searchTerm)
+                this.tokenIncludesTerm(stakingToken, searchTerm) ||
+                this.tokenIncludesTerm(farmToken, searchTerm) ||
+                this.tokenIncludesTerm(dualYieldToken, searchTerm) ||
+                this.tokenIncludesTerm(lpFarmToken, searchTerm)
             ) {
                 filteredAddresses.push(address);
             }
         }
 
         return filteredAddresses;
+    }
+
+    private tokenIncludesTerm(
+        token: EsdtToken | NftCollection,
+        term: string,
+    ): boolean {
+        const identifier =
+            'identifier' in token ? token.identifier : token.collection;
+
+        return (
+            token.name.toUpperCase().includes(term) ||
+            identifier.toUpperCase().includes(term) ||
+            token.ticker.toUpperCase().includes(term)
+        );
     }
 }

--- a/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { StakingProxiesFilter } from '../models/staking.proxy.args.model';
+import { StakingProxyAbiService } from './staking.proxy.abi.service';
+
+@Injectable()
+export class StakingProxyFilteringService {
+    constructor(private readonly stakingProxyAbi: StakingProxyAbiService) {}
+
+    async stakingProxiesByPairAdddress(
+        filter: StakingProxiesFilter,
+        stakingProxyAddresses: string[],
+    ): Promise<string[]> {
+        if (!filter.pairAddress) {
+            return stakingProxyAddresses;
+        }
+
+        const pairAddresses = await Promise.all(
+            stakingProxyAddresses.map((address) =>
+                this.stakingProxyAbi.pairAddress(address),
+            ),
+        );
+
+        return stakingProxyAddresses.filter(
+            (_, index) => pairAddresses[index] === filter.pairAddress,
+        );
+    }
+}

--- a/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
@@ -13,16 +13,16 @@ export class StakingProxyFilteringService {
         private readonly stakingProxyService: StakingProxyService,
     ) {}
 
-    async stakingProxiesByAddress(
+    stakingProxiesByAddress(
         filter: StakingProxiesFilter,
         stakingProxyAddresses: string[],
-    ): Promise<string[]> {
+    ): string[] {
         if (filter.address) {
             stakingProxyAddresses = stakingProxyAddresses.filter(
                 (address) => filter.address === address,
             );
         }
-        return await Promise.resolve(stakingProxyAddresses);
+        return stakingProxyAddresses;
     }
 
     async stakingProxiesByPairAdddress(

--- a/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
@@ -1,10 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { StakingProxiesFilter } from '../models/staking.proxy.args.model';
 import { StakingProxyAbiService } from './staking.proxy.abi.service';
+import { StakingProxyService } from './staking.proxy.service';
 
 @Injectable()
 export class StakingProxyFilteringService {
-    constructor(private readonly stakingProxyAbi: StakingProxyAbiService) {}
+    constructor(
+        private readonly stakingProxyAbi: StakingProxyAbiService,
+        @Inject(forwardRef(() => StakingProxyService))
+        private readonly stakingProxyService: StakingProxyService,
+    ) {}
+
+    async stakingProxiesByAddress(
+        filter: StakingProxiesFilter,
+        stakingProxyAddresses: string[],
+    ): Promise<string[]> {
+        if (filter.address) {
+            stakingProxyAddresses = stakingProxyAddresses.filter(
+                (address) => filter.address === address,
+            );
+        }
+        return await Promise.resolve(stakingProxyAddresses);
+    }
 
     async stakingProxiesByPairAdddress(
         filter: StakingProxiesFilter,
@@ -23,5 +40,76 @@ export class StakingProxyFilteringService {
         return stakingProxyAddresses.filter(
             (_, index) => pairAddresses[index] === filter.pairAddress,
         );
+    }
+
+    async stakingProxiesByStakingFarmAdddress(
+        filter: StakingProxiesFilter,
+        stakingProxyAddresses: string[],
+    ): Promise<string[]> {
+        if (!filter.stakingFarmAddress) {
+            return stakingProxyAddresses;
+        }
+
+        const stakingFarmAddresses = await Promise.all(
+            stakingProxyAddresses.map((address) =>
+                this.stakingProxyAbi.stakingFarmAddress(address),
+            ),
+        );
+
+        return stakingProxyAddresses.filter(
+            (_, index) =>
+                stakingFarmAddresses[index] === filter.stakingFarmAddress,
+        );
+    }
+
+    async stakingProxiesByLpFarmAdddress(
+        filter: StakingProxiesFilter,
+        stakingProxyAddresses: string[],
+    ): Promise<string[]> {
+        if (!filter.lpFarmAddress) {
+            return stakingProxyAddresses;
+        }
+
+        const lpFarmAddresses = await Promise.all(
+            stakingProxyAddresses.map((address) =>
+                this.stakingProxyAbi.lpFarmAddress(address),
+            ),
+        );
+
+        return stakingProxyAddresses.filter(
+            (_, index) => lpFarmAddresses[index] === filter.lpFarmAddress,
+        );
+    }
+
+    async stakingProxiesByToken(
+        filter: StakingProxiesFilter,
+        stakingProxyAddresses: string[],
+    ): Promise<string[]> {
+        if (!filter.searchToken || filter.searchToken.trim().length < 3) {
+            return stakingProxyAddresses;
+        }
+
+        const searchTerm = filter.searchToken.toUpperCase().trim();
+
+        const stakingTokens = await Promise.all(
+            stakingProxyAddresses.map((address) =>
+                this.stakingProxyService.getStakingToken(address),
+            ),
+        );
+
+        const filteredAddresses: string[] = [];
+        for (const [index, address] of stakingProxyAddresses.entries()) {
+            const stakingToken = stakingTokens[index];
+
+            if (
+                stakingToken.name.toUpperCase().includes(searchTerm) ||
+                stakingToken.identifier.toUpperCase().includes(searchTerm) ||
+                stakingToken.ticker.toUpperCase().includes(searchTerm)
+            ) {
+                filteredAddresses.push(address);
+            }
+        }
+
+        return filteredAddresses;
     }
 }

--- a/src/modules/staking-proxy/services/staking.proxy.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.service.ts
@@ -68,7 +68,7 @@ export class StakingProxyService {
             await this.remoteConfigGetterService.getStakingProxyAddresses();
 
         stakingProxiesAddresses =
-            await this.stakingProxyFilteringService.stakingProxiesByAddress(
+            this.stakingProxyFilteringService.stakingProxiesByAddress(
                 filters,
                 stakingProxiesAddresses,
             );

--- a/src/modules/staking-proxy/specs/staking.proxy.transaction.service.spec.ts
+++ b/src/modules/staking-proxy/specs/staking.proxy.transaction.service.spec.ts
@@ -43,6 +43,7 @@ import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { AnalyticsQueryServiceProvider } from 'src/services/analytics/mocks/analytics.query.service.mock';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { StakingProxyFilteringService } from '../services/staking.proxy.filtering.service';
 
 describe('StakingProxyTransactionService', () => {
     let module: TestingModule;
@@ -65,6 +66,7 @@ describe('StakingProxyTransactionService', () => {
                     provide: StakingService,
                     useClass: StakingServiceMock,
                 },
+                StakingProxyFilteringService,
                 PairService,
                 PairAbiServiceProvider,
                 PairComputeServiceProvider,

--- a/src/modules/staking-proxy/staking.proxy.module.ts
+++ b/src/modules/staking-proxy/staking.proxy.module.ts
@@ -12,6 +12,7 @@ import { StakingProxyService } from './services/staking.proxy.service';
 import { StakingProxySetterService } from './services/staking.proxy.setter.service';
 import { StakingProxyTransactionService } from './services/staking.proxy.transactions.service';
 import { StakingProxyResolver } from './staking.proxy.resolver';
+import { StakingProxyFilteringService } from './services/staking.proxy.filtering.service';
 
 @Module({
     imports: [
@@ -30,6 +31,7 @@ import { StakingProxyResolver } from './staking.proxy.resolver';
         StakingProxySetterService,
         StakingProxyTransactionService,
         StakingProxyResolver,
+        StakingProxyFilteringService,
     ],
     exports: [
         StakingProxyAbiService,

--- a/src/modules/staking-proxy/staking.proxy.module.ts
+++ b/src/modules/staking-proxy/staking.proxy.module.ts
@@ -37,6 +37,7 @@ import { StakingProxyFilteringService } from './services/staking.proxy.filtering
         StakingProxyAbiService,
         StakingProxyService,
         StakingProxySetterService,
+        StakingProxyFilteringService,
     ],
 })
 export class StakingProxyModule {}

--- a/src/modules/user/specs/user.energy.compute.service.spec.ts
+++ b/src/modules/user/specs/user.energy.compute.service.spec.ts
@@ -67,6 +67,7 @@ import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { AnalyticsQueryServiceProvider } from 'src/services/analytics/mocks/analytics.query.service.mock';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { StakingProxyFilteringService } from 'src/modules/staking-proxy/services/staking.proxy.filtering.service';
 
 describe('UserEnergyComputeService', () => {
     let module: TestingModule;
@@ -112,6 +113,7 @@ describe('UserEnergyComputeService', () => {
                 UserEsdtComputeService,
                 StakingProxyService,
                 StakingProxyAbiService,
+                StakingProxyFilteringService,
                 SimpleLockAbiServiceProvider,
                 SimpleLockService,
                 StakingAbiServiceProvider,


### PR DESCRIPTION
## Reasoning
- provide a [Relay](https://relay.dev/)-compliant query for fetching staking proxies data
  
## Proposed Changes
- create new `filteredStakingProxies` query that follows the GraphQL "Connections" specification
- add staking farms filtering service (wildcard filtering by a token + filtering by address / LP farm address / staking farm address / pair address)
- 

## How to test
```
query {
  filteredStakingProxies(
    filters: {
      searchToken: "UTK"
      address: "erd1qqqqqqqqqqqqqpgqqwn0qa7ft4tew05r0zcd0c5hay5mp6np0n4ss8jm86"
      stakingFarmAddress: "erd1qqqqqqqqqqqqqpgquvklwltnlgyn5w5cd65ey36nw8sc008d0n4s0xpr25"
      pairAddress: "erd1qqqqqqqqqqqqqpgq4zafu6rzdw7fj07hjh5tkm68jsaj7hl60n4s8py4ra"
      lpFarmAddress: "erd1qqqqqqqqqqqqqpgql7rysqgxxzhykg3j6vccnx4003z2mcl80n4ste3jh8"
    }
    pagination: { first: 200 }
  ) {
    edges {
      cursor
      node {
        address
        lpFarmAddress
        stakingFarmAddress
        pairAddress
        stakingToken {
          identifier
        }
        farmToken {
          ticker
        }
        dualYieldToken {
          ticker
        }
        lpFarmToken {
          ticker
        }
      }
    }
    pageInfo {
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
