### PR TITLE
[SERVICES-2532] return staking proxy address with farm V2 for pair model

### DIFF
--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -780,15 +780,16 @@ export class PairComputeService implements IPairComputeService {
 
         const stakingProxyAddresses =
             await this.remoteConfigGetterService.getStakingProxyAddresses();
+        const farmAddress = await this.getPairFarmAddress(pairAddress);
 
-        const pairAddresses = await Promise.all(
+        const farmsAddresses = await Promise.all(
             stakingProxyAddresses.map((address) =>
-                this.stakingProxyAbiService.pairAddress(address),
+                this.stakingProxyAbiService.lpFarmAddress(address),
             ),
         );
 
-        const stakingProxyIndex = pairAddresses.findIndex(
-            (address) => address === pairAddress,
+        const stakingProxyIndex = farmsAddresses.findIndex(
+            (address) => address === farmAddress,
         );
 
         return stakingProxyIndex === -1


### PR DESCRIPTION
## Reasoning
- stakingProxyAddress field from pair model returns old version of smart contract
  
## Proposed Changes
- return stakingProxyAddress based on the farm v2 address for pair field

## How to test
```
query Pairs {
  pairs(offset: 0, limit: 50) {
    address
    firstToken {
        identifier
    }
    secondToken {
        identifier
    }
    farmAddress
    stakingProxyAddress
  }
}
```
- query should return a staking proxy address associated with a farm v2