### PR TITLE
[MEX-494] farm token supply for week

### DIFF
--- a/src/modules/farm/models/farm.v2.model.ts
+++ b/src/modules/farm/models/farm.v2.model.ts
@@ -48,6 +48,8 @@ export class FarmModelV2 extends BaseFarmModel {
     @Field()
     lastGlobalUpdateWeek: number;
     @Field()
+    farmTokenSupplyCurrentWeek: string;
+    @Field()
     baseApr: string;
     @Field()
     boostedApr: string;

--- a/src/modules/farm/v2/farm.v2.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.resolver.ts
@@ -159,6 +159,14 @@ export class FarmResolverV2 extends FarmResolver {
         return this.farmAbi.energyFactoryAddress(parent.address);
     }
 
+    @ResolveField()
+    async farmTokenSupplyCurrentWeek(
+        @Parent() parent: FarmModelV2,
+    ): Promise<string> {
+        const week = await this.weekTimekeepingAbi.currentWeek(parent.address);
+        return this.farmAbi.farmSupplyForWeek(parent.address, week);
+    }
+
     @UseGuards(JwtOrNativeAuthGuard)
     @Query(() => [UserTotalBoostedPosition], {
         description: 'Returns the total farm position of the user in the farm',

--- a/src/modules/farm/v2/services/farm.v2.abi.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.service.ts
@@ -436,4 +436,32 @@ export class FarmAbiServiceV2
         const response = await this.getGenericData(interaction);
         return response.firstValue.valueOf().toNumber();
     }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'farm',
+        remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
+        localTtl: CacheTtlInfo.ContractInfo.localTtl,
+    })
+    async farmSupplyForWeek(
+        farmAddress: string,
+        week: number,
+    ): Promise<string> {
+        return this.getFarmSupplyForWeekRaw(farmAddress, week);
+    }
+
+    async getFarmSupplyForWeekRaw(
+        farmAddress: string,
+        week: number,
+    ): Promise<string> {
+        const contract = await this.mxProxy.getFarmSmartContract(farmAddress);
+        const interaction: Interaction =
+            contract.methodsExplicit.getFarmSupplyForWeek([
+                new U32Value(new BigNumber(week)),
+            ]);
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().toFixed();
+    }
 }

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -67,6 +67,8 @@ export class StakingModel {
     @Field()
     lastGlobalUpdateWeek: number;
     @Field()
+    farmTokenSupplyCurrentWeek: string;
+    @Field()
     energyFactoryAddress: string;
     @Field({ description: 'Accumulated boosted rewards for specific week' })
     accumulatedRewardsForWeek: string;

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -633,6 +633,36 @@ export class StakingAbiService
         logArgs: true,
     })
     @GetOrSetCache({
+        baseKey: 'farm',
+        remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
+        localTtl: CacheTtlInfo.ContractInfo.localTtl,
+    })
+    async farmSupplyForWeek(
+        farmAddress: string,
+        week: number,
+    ): Promise<string> {
+        return this.getFarmSupplyForWeekRaw(farmAddress, week);
+    }
+
+    async getFarmSupplyForWeekRaw(
+        farmAddress: string,
+        week: number,
+    ): Promise<string> {
+        const contract = await this.mxProxy.getStakingSmartContract(
+            farmAddress,
+        );
+        const interaction: Interaction =
+            contract.methodsExplicit.getFarmSupplyForWeek([
+                new U32Value(new BigNumber(week)),
+            ]);
+        const response = await this.getGenericData(interaction);
+        return response.firstValue.valueOf().toFixed();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
         baseKey: 'stake',
         remoteTtl: CacheTtlInfo.ContractInfo.remoteTtl,
         localTtl: CacheTtlInfo.ContractInfo.localTtl,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -192,6 +192,14 @@ export class StakingResolver {
     }
 
     @ResolveField()
+    async farmTokenSupplyCurrentWeek(
+        @Parent() parent: StakingModel,
+    ): Promise<string> {
+        const week = await this.weekTimekeepingAbi.currentWeek(parent.address);
+        return this.stakingAbi.farmSupplyForWeek(parent.address, week);
+    }
+
+    @ResolveField()
     async energyFactoryAddress(
         @Parent() parent: StakingModel,
     ): Promise<string> {


### PR DESCRIPTION
## Reasoning
- missing information for farm and staking contracts
  
## Proposed Changes
- added methods to get farm token supply for week from farms and staking contracts
- added field resolvers for farm token supply for current week on farms and staking resolvers

## How to test
```
query Stakings {
    stakingFarms {
        address
        farmTokenSupplyCurrentWeek
    }
}
```
- query should return value on staking boosted rewards contracts