### PR TITLE
[SERVICES-2513] Caching optimizations

### DIFF
--- a/src/helpers/decorators/caching.decorator.ts
+++ b/src/helpers/decorators/caching.decorator.ts
@@ -48,13 +48,9 @@ export function GetOrSetCache(cachingOptions: ICachingOptions) {
 
             const value = await originalMethod.apply(this, args);
 
-            console.log('CACHE MISS', cacheKey);
-
             let { remoteTtl, localTtl } = cachingOptions;
 
             if (typeof value === 'undefined' || value === null) {
-                console.log('NULL', cacheKey, value);
-
                 remoteTtl = CacheTtlInfo.NullValue.remoteTtl;
                 localTtl = CacheTtlInfo.NullValue.localTtl;
             }

--- a/src/modules/farm/base-module/services/farm.setter.service.ts
+++ b/src/modules/farm/base-module/services/farm.setter.service.ts
@@ -282,7 +282,6 @@ export abstract class FarmSetterService extends GenericSetterService {
     }
 
     async setFarmBaseAPR(farmAddress: string, value: string): Promise<string> {
-        console.log(this.getCacheKey('farmBaseAPR', farmAddress));
         return await this.setData(
             this.getCacheKey('farmBaseAPR', farmAddress),
             value,
@@ -295,7 +294,6 @@ export abstract class FarmSetterService extends GenericSetterService {
         farmAddress: string,
         value: string,
     ): Promise<string> {
-        console.log(this.getCacheKey('farmBoostedAPR', farmAddress));
         return await this.setData(
             this.getCacheKey('maxBoostedApr', farmAddress),
             value,

--- a/src/modules/farm/base-module/services/farm.setter.service.ts
+++ b/src/modules/farm/base-module/services/farm.setter.service.ts
@@ -280,4 +280,27 @@ export abstract class FarmSetterService extends GenericSetterService {
             CacheTtlInfo.ContractInfo.localTtl,
         );
     }
+
+    async setFarmBaseAPR(farmAddress: string, value: string): Promise<string> {
+        console.log(this.getCacheKey('farmBaseAPR', farmAddress));
+        return await this.setData(
+            this.getCacheKey('farmBaseAPR', farmAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+
+    async setFarmBoostedAPR(
+        farmAddress: string,
+        value: string,
+    ): Promise<string> {
+        console.log(this.getCacheKey('farmBoostedAPR', farmAddress));
+        return await this.setData(
+            this.getCacheKey('maxBoostedApr', farmAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
 }

--- a/src/modules/pair/services/pair.setter.service.ts
+++ b/src/modules/pair/services/pair.setter.service.ts
@@ -402,4 +402,28 @@ export class PairSetterService extends GenericSetterService {
             CacheTtlInfo.ContractState.localTtl,
         );
     }
+
+    async setInitialLiquidityAdder(
+        pairAddress: string,
+        value: string,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('initialLiquidityAdder', pairAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+
+    async setTrustedSwapPairs(
+        pairAddress: string,
+        value: string[],
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('trustedSwapPairs', pairAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
 }

--- a/src/modules/router/services/router.service.ts
+++ b/src/modules/router/services/router.service.ts
@@ -287,6 +287,10 @@ export class RouterService {
     ): Promise<PairMetadata[]> {
         let sortFieldData = [];
 
+        if (!sortField) {
+            return pairsMetadata;
+        }
+
         switch (sortField) {
             case PairSortableFields.DEPLOYED_AT:
                 sortFieldData = await Promise.all(

--- a/src/modules/staking/services/staking.setter.service.ts
+++ b/src/modules/staking/services/staking.setter.service.ts
@@ -213,4 +213,28 @@ export class StakingSetterService extends GenericSetterService {
             CacheTtlInfo.ContractBalance.localTtl,
         );
     }
+
+    async setStakeFarmBaseAPR(
+        stakeAddress: string,
+        value: string,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('stakeFarmBaseAPR', stakeAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+
+    async setStakeFarmBoostedAPR(
+        stakeAddress: string,
+        value: string,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('boostedApr', stakeAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
 }

--- a/src/modules/tokens/services/token.setter.service.ts
+++ b/src/modules/tokens/services/token.setter.service.ts
@@ -146,6 +146,15 @@ export class TokenSetterService extends GenericSetterService {
         );
     }
 
+    async setCreatedAt(tokenID: string, value: string): Promise<string> {
+        return await this.setData(
+            `token.tokenCreatedAt.${tokenID}`,
+            value,
+            CacheTtlInfo.Token.remoteTtl,
+            CacheTtlInfo.Token.localTtl,
+        );
+    }
+
     private getTokenCacheKey(tokenID: string, ...args: any): string {
         return generateCacheKeyFromParams('token', tokenID, args);
     }

--- a/src/modules/tokens/specs/token.service.spec.ts
+++ b/src/modules/tokens/specs/token.service.spec.ts
@@ -62,8 +62,5 @@ describe('TokenService', () => {
         await cachingService.deleteInCache(cacheKey);
         token = await service.tokenMetadata(tokenID);
         expect(token).toEqual(undefined);
-
-        token = await service.tokenMetadata(tokenID);
-        expect(token).toEqual(expectedToken);
     });
 });

--- a/src/services/cache.warmer.module.ts
+++ b/src/services/cache.warmer.module.ts
@@ -36,6 +36,7 @@ import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { GovernanceCacheWarmerService } from './crons/governance.cache.warmer.service';
 import { GovernanceModule } from '../modules/governance/governance.module';
 import { TokensCacheWarmerService } from './crons/tokens.cache.warmer.service';
+import { FarmModuleV2 } from 'src/modules/farm/v2/farm.v2.module';
 
 @Module({
     imports: [
@@ -48,6 +49,7 @@ import { TokensCacheWarmerService } from './crons/tokens.cache.warmer.service';
         FarmModule,
         FarmModuleV1_2,
         FarmModuleV1_3,
+        FarmModuleV2,
         StakingModule,
         StakingProxyModule,
         MetabondingModule,

--- a/src/services/caching/cache.ttl.info.ts
+++ b/src/services/caching/cache.ttl.info.ts
@@ -43,4 +43,9 @@ export class CacheTtlInfo {
         Constants.oneHour(),
         Constants.oneMinute() * 45,
     );
+
+    static NullValue: CacheTtlInfo = new CacheTtlInfo(
+        Constants.oneMinute() * 2,
+        Constants.oneMinute(),
+    );
 }

--- a/src/services/crons/farm.cache.warmer.service.ts
+++ b/src/services/crons/farm.cache.warmer.service.ts
@@ -121,11 +121,7 @@ export class FarmCacheWarmerService {
 
     @Cron(CronExpression.EVERY_MINUTE)
     async cacheFarmsV2APRs(): Promise<void> {
-        for (const address of farmsAddresses()) {
-            if (farmVersion(address) !== FarmVersion.V2) {
-                continue;
-            }
-
+        for (const address of farmsAddresses([FarmVersion.V2])) {
             const [baseApr, boostedApr] = await Promise.all([
                 this.farmComputeV2.computeFarmBaseAPR(address),
                 this.farmComputeV2.computeMaxBoostedApr(address),

--- a/src/services/crons/staking.cache.warmer.service.ts
+++ b/src/services/crons/staking.cache.warmer.service.ts
@@ -56,12 +56,16 @@ export class StakingCacheWarmerService {
                 divisionSafetyConstant,
                 state,
                 apr,
+                baseApr,
+                boostedApr,
             ] = await Promise.all([
                 this.stakingAbi.getAnnualPercentageRewardsRaw(address),
                 this.stakingAbi.getMinUnbondEpochsRaw(address),
                 this.stakingAbi.getDivisionSafetyConstantRaw(address),
                 this.stakingAbi.getStateRaw(address),
                 this.stakeCompute.computeStakeFarmAPR(address),
+                this.stakeCompute.computeStakeFarmBaseAPR(address),
+                this.stakeCompute.computeBoostedApr(address),
             ]);
 
             const cacheKeys = await Promise.all([
@@ -79,6 +83,11 @@ export class StakingCacheWarmerService {
                 ),
                 this.stakeSetterService.setState(address, state),
                 this.stakeSetterService.setStakeFarmAPR(address, apr),
+                this.stakeSetterService.setStakeFarmBaseAPR(address, baseApr),
+                this.stakeSetterService.setStakeFarmBoostedAPR(
+                    address,
+                    boostedApr,
+                ),
             ]);
 
             await this.deleteCacheKeys(cacheKeys);

--- a/src/services/crons/tokens.cache.warmer.service.ts
+++ b/src/services/crons/tokens.cache.warmer.service.ts
@@ -69,6 +69,7 @@ export class TokensCacheWarmerService {
                 pricePrevious24h,
                 pricePrevious7D,
                 liquidityUSD,
+                createdAt,
             ] = await Promise.all([
                 this.tokenComputeService.computeTokenLast2DaysVolumeUSD(
                     tokenID,
@@ -76,6 +77,9 @@ export class TokensCacheWarmerService {
                 this.tokenComputeService.computeTokenPrevious24hPrice(tokenID),
                 this.tokenComputeService.computeTokenPrevious7dPrice(tokenID),
                 this.tokenComputeService.computeTokenLiquidityUSD(tokenID),
+                this.tokenComputeService.computeTokenCreatedAtTimestamp(
+                    tokenID,
+                ),
             ]);
 
             const cachedKeys = await Promise.all([
@@ -92,6 +96,7 @@ export class TokensCacheWarmerService {
                     pricePrevious7D,
                 ),
                 this.tokenSetterService.setLiquidityUSD(tokenID, liquidityUSD),
+                this.tokenSetterService.setCreatedAt(tokenID, createdAt),
             ]);
             await this.deleteCacheKeys(cachedKeys);
         }

--- a/src/services/generics/generic.setter.service.ts
+++ b/src/services/generics/generic.setter.service.ts
@@ -5,6 +5,7 @@ import { Logger } from 'winston';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { generateCacheKeyFromParams } from '../../utils/generate-cache-key';
 import { CacheTtlInfo } from '../caching/cache.ttl.info';
+import { formatNullOrUndefined } from 'src/utils/cache.utils';
 
 @Injectable()
 export class GenericSetterService {
@@ -25,10 +26,12 @@ export class GenericSetterService {
             localTtl = CacheTtlInfo.NullValue.localTtl;
         }
 
-        value = typeof value === 'undefined' ? 'undefined' : value;
-        value = value === null ? 'null' : value;
-
-        await this.cachingService.set(cacheKey, value, remoteTtl, localTtl);
+        await this.cachingService.set(
+            cacheKey,
+            formatNullOrUndefined(value),
+            remoteTtl,
+            localTtl,
+        );
         return cacheKey;
     }
 

--- a/src/services/generics/generic.setter.service.ts
+++ b/src/services/generics/generic.setter.service.ts
@@ -4,6 +4,7 @@ import { generateSetLogMessage } from 'src/utils/generate-log-message';
 import { Logger } from 'winston';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { generateCacheKeyFromParams } from '../../utils/generate-cache-key';
+import { CacheTtlInfo } from '../caching/cache.ttl.info';
 
 @Injectable()
 export class GenericSetterService {
@@ -19,6 +20,14 @@ export class GenericSetterService {
         remoteTtl: number,
         localTtl?: number,
     ): Promise<string> {
+        if (typeof value === 'undefined' || value === null) {
+            remoteTtl = CacheTtlInfo.NullValue.remoteTtl;
+            localTtl = CacheTtlInfo.NullValue.localTtl;
+        }
+
+        value = typeof value === 'undefined' ? 'undefined' : value;
+        value = value === null ? 'null' : value;
+
         await this.cachingService.set(cacheKey, value, remoteTtl, localTtl);
         return cacheKey;
     }

--- a/src/utils/cache.utils.ts
+++ b/src/utils/cache.utils.ts
@@ -1,0 +1,23 @@
+export const formatNullOrUndefined = (value: any): any => {
+    if (typeof value === 'undefined') {
+        return 'undefined';
+    }
+
+    if (value === null) {
+        return 'null';
+    }
+
+    return value;
+};
+
+export const parseCachedNullOrUndefined = (cachedValue: any): any => {
+    if (cachedValue === 'undefined') {
+        return undefined;
+    }
+
+    if (cachedValue === 'null') {
+        return null;
+    }
+
+    return cachedValue;
+};


### PR DESCRIPTION
## Reasoning
- high cache miss rate on pair field resolvers 
  
## Proposed Changes
- cache `undefined` and `null` values in `GetOrSet` decorator, as well as GenericSetter (cache) service 
- add more fields to pairs, tokens, farms and staking cache warmers

## How to test
- N/A
