### PR TITLE
[MEX-498] Add filtering of farms query

### DIFF
--- a/src/modules/farm/farm.factory.ts
+++ b/src/modules/farm/farm.factory.ts
@@ -20,10 +20,10 @@ export class FarmFactoryService {
         private readonly farmServiceV2: FarmServiceV2,
     ) {}
 
-    getFarms(filters: FarmsFilter): Array<typeof FarmsUnion> {
+    getFarms(filters?: FarmsFilter): Array<typeof FarmsUnion> {
         const farms: Array<typeof FarmsUnion> = [];
-        let addresses = farmsAddresses(filters.versions);
-        if (filters.addresses) {
+        let addresses = farmsAddresses(filters?.versions);
+        if (filters?.addresses) {
             addresses = addresses.filter((address) =>
                 filters.addresses.includes(address),
             );

--- a/src/modules/farm/farm.factory.ts
+++ b/src/modules/farm/farm.factory.ts
@@ -10,6 +10,7 @@ import { FarmServiceV1_3 } from './v1.3/services/farm.v1.3.service';
 import { FarmServiceV2 } from './v2/services/farm.v2.service';
 import { FarmServiceBase } from './base-module/services/farm.base.service';
 import { FarmModelV2 } from './models/farm.v2.model';
+import { FarmsFilter } from './models/farm.args';
 
 @Injectable()
 export class FarmFactoryService {
@@ -19,9 +20,16 @@ export class FarmFactoryService {
         private readonly farmServiceV2: FarmServiceV2,
     ) {}
 
-    getFarms(): Array<typeof FarmsUnion> {
+    getFarms(filters: FarmsFilter): Array<typeof FarmsUnion> {
         const farms: Array<typeof FarmsUnion> = [];
-        for (const address of farmsAddresses()) {
+        let addresses = farmsAddresses(filters.versions);
+        if (filters.addresses) {
+            addresses = addresses.filter((address) =>
+                filters.addresses.includes(address),
+            );
+        }
+
+        for (const address of addresses) {
             const version = farmVersion(address);
             switch (version) {
                 case FarmVersion.V1_2:

--- a/src/modules/farm/farm.query.resolver.ts
+++ b/src/modules/farm/farm.query.resolver.ts
@@ -5,6 +5,7 @@ import { FarmFactoryService } from './farm.factory';
 import {
     BatchFarmRewardsComputeArgs,
     CalculateRewardsArgs,
+    FarmsFilter,
 } from './models/farm.args';
 import { ExitFarmTokensModel, RewardsModel } from './models/farm.model';
 import { FarmsUnion } from './models/farm.union';
@@ -15,8 +16,15 @@ export class FarmQueryResolver {
     constructor(private readonly farmFactory: FarmFactoryService) {}
 
     @Query(() => [FarmsUnion])
-    async farms(): Promise<Array<typeof FarmsUnion>> {
-        return this.farmFactory.getFarms();
+    async farms(
+        @Args({
+            name: 'filters',
+            type: () => FarmsFilter,
+            nullable: true,
+        })
+        filters: FarmsFilter,
+    ): Promise<Array<typeof FarmsUnion>> {
+        return this.farmFactory.getFarms(filters);
     }
 
     @UseGuards(JwtOrNativeAuthGuard)

--- a/src/modules/farm/models/farm.args.ts
+++ b/src/modules/farm/models/farm.args.ts
@@ -2,6 +2,15 @@ import { ArgsType, Field, InputType, Int } from '@nestjs/graphql';
 import { InputTokenModel } from 'src/models/inputToken.model';
 
 @InputType()
+export class FarmsFilter {
+    @Field(() => [String], { nullable: true })
+    versions?: string[];
+
+    @Field(() => [String], { nullable: true })
+    addresses?: string[];
+}
+
+@InputType()
 export class CalculateRewardsArgs {
     @Field()
     farmAddress: string;


### PR DESCRIPTION
## Reasoning
- filter farms by address and version
  
## Proposed Changes
- added filtering on farms based on version and farm address

## How to test
```
query farmsPageDataQuery {
  farms(
    filters: {
        versions: ["v1.2", "v2"],
        addresses: [
            <farm_address>
        ]
    }
  ) {
    ...on FarmModelV1_2 {
        address
        version
    }
    ...on FarmModelV1_3 {
        address
        version
    }
    ...on FarmModelV2 {
        address
        version
    }
  }
}

```
- query should return filtered farms