### PR TITLE
[SERVICES-2525] Fix for candlesticks response next time

### DIFF
--- a/src/modules/trading-view/services/trading.view.service.ts
+++ b/src/modules/trading-view/services/trading.view.service.ts
@@ -175,10 +175,24 @@ export class TradingViewService {
         });
 
         if (priceCandles.length === 0) {
-            return new BarsResponse({
+            const seriesStartDate =
+                await this.analyticsQueryService.getStartDate(series);
+
+            const noDataResponse = new BarsResponse({
                 s: 'no_data',
-                nextTime: start - 1,
             });
+
+            if (!seriesStartDate) {
+                return noDataResponse;
+            }
+
+            const seriesStartUnix = moment(seriesStartDate).unix();
+
+            if (start > seriesStartUnix) {
+                noDataResponse.nextTime = start - 1;
+            }
+
+            return noDataResponse;
         }
 
         return this.formatCandlesResponse(metric, priceCandles, tokenDecimals);

--- a/src/services/analytics/interfaces/analytics.query.interface.ts
+++ b/src/services/analytics/interfaces/analytics.query.interface.ts
@@ -45,4 +45,6 @@ export interface AnalyticsQueryInterface {
         start,
         end,
     }): Promise<OhlcvDataModel[]>;
+
+    getStartDate(series: string): Promise<string>;
 }

--- a/src/services/analytics/mocks/analytics.query.service.mock.ts
+++ b/src/services/analytics/mocks/analytics.query.service.mock.ts
@@ -52,6 +52,9 @@ export class AnalyticsQueryServiceMock implements AnalyticsQueryInterface {
     getCandles({ series, metric, start, end }): Promise<OhlcvDataModel[]> {
         throw new Error('Method not implemented.');
     }
+    getStartDate(series: string): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
 }
 
 export const AnalyticsQueryServiceProvider = {

--- a/src/services/analytics/services/analytics.query.service.ts
+++ b/src/services/analytics/services/analytics.query.service.ts
@@ -116,6 +116,11 @@ export class AnalyticsQueryService implements AnalyticsQueryInterface {
         });
     }
 
+    async getStartDate(series: string): Promise<string | undefined> {
+        const service = await this.getService();
+        return await service.getStartDate(series);
+    }
+
     private async getService(): Promise<AnalyticsQueryInterface> {
         return this.timescaleDBQuery;
     }

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -421,7 +421,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
         );
     }
 
-    private async getStartDate(series: string): Promise<string | undefined> {
+    async getStartDate(series: string): Promise<string | undefined> {
         const cacheKey = `startDate.${series}`;
         const cachedValue = await this.cacheService.get<string>(cacheKey);
         if (cachedValue !== undefined) {


### PR DESCRIPTION
## Reasoning
- there's currently no check for the start of activity on a pair / token when returning `nextTime` on empty intervals. This causes the library to perform a series of requests (+30) before initial render

  
## Proposed Changes
- compare request `start` parameter with the series start date before returning `nextTime` in intervals without data (signals to the frontend TV library that there are no more candles in the past) 

## How to test
- N/A

