### PR TITLE
[SERVICES-2495] Fix negative energy query + dual farms base apr computation

### DIFF
--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -146,7 +146,7 @@ export class PairCompoundedAPRResolver extends GenericResolver {
             return '0';
         }
 
-        return await this.stakingCompute.stakeFarmAPR(stakingAddress);
+        return await this.stakingCompute.stakeFarmBaseAPR(stakingAddress);
     }
 
     @ResolveField(() => String)

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -231,6 +231,29 @@ export class StakingComputeService {
                   .toFixed();
     }
 
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async stakeFarmBaseAPR(stakeAddress: string): Promise<string> {
+        return await this.computeStakeFarmBaseAPR(stakeAddress);
+    }
+
+    async computeStakeFarmBaseAPR(stakeAddress: string): Promise<string> {
+        const [apr, rawBoostedApr] = await Promise.all([
+            this.stakeFarmAPR(stakeAddress),
+            this.boostedApr(stakeAddress),
+        ]);
+
+        const baseApr = new BigNumber(apr).minus(rawBoostedApr);
+
+        return baseApr.toFixed();
+    }
+
     async computeRewardsRemainingDays(stakeAddress: string): Promise<number> {
         const [perBlockRewardAmount, accumulatedRewards, rewardsCapacity] =
             await Promise.all([

--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -492,6 +492,9 @@ export class UserEnergyComputeService {
                 }
             }
         }
+        if (lockedTokensAttributes.length === 0) {
+            return false;
+        }
         return true;
     }
 
@@ -503,6 +506,9 @@ export class UserEnergyComputeService {
             if (attributes.unlockEpoch > currentEpoch) {
                 return false;
             }
+        }
+        if (lockedTokensAttributes.length === 0) {
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
## Reasoning
- negative energy query returns false positive
- wrong values for `dualFarmBaseAPR` field of PairCompoundedAPR model
- 
  
## Proposed Changes
- return `false` on negative energy query when no locked tokens are present
- add stake farm base APR compute method + use it in Pair compounded APR field resolver 


## How to test
- `userNegativeEnergyCheck` query should return false when there're no locked tokens of a certain type

