### PR TITLE
SERVICES-2538: add trending score config for battlenet

### DIFF
--- a/src/config/shadowfork2.json
+++ b/src/config/shadowfork2.json
@@ -120,6 +120,13 @@
             "USDC-c76f1f": "5000000",
             "WEGLD-bd4d79": "100000000000000000",
             "MEX-455c57": "1000000000000000000000000"
+        },
+        "trendingScore": {
+          "MIN_24H_VOLUME": 10000,
+          "MIN_24H_TRADE_COUNT": 100,
+          "PRICE_WEIGHT": 0.5,
+          "VOLUME_WEIGHT": 0.5,
+          "TRADES_COUNT_WEIGHT": 0
         }
     }
 }


### PR DESCRIPTION
## Reasoning
- too few trades on battlenet affects computed trending score for tokens
  
## Proposed Changes
- add trending score config values to battlenet config
- reduce trades count weight to 0

## How to test
- N/A
