### PR TITLE
[SERVICES-2485] Update caching strategy for tokens metadata

### DIFF
--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -50,7 +50,7 @@ export class AnalyticsResolver {
 
     @Query(() => String)
     async totalTokenSupply(@Args('tokenID') tokenID: string): Promise<string> {
-        return (await this.tokenService.getTokenMetadata(tokenID)).supply;
+        return (await this.tokenService.tokenMetadata(tokenID)).supply;
     }
 
     @Query(() => String)

--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -208,9 +208,7 @@ export class AnalyticsComputeService {
                 this.tokenCompute.tokenPriceDerivedUSD(
                     constantsConfig.MEX_TOKEN_ID,
                 ),
-                this.tokenService.getTokenMetadata(
-                    constantsConfig.MEX_TOKEN_ID,
-                ),
+                this.tokenService.tokenMetadata(constantsConfig.MEX_TOKEN_ID),
                 this.weeklyRewardsSplittingAbi.totalLockedTokensForWeek(
                     scAddress.feesCollector,
                     currentWeek,

--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -79,8 +79,8 @@ export class AutoRouterService {
             await Promise.all([
                 this.remoteConfigGetterService.getMultiSwapStatus(),
                 this.getAllActivePairs(),
-                this.tokenService.getTokenMetadata(tokenInID),
-                this.tokenService.getTokenMetadata(tokenOutID),
+                this.tokenService.tokenMetadata(tokenInID),
+                this.tokenService.tokenMetadata(tokenOutID),
             ]);
 
         args.amountIn = this.setDefaultAmountInIfNeeded(args, tokenInMetadata);
@@ -510,9 +510,9 @@ export class AutoRouterService {
                 intermediaryTokenOut,
                 intermediaryTokenOutPriceUSD,
             ] = await Promise.all([
-                this.tokenService.getTokenMetadata(tokenInID),
+                this.tokenService.tokenMetadata(tokenInID),
                 this.pairCompute.tokenPriceUSD(tokenInID),
-                this.tokenService.getTokenMetadata(tokenOutID),
+                this.tokenService.tokenMetadata(tokenOutID),
                 this.pairCompute.tokenPriceUSD(tokenOutID),
             ]);
 

--- a/src/modules/energy/services/energy.service.ts
+++ b/src/modules/energy/services/energy.service.ts
@@ -22,7 +22,7 @@ export class EnergyService {
 
     async getBaseAssetToken(): Promise<EsdtToken> {
         const tokenID = await this.energyAbi.baseAssetTokenID();
-        return await this.tokenService.getTokenMetadata(tokenID);
+        return await this.tokenService.tokenMetadata(tokenID);
     }
 
     async getLockedToken(): Promise<NftCollection> {

--- a/src/modules/farm/base-module/services/farm.base.service.ts
+++ b/src/modules/farm/base-module/services/farm.base.service.ts
@@ -29,7 +29,7 @@ export abstract class FarmServiceBase {
 
     async getFarmedToken(farmAddress: string): Promise<EsdtToken> {
         const farmedTokenID = await this.farmAbi.farmedTokenID(farmAddress);
-        return this.tokenService.getTokenMetadata(farmedTokenID);
+        return this.tokenService.tokenMetadata(farmedTokenID);
     }
 
     async getFarmToken(farmAddress: string): Promise<NftCollection> {
@@ -39,7 +39,7 @@ export abstract class FarmServiceBase {
 
     async getFarmingToken(farmAddress: string): Promise<EsdtToken> {
         const farmingTokenID = await this.farmAbi.farmingTokenID(farmAddress);
-        return this.tokenService.getTokenMetadata(farmingTokenID);
+        return this.tokenService.tokenMetadata(farmingTokenID);
     }
 
     protected async getRemainingFarmingEpochs(

--- a/src/modules/fees-collector/services/fees-collector.compute.service.ts
+++ b/src/modules/fees-collector/services/fees-collector.compute.service.ts
@@ -187,7 +187,7 @@ export class FeesCollectorComputeService {
 
         const [baseToken, userEnergy, totalRewardsForWeekUSD] =
             await Promise.all([
-                this.tokenService.getTokenMetadata(baseAssetTokenID),
+                this.tokenService.tokenMetadata(baseAssetTokenID),
                 this.energyService.getUserEnergy(userAddress),
                 this.weeklyRewardsSplittingCompute.totalRewardsForWeekUSD(
                     scAddress,

--- a/src/modules/locked-asset-factory/services/locked.asset.getter.service.ts
+++ b/src/modules/locked-asset-factory/services/locked.asset.getter.service.ts
@@ -43,7 +43,7 @@ export class LockedAssetGetterService extends GenericGetterService {
 
     async getAssetToken(): Promise<EsdtToken> {
         const assetTokenID = await this.getAssetTokenID();
-        return await this.tokenService.getTokenMetadata(assetTokenID);
+        return await this.tokenService.tokenMetadata(assetTokenID);
     }
 
     async getLockedToken(): Promise<NftCollection> {

--- a/src/modules/pair/services/pair.service.ts
+++ b/src/modules/pair/services/pair.service.ts
@@ -36,19 +36,19 @@ export class PairService {
 
     async getFirstToken(pairAddress: string): Promise<EsdtToken> {
         const firstTokenID = await this.pairAbi.firstTokenID(pairAddress);
-        return await this.tokenService.getTokenMetadata(firstTokenID);
+        return await this.tokenService.tokenMetadata(firstTokenID);
     }
 
     async getSecondToken(pairAddress: string): Promise<EsdtToken> {
         const secondTokenID = await this.pairAbi.secondTokenID(pairAddress);
-        return await this.tokenService.getTokenMetadata(secondTokenID);
+        return await this.tokenService.tokenMetadata(secondTokenID);
     }
 
     async getLpToken(pairAddress: string): Promise<EsdtToken> {
         const lpTokenID = await this.pairAbi.lpTokenID(pairAddress);
         return lpTokenID === undefined
             ? undefined
-            : await this.tokenService.getTokenMetadata(lpTokenID);
+            : await this.tokenService.tokenMetadata(lpTokenID);
     }
 
     async getAmountOut(

--- a/src/modules/price-discovery/services/price.discovery.service.ts
+++ b/src/modules/price-discovery/services/price.discovery.service.ts
@@ -30,14 +30,14 @@ export class PriceDiscoveryService {
         const launchedTokenID = await this.priceDiscoveryAbi.launchedTokenID(
             priceDiscoveryAddress,
         );
-        return this.tokenService.getTokenMetadata(launchedTokenID);
+        return this.tokenService.tokenMetadata(launchedTokenID);
     }
 
     async getAcceptedToken(priceDiscoveryAddress: string): Promise<EsdtToken> {
         const acceptedTokenID = await this.priceDiscoveryAbi.acceptedTokenID(
             priceDiscoveryAddress,
         );
-        return this.tokenService.getTokenMetadata(acceptedTokenID);
+        return this.tokenService.tokenMetadata(acceptedTokenID);
     }
 
     async getRedeemToken(

--- a/src/modules/proxy/services/proxy.service.ts
+++ b/src/modules/proxy/services/proxy.service.ts
@@ -63,7 +63,7 @@ export class ProxyService {
 
     async getAssetToken(proxyAddress: string): Promise<EsdtToken> {
         const assetTokenID = await this.proxyAbi.assetTokenID(proxyAddress);
-        return this.tokenService.getTokenMetadata(assetTokenID);
+        return this.tokenService.tokenMetadata(assetTokenID);
     }
 
     async getlockedAssetToken(proxyAddress: string): Promise<NftCollection[]> {

--- a/src/modules/rabbitmq/handlers/pair.liquidity.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/pair.liquidity.handler.service.ts
@@ -41,8 +41,8 @@ export class LiquidityHandler {
             secondTokenPriceUSD,
             newTotalLockedValueUSD,
         ] = await Promise.all([
-            this.tokenService.getTokenMetadata(event.getFirstToken().tokenID),
-            this.tokenService.getTokenMetadata(event.getSecondToken().tokenID),
+            this.tokenService.tokenMetadata(event.getFirstToken().tokenID),
+            this.tokenService.tokenMetadata(event.getSecondToken().tokenID),
             this.tokenCompute.tokenPriceDerivedUSD(
                 event.getFirstToken().tokenID,
             ),

--- a/src/modules/staking-proxy/services/staking.proxy.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.service.ts
@@ -58,7 +58,7 @@ export class StakingProxyService {
         const stakingTokenID = await this.stakingProxyAbi.stakingTokenID(
             stakingProxyAddress,
         );
-        return await this.tokenService.getTokenMetadata(stakingTokenID);
+        return await this.tokenService.tokenMetadata(stakingTokenID);
     }
 
     async getFarmToken(stakingProxyAddress: string): Promise<NftCollection> {

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -168,7 +168,7 @@ export class StakingComputeService {
     async computeStakedValueUSD(stakeAddress: string): Promise<string> {
         const [farmTokenSupply, farmingToken] = await Promise.all([
             this.stakingAbi.farmTokenSupply(stakeAddress),
-            this.tokenService.getTokenMetadata(constantsConfig.MEX_TOKEN_ID),
+            this.tokenService.tokenMetadata(constantsConfig.MEX_TOKEN_ID),
             this.stakingService.getFarmingToken(stakeAddress),
         ]);
 

--- a/src/modules/staking/services/staking.service.ts
+++ b/src/modules/staking/services/staking.service.ts
@@ -105,12 +105,12 @@ export class StakingService {
         const farmingTokenID = await this.stakingAbi.farmingTokenID(
             stakeAddress,
         );
-        return await this.tokenService.getTokenMetadata(farmingTokenID);
+        return await this.tokenService.tokenMetadata(farmingTokenID);
     }
 
     async getRewardToken(stakeAddress: string): Promise<EsdtToken> {
         const rewardTokenID = await this.stakingAbi.rewardTokenID(stakeAddress);
-        return await this.tokenService.getTokenMetadata(rewardTokenID);
+        return await this.tokenService.tokenMetadata(rewardTokenID);
     }
 
     decodeStakingTokenAttributes(

--- a/src/modules/tokens/mocks/token.service.mock.ts
+++ b/src/modules/tokens/mocks/token.service.mock.ts
@@ -4,7 +4,7 @@ import { EsdtToken } from '../models/esdtToken.model';
 import { TokenService } from '../services/token.service';
 
 export class TokenServiceMock {
-    async getTokenMetadata(tokenID: string): Promise<EsdtToken> {
+    async tokenMetadata(tokenID: string): Promise<EsdtToken> {
         return Tokens(tokenID);
     }
 

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -118,8 +118,8 @@ export class TokenService {
     })
     @GetOrSetCache({
         baseKey: 'token',
-        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
-        localTtl: CacheTtlInfo.ContractState.localTtl,
+        remoteTtl: CacheTtlInfo.Token.remoteTtl,
+        localTtl: CacheTtlInfo.Token.localTtl,
     })
     async tokenMetadata(tokenID: string): Promise<EsdtToken> {
         return await this.tokenMetadataRaw(tokenID);

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -44,9 +44,7 @@ export class TokenService {
             );
         }
 
-        const promises = tokenIDs.map((tokenID) =>
-            this.getTokenMetadata(tokenID),
-        );
+        const promises = tokenIDs.map((tokenID) => this.tokenMetadata(tokenID));
         let tokens = await Promise.all(promises);
 
         if (filters.type) {
@@ -86,7 +84,7 @@ export class TokenService {
         }
 
         let tokens = await Promise.all(
-            tokenIDs.map((tokenID) => this.getTokenMetadata(tokenID)),
+            tokenIDs.map((tokenID) => this.tokenMetadata(tokenID)),
         );
 
         tokens = await this.tokenFilteringService.tokensBySearchTerm(
@@ -118,16 +116,16 @@ export class TokenService {
     @ErrorLoggerAsync({
         logArgs: true,
     })
-    async getTokenMetadata(tokenID: string): Promise<EsdtToken> {
-        return await this.cachingService.getOrSet(
-            `token.${tokenID}`,
-            () => this.getTokenMetadataRaw(tokenID),
-            CacheTtlInfo.ContractState.remoteTtl,
-            CacheTtlInfo.ContractState.localTtl,
-        );
+    @GetOrSetCache({
+        baseKey: 'token',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async tokenMetadata(tokenID: string): Promise<EsdtToken> {
+        return await this.tokenMetadataRaw(tokenID);
     }
 
-    async getTokenMetadataRaw(tokenID: string): Promise<EsdtToken> {
+    async tokenMetadataRaw(tokenID: string): Promise<EsdtToken> {
         return await this.apiService.getToken(tokenID);
     }
 

--- a/src/modules/tokens/services/token.setter.service.ts
+++ b/src/modules/tokens/services/token.setter.service.ts
@@ -137,6 +137,15 @@ export class TokenSetterService extends GenericSetterService {
         );
     }
 
+    async setMetadata(tokenID: string, value: EsdtToken): Promise<string> {
+        return await this.setData(
+            `token.${tokenID}`,
+            value,
+            CacheTtlInfo.Token.remoteTtl,
+            CacheTtlInfo.Token.localTtl,
+        );
+    }
+
     private getTokenCacheKey(tokenID: string, ...args: any): string {
         return generateCacheKeyFromParams('token', tokenID, args);
     }

--- a/src/modules/tokens/services/token.setter.service.ts
+++ b/src/modules/tokens/services/token.setter.service.ts
@@ -139,7 +139,7 @@ export class TokenSetterService extends GenericSetterService {
 
     async setMetadata(tokenID: string, value: EsdtToken): Promise<string> {
         return await this.setData(
-            `token.${tokenID}`,
+            `token.tokenMetadata.${tokenID}`,
             value,
             CacheTtlInfo.Token.remoteTtl,
             CacheTtlInfo.Token.localTtl,

--- a/src/modules/tokens/specs/token.service.spec.ts
+++ b/src/modules/tokens/specs/token.service.spec.ts
@@ -52,7 +52,7 @@ describe('TokenService', () => {
 
         const tokenID = 'WEGLD-123456';
         const expectedToken = Tokens(tokenID);
-        const cacheKey = `token.${tokenID}`;
+        const cacheKey = `token.tokenMetadata.${tokenID}`;
         await cachingService.deleteInCache(cacheKey);
 
         let token = await service.tokenMetadata(tokenID);

--- a/src/modules/tokens/specs/token.service.spec.ts
+++ b/src/modules/tokens/specs/token.service.spec.ts
@@ -55,15 +55,15 @@ describe('TokenService', () => {
         const cacheKey = `token.${tokenID}`;
         await cachingService.deleteInCache(cacheKey);
 
-        let token = await service.getTokenMetadata(tokenID);
+        let token = await service.tokenMetadata(tokenID);
         expect(token).toEqual(expectedToken);
 
         jest.spyOn(apiService, 'getToken').mockResolvedValueOnce(undefined);
         await cachingService.deleteInCache(cacheKey);
-        token = await service.getTokenMetadata(tokenID);
+        token = await service.tokenMetadata(tokenID);
         expect(token).toEqual(undefined);
 
-        token = await service.getTokenMetadata(tokenID);
+        token = await service.tokenMetadata(tokenID);
         expect(token).toEqual(expectedToken);
     });
 });

--- a/src/modules/wrapping/services/wrap.service.ts
+++ b/src/modules/wrapping/services/wrap.service.ts
@@ -31,6 +31,6 @@ export class WrapService {
 
     async wrappedEgldToken(): Promise<EsdtToken> {
         const wrappedEgldTokenID = await this.wrapAbi.wrappedEgldTokenID();
-        return this.tokenService.getTokenMetadata(wrappedEgldTokenID);
+        return this.tokenService.tokenMetadata(wrappedEgldTokenID);
     }
 }

--- a/src/services/crons/tokens.cache.warmer.service.ts
+++ b/src/services/crons/tokens.cache.warmer.service.ts
@@ -21,7 +21,7 @@ export class TokensCacheWarmerService {
         @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
     ) {}
 
-    @Cron(CronExpression.EVERY_MINUTE)
+    @Cron(CronExpression.EVERY_5_MINUTES)
     @Lock({ name: 'cacheTokensMetadata', verbose: true })
     async cacheTokensMetadata(): Promise<void> {
         this.logger.info('Start refresh cached tokens metadata', {

--- a/src/services/crons/tokens.cache.warmer.service.ts
+++ b/src/services/crons/tokens.cache.warmer.service.ts
@@ -33,7 +33,7 @@ export class TokensCacheWarmerService {
         const cachedKeys = [];
 
         for (const tokenID of tokenIDs) {
-            const token = await this.tokenService.getTokenMetadataRaw(tokenID);
+            const token = await this.tokenService.tokenMetadataRaw(tokenID);
 
             const cachedKey = await this.tokenSetterService.setMetadata(
                 tokenID,

--- a/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
+++ b/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
@@ -183,7 +183,7 @@ export class WeeklyRewardsSplittingComputeService
                         ? baseAssetTokenID
                         : reward.tokenID;
                 const [token, rewardsPriceUSD] = await Promise.all([
-                    this.tokenService.getTokenMetadata(tokenID),
+                    this.tokenService.tokenMetadata(tokenID),
                     this.tokenCompute.computeTokenPriceDerivedUSD(tokenID),
                 ]);
                 return computeValueUSD(


### PR DESCRIPTION
## Reasoning
- currently the TTL for existing cached token metadata is simply extended on request. A refetch of the data is only performed if the value is not present in cache 
  
## Proposed Changes
- add method for maintaining token metadata in cache warmer
- remove logic that extends TTL for values present in cache

## How to test
```
query {
  filteredTokens(
    filters: { identifiers: ["WEGLD-a28c59"] }
    pagination: { first: 200 }
    sorting: { sortField: TRENDING_SCORE, sortOrder: DESC }
  ) {
    edges {
      cursor
      node {
        identifier
        volumeUSD24h
        price
        circulatingSupply
      }
    }
    pageInfo {
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```