### PR TITLE
[MEX-496] fix metabonding negative energy check

### DIFF
--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -454,20 +454,23 @@ export class UserEnergyComputeService {
             const userMetabondingEntry = await this.metabondingAbi.userEntry(
                 userAddress,
             );
-            const metabondingTokensAttributes =
-                await this.mxApi.getNftAttributesByTokenIdentifier(
-                    scAddress.metabondingStakingAddress,
-                    tokenIdentifier(
-                        lkmexTokenID,
-                        userMetabondingEntry.tokenNonce,
+
+            if (userMetabondingEntry.tokenNonce > 0) {
+                const metabondingTokensAttributes =
+                    await this.mxApi.getNftAttributesByTokenIdentifier(
+                        scAddress.metabondingStakingAddress,
+                        tokenIdentifier(
+                            lkmexTokenID,
+                            userMetabondingEntry.tokenNonce,
+                        ),
+                    );
+                metabondingCheck = this.checkLKMEXNegativeEnergy(stats.epoch, [
+                    LockedAssetAttributes.fromAttributes(
+                        userMetabondingEntry.tokenNonce >= lkmexActivationNonce,
+                        metabondingTokensAttributes,
                     ),
-                );
-            metabondingCheck = this.checkLKMEXNegativeEnergy(stats.epoch, [
-                LockedAssetAttributes.fromAttributes(
-                    userMetabondingEntry.tokenNonce >= lkmexActivationNonce,
-                    metabondingTokensAttributes,
-                ),
-            ]);
+                ]);
+            }
         }
 
         return new UserNegativeEnergyCheck({


### PR DESCRIPTION
## Reasoning
- metabonding energy for user returns default value if no tokens staked
  
## Proposed Changes
- check for valid staked token nonce on metabonding negative energy check

## How to test
```
query NegativeEnergyCheck {
    userNegativeEnergyCheck {
        metabonding
    }
}
```
- query should not return error if no tokens staked in metabonding staking sc