### PR TITLE
[SERVICES-2533] Improve fetching series start date performance in timescaledb

### DIFF
--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -34,8 +34,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { TimescaleDBQuery } from 'src/helpers/decorators/timescaledb.query.decorator';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
-import { Constants } from '@multiversx/sdk-nestjs-common';
+import { Constants, ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { PriceCandlesResolutions } from 'src/modules/analytics/models/query.args';
+import { PerformanceProfiler } from '@multiversx/sdk-nestjs-monitoring';
+import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 
 @Injectable()
 export class TimescaleDBQueryService implements AnalyticsQueryInterface {
@@ -388,41 +390,56 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     }
 
     private async getStartDate(series: string): Promise<string | undefined> {
-        const cacheKey = `startDate.${series}`;
-        const cachedValue = await this.cacheService.get<string>(cacheKey);
-        if (cachedValue !== undefined) {
-            return cachedValue;
+        const allStartDates = await this.allStartDates();
+
+        if (!series.includes('%')) {
+            return allStartDates[series] ?? undefined;
         }
 
-        const seriesWhere = series.includes('%')
-            ? 'series LIKE :series'
-            : 'series = :series';
+        const seriesWithoutWildcard = series.replace(new RegExp('%', 'g'), '');
+        const filteredTimestamps = [];
+        for (const [key, value] of Object.entries(allStartDates)) {
+            if (!key.includes(seriesWithoutWildcard)) {
+                continue;
+            }
+            filteredTimestamps.push(moment(value));
+        }
 
-        const firstRow = await this.dexAnalytics
+        if (filteredTimestamps.length === 0) {
+            return undefined;
+        }
+
+        return moment.min(filteredTimestamps).toISOString();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'timescaledb',
+        remoteTtl: Constants.oneMinute() * 30,
+        localTtl: Constants.oneMinute() * 20,
+    })
+    private async allStartDates(): Promise<object> {
+        return await this.allStartDatesRaw();
+    }
+
+    private async allStartDatesRaw(): Promise<object> {
+        const startDateRows = await this.dexAnalytics
             .createQueryBuilder()
-            .select('timestamp')
-            .where(seriesWhere, { series })
-            .orderBy('timestamp', 'ASC')
-            .limit(1)
-            .getRawOne();
+            .select('series')
+            .addSelect('min(timestamp) as earliest_timestamp')
+            .groupBy('series')
+            .getRawMany();
 
-        if (firstRow) {
-            await this.cacheService.set(
-                cacheKey,
-                firstRow.timestamp,
-                Constants.oneMinute() * 30,
-                Constants.oneMinute() * 20,
-            );
-        } else {
-            await this.cacheService.set(
-                cacheKey,
-                null,
-                Constants.oneMinute() * 10,
-                Constants.oneMinute() * 7,
-            );
+        const allDates = {};
+
+        for (let i = 0; i < startDateRows.length; i++) {
+            const row = startDateRows[i];
+            allDates[row.series] = row.earliest_timestamp;
         }
 
-        return firstRow?.timestamp;
+        return allDates;
     }
 
     @TimescaleDBQuery()


### PR DESCRIPTION
## Reasoning
- the query performed in cases where manual gapfilling is needed has poor performance on series without any activity (+3s)
  
## Proposed Changes
- make a single query for fetching start dates for all series

## How to test
- N/A
