### PR TITLE
[SERVICES-2532] Expose extra fields on pair model

### DIFF
--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -210,6 +210,15 @@ export class PairModel {
     @Field(() => PairRewardTokensModel, { nullable: true })
     rewardTokens: PairRewardTokensModel;
 
+    @Field({ nullable: true })
+    farmAddress: string;
+
+    @Field({ nullable: true })
+    stakingFarmAddress: string;
+
+    @Field({ nullable: true })
+    stakingProxyAddress: string;
+
     constructor(init?: Partial<PairModel>) {
         Object.assign(this, init);
     }

--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -214,9 +214,6 @@ export class PairModel {
     farmAddress: string;
 
     @Field({ nullable: true })
-    stakingFarmAddress: string;
-
-    @Field({ nullable: true })
     stakingProxyAddress: string;
 
     constructor(init?: Partial<PairModel>) {

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -397,6 +397,23 @@ export class PairResolver {
         return new PairRewardTokensModel({ address: parent.address });
     }
 
+    @ResolveField()
+    async farmAddress(@Parent() parent: PairModel): Promise<string> {
+        return await this.pairCompute.getPairFarmAddress(parent.address);
+    }
+
+    @ResolveField()
+    async stakingFarmAddress(@Parent() parent: PairModel): Promise<string> {
+        return await this.pairCompute.getPairStakingFarmAddress(parent.address);
+    }
+
+    @ResolveField()
+    async stakingProxyAddress(@Parent() parent: PairModel): Promise<string> {
+        return await this.pairCompute.getPairStakingProxyAddress(
+            parent.address,
+        );
+    }
+
     @Query(() => String)
     async getAmountOut(
         @Args('pairAddress') pairAddress: string,

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -403,11 +403,6 @@ export class PairResolver {
     }
 
     @ResolveField()
-    async stakingFarmAddress(@Parent() parent: PairModel): Promise<string> {
-        return await this.pairCompute.getPairStakingFarmAddress(parent.address);
-    }
-
-    @ResolveField()
     async stakingProxyAddress(@Parent() parent: PairModel): Promise<string> {
         return await this.pairCompute.getPairStakingProxyAddress(
             parent.address,


### PR DESCRIPTION
## Reasoning
- exposing the farm address and staking proxy address on the Pair model would reduce the number of needed queries on the `Create position` page
  
## Proposed Changes
- expose `farmAddress` and `stakingProxyAddress` fields on the Pair model


## How to test
```
query {
  filteredPairs(
    filters: {}
    pagination: { first: 100 }
    sorting: { sortField: TVL, sortOrder: DESC }
  ) {
    edges {
      cursor
      node {
        address
        firstToken {
          name
          identifier
        }
        secondToken {
          name
          identifier
        }
        farmAddress
        stakingProxyAddress
      }
    }
    pageInfo {
      startCursor
      endCursor
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
