### PR TITLE
[MEX-497] use cached data to compute totalVolumeUSD24h

### DIFF
--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { ContextModule } from 'src/services/context/context.module';
 import { MXCommunicationModule } from 'src/services/multiversx-communication/mx.communication.module';
 import { PairModule } from '../pair/pair.module';
@@ -27,7 +27,7 @@ import { AnalyticsSetterService } from './services/analytics.setter.service';
         AnalyticsServicesModule,
         MXCommunicationModule,
         ContextModule,
-        RouterModule,
+        forwardRef(() => RouterModule),
         PairModule,
         FarmModule,
         ProxyModule,

--- a/src/modules/router/router.module.ts
+++ b/src/modules/router/router.module.ts
@@ -15,6 +15,7 @@ import { ElasticService } from 'src/helpers/elastic.service';
 import { SwapEnableConfigResolver } from './swap.enable.config.resolver';
 import { SimpleLockModule } from '../simple-lock/simple.lock.module';
 import { ESTransactionsService } from 'src/services/elastic-search/services/es.transactions.service';
+import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
     imports: [
@@ -22,6 +23,7 @@ import { ESTransactionsService } from 'src/services/elastic-search/services/es.t
         MXCommunicationModule,
         PairModule,
         SimpleLockModule,
+        AnalyticsModule,
         ContextModule,
         WrappingModule,
         RemoteConfigModule,

--- a/src/modules/router/services/router.compute.service.ts
+++ b/src/modules/router/services/router.compute.service.ts
@@ -51,36 +51,6 @@ export class RouterComputeService {
         baseKey: 'router',
         remoteTtl: Constants.oneMinute() * 5,
     })
-    async totalVolumeUSD(time: string): Promise<BigNumber> {
-        return await this.computeTotalVolumeUSD(time);
-    }
-
-    async computeTotalVolumeUSD(time: string): Promise<BigNumber> {
-        const pairsAddress = await this.routerAbi.pairsAddress();
-        let totalVolumeUSD = new BigNumber(0);
-
-        const promises = pairsAddress.map((pairAddress) =>
-            this.pairCompute.volumeUSD(pairAddress, time),
-        );
-
-        const volumesUSD = await Promise.all(promises);
-        for (const volumeUSD of volumesUSD) {
-            totalVolumeUSD =
-                volumeUSD !== 'NaN'
-                    ? totalVolumeUSD.plus(volumeUSD)
-                    : totalVolumeUSD;
-        }
-
-        return totalVolumeUSD;
-    }
-
-    @ErrorLoggerAsync({
-        logArgs: true,
-    })
-    @GetOrSetCache({
-        baseKey: 'router',
-        remoteTtl: Constants.oneMinute() * 5,
-    })
     async totalFeesUSD(time: string): Promise<BigNumber> {
         return await this.computeTotalFeesUSD(time);
     }

--- a/src/modules/router/services/router.setter.service.ts
+++ b/src/modules/router/services/router.setter.service.ts
@@ -48,14 +48,6 @@ export class RouterSetterService extends GenericSetterService {
         );
     }
 
-    async setTotalVolumeUSD(time: string, value: string): Promise<string> {
-        return await this.setData(
-            this.getCacheKey('totalVolumeUSD', time),
-            value,
-            Constants.oneMinute(),
-        );
-    }
-
     async setTotalFeesUSD(time: string, value: string): Promise<string> {
         return await this.setData(
             this.getCacheKey('totalFeesUSD', time),


### PR DESCRIPTION
## Reasoning
- compute total volumes for 24h takes too long when no value is cached
  
## Proposed Changes
- use data from analytics cached values for volumes to compute total volumes in 24h

## How to test
```
query Factory {
    factory {
        totalVolumeUSD24h
    }
}
```
- query should return value when the cron job finished to refresh the volumes