### PR TITLE
[SERVICES-2488] Token rewards information for pool

### DIFF
--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -67,6 +67,19 @@ export class PairCompoundedAPRModel {
 }
 
 @ObjectType()
+export class PairRewardTokensModel {
+    @Field()
+    address: string;
+
+    @Field({ nullable: true })
+    dualFardRewardToken: EsdtToken;
+
+    constructor(init?: Partial<PairRewardTokensModel>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
 export class PairModel {
     @Field()
     address: string;
@@ -186,6 +199,9 @@ export class PairModel {
 
     @Field(() => PairCompoundedAPRModel, { nullable: true })
     compoundedAPR: PairCompoundedAPRModel;
+
+    @Field(() => PairRewardTokensModel, { nullable: true })
+    rewardTokens: PairRewardTokensModel;
 
     constructor(init?: Partial<PairModel>) {
         Object.assign(this, init);

--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -4,6 +4,7 @@ import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { PairInfoModel } from './pair-info.model';
 import { SimpleLockModel } from 'src/modules/simple-lock/models/simple.lock.model';
 import { FeesCollectorModel } from 'src/modules/fees-collector/models/fees-collector.model';
+import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 
 @ArgsType()
 export class GetPairsArgs extends PaginationArgs {}
@@ -71,8 +72,14 @@ export class PairRewardTokensModel {
     @Field()
     address: string;
 
+    @Field(() => [EsdtToken])
+    poolRewards: EsdtToken[];
+
     @Field({ nullable: true })
-    dualFardRewardToken: EsdtToken;
+    farmReward: NftCollection;
+
+    @Field({ nullable: true })
+    dualFarmReward: EsdtToken;
 
     constructor(init?: Partial<PairRewardTokensModel>) {
         Object.assign(this, init);

--- a/src/modules/pair/pair.module.ts
+++ b/src/modules/pair/pair.module.ts
@@ -24,6 +24,7 @@ import { ElasticService } from 'src/helpers/elastic.service';
 import { FarmModuleV2 } from '../farm/v2/farm.v2.module';
 import { PairFilteringService } from './services/pair.filtering.service';
 import { StakingModule } from '../staking/staking.module';
+import { EnergyModule } from '../energy/energy.module';
 @Module({
     imports: [
         CommonAppModule,
@@ -39,6 +40,7 @@ import { StakingModule } from '../staking/staking.module';
         FarmModuleV2,
         StakingProxyModule,
         StakingModule,
+        EnergyModule,
     ],
     providers: [
         PairService,

--- a/src/modules/pair/pair.module.ts
+++ b/src/modules/pair/pair.module.ts
@@ -1,6 +1,10 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { PairService } from './services/pair.service';
-import { PairCompoundedAPRResolver, PairResolver } from './pair.resolver';
+import {
+    PairCompoundedAPRResolver,
+    PairResolver,
+    PairRewardTokensResolver,
+} from './pair.resolver';
 import { PairAbiService } from './services/pair.abi.service';
 import { PairTransactionService } from './services/pair.transactions.service';
 import { ContextModule } from '../../services/context/context.module';
@@ -46,6 +50,7 @@ import { StakingModule } from '../staking/staking.module';
         ElasticService,
         PairFilteringService,
         PairCompoundedAPRResolver,
+        PairRewardTokensResolver,
     ],
     exports: [
         PairService,

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -33,18 +33,47 @@ import { GenericResolver } from 'src/services/generics/generic.resolver';
 import { FarmComputeServiceV2 } from '../farm/v2/services/farm.v2.compute.service';
 import { StakingComputeService } from '../staking/services/staking.compute.service';
 import { StakingProxyService } from '../staking-proxy/services/staking.proxy.service';
+import { NftCollection } from '../tokens/models/nftCollection.model';
+import { EnergyService } from '../energy/services/energy.service';
 
 @Resolver(() => PairRewardTokensModel)
 export class PairRewardTokensResolver extends GenericResolver {
     constructor(
         private readonly pairCompute: PairComputeService,
+        private readonly pairService: PairService,
         private readonly stakingProxyService: StakingProxyService,
+        private readonly energyService: EnergyService,
     ) {
         super();
     }
 
     @ResolveField()
-    async dualFardRewardToken(
+    async poolRewards(
+        @Parent() parent: PairRewardTokensModel,
+    ): Promise<EsdtToken[]> {
+        return await Promise.all([
+            this.pairService.getFirstToken(parent.address),
+            this.pairService.getSecondToken(parent.address),
+        ]);
+    }
+
+    @ResolveField()
+    async farmReward(
+        @Parent() parent: PairRewardTokensModel,
+    ): Promise<NftCollection> {
+        const farmAddress = await this.pairCompute.getPairFarmAddress(
+            parent.address,
+        );
+
+        if (!farmAddress) {
+            return undefined;
+        }
+
+        return await this.energyService.getLockedToken();
+    }
+
+    @ResolveField()
+    async dualFarmReward(
         @Parent() parent: PairRewardTokensModel,
     ): Promise<EsdtToken> {
         const stakingProxyAddress =

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -748,6 +748,20 @@ export class PairComputeService implements IPairComputeService {
     }
 
     async getPairStakingFarmAddress(pairAddress: string): Promise<string> {
+        const stakingProxyAddress = await this.getPairStakingProxyAddress(
+            pairAddress,
+        );
+
+        if (!stakingProxyAddress) {
+            return undefined;
+        }
+
+        return await this.stakingProxyAbiService.stakingFarmAddress(
+            stakingProxyAddress,
+        );
+    }
+
+    async getPairStakingProxyAddress(pairAddress: string): Promise<string> {
         const hasDualFarms = await this.hasDualFarms(pairAddress);
 
         if (!hasDualFarms) {
@@ -767,13 +781,9 @@ export class PairComputeService implements IPairComputeService {
             (address) => address === pairAddress,
         );
 
-        if (stakingProxyIndex === -1) {
-            return undefined;
-        }
-
-        return await this.stakingProxyAbiService.stakingFarmAddress(
-            stakingProxyAddresses[stakingProxyIndex],
-        );
+        return stakingProxyIndex === -1
+            ? undefined
+            : stakingProxyAddresses[stakingProxyIndex];
     }
 
     async computeCompoundedApr(pairAddress: string): Promise<string> {


### PR DESCRIPTION
## Reasoning
- expose token rewards on the Pair model
  
## Proposed Changes
- add `PairRewardTokensModel` with field resolvers
- add `rewardTokens` field to `PairModel`

## How to test
- On `filteredPairs` query : 
```
query {
  filteredPairs(filters: {}, pagination: { first: 200 }) {
    edges {
      cursor
      node {
        address
        rewardTokens {
          poolRewards {
            identifier
            assets {
              svgUrl
            }
          }
          farmReward {
            collection
            assets {
              svgUrl
            }
          }
          dualFarmReward {
            identifier
            assets {
              svgUrl
            }
          }
        }
      }
    }
    pageInfo {
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
