### PR TITLE
[MEX-502] fixes on staking module

### DIFF
--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -161,7 +161,7 @@ export class PairCompoundedAPRResolver extends GenericResolver {
             return '0';
         }
 
-        return await this.stakingCompute.boostedApr(stakingAddress);
+        return await this.stakingCompute.boostedAPR(stakingAddress);
     }
 }
 

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -830,7 +830,7 @@ export class PairComputeService implements IPairComputeService {
         if (stakingFarmAddress) {
             const [dualFarmBaseAPR, dualFarmBoostedAPR] = await Promise.all([
                 this.stakingCompute.stakeFarmAPR(stakingFarmAddress),
-                this.stakingCompute.boostedApr(stakingFarmAddress),
+                this.stakingCompute.boostedAPR(stakingFarmAddress),
             ]);
 
             dualFarmBaseAprBN = new BigNumber(dualFarmBaseAPR);

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -202,6 +202,20 @@ export class StakingComputeService {
     }
 
     async computeStakeFarmAPR(stakeAddress: string): Promise<string> {
+        const [accumulatedRewards, rewardsCapacity, produceRewardsEnabled] =
+            await Promise.all([
+                this.stakingAbi.accumulatedRewards(stakeAddress),
+                this.stakingAbi.rewardCapacity(stakeAddress),
+                this.stakingAbi.produceRewardsEnabled(stakeAddress),
+            ]);
+
+        if (
+            !produceRewardsEnabled ||
+            new BigNumber(accumulatedRewards).isEqualTo(rewardsCapacity)
+        ) {
+            return '0';
+        }
+
         const [
             annualPercentageRewards,
             perBlockRewardAmount,
@@ -234,24 +248,45 @@ export class StakingComputeService {
     @ErrorLoggerAsync({
         logArgs: true,
     })
-    @GetOrSetCache({
-        baseKey: 'stake',
-        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
-        localTtl: CacheTtlInfo.ContractState.localTtl,
-    })
     async stakeFarmBaseAPR(stakeAddress: string): Promise<string> {
         return await this.computeStakeFarmBaseAPR(stakeAddress);
     }
 
     async computeStakeFarmBaseAPR(stakeAddress: string): Promise<string> {
-        const [apr, rawBoostedApr] = await Promise.all([
+        const [apr, boostedApr] = await Promise.all([
             this.stakeFarmAPR(stakeAddress),
-            this.boostedApr(stakeAddress),
+            this.boostedAPR(stakeAddress),
         ]);
 
-        const baseApr = new BigNumber(apr).minus(rawBoostedApr);
+        const baseAPR = new BigNumber(apr).minus(boostedApr);
 
-        return baseApr.toFixed();
+        return baseAPR.toFixed();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    async boostedAPR(stakeAddress: string): Promise<string> {
+        return await this.computeBoostedAPR(stakeAddress);
+    }
+
+    async computeBoostedAPR(stakeAddress: string): Promise<string> {
+        const [boostedYieldsRewardsPercentage, apr] = await Promise.all([
+            this.stakingAbi.boostedYieldsRewardsPercenatage(stakeAddress),
+            this.stakeFarmAPR(stakeAddress),
+        ]);
+
+        const bnBoostedRewardsPercentage = new BigNumber(
+            boostedYieldsRewardsPercentage,
+        )
+            .dividedBy(constantsConfig.MAX_PERCENT)
+            .multipliedBy(100);
+
+        const boostedAPR = new BigNumber(apr).multipliedBy(
+            bnBoostedRewardsPercentage.dividedBy(100),
+        );
+
+        return boostedAPR.toFixed();
     }
 
     async computeRewardsRemainingDays(stakeAddress: string): Promise<number> {
@@ -777,36 +812,5 @@ export class StakingComputeService {
             stakeAddress,
         );
         return deployedAt ?? undefined;
-    }
-
-    @ErrorLoggerAsync({
-        logArgs: true,
-    })
-    @GetOrSetCache({
-        baseKey: 'stake',
-        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
-        localTtl: CacheTtlInfo.ContractState.localTtl,
-    })
-    async boostedApr(stakeAddress: string): Promise<string> {
-        return await this.computeBoostedApr(stakeAddress);
-    }
-
-    async computeBoostedApr(stakeAddress: string): Promise<string> {
-        const [boostedYieldsRewardsPercentage, apr] = await Promise.all([
-            this.stakingAbi.boostedYieldsRewardsPercenatage(stakeAddress),
-            this.stakeFarmAPR(stakeAddress),
-        ]);
-
-        const bnBoostedRewardsPercentage = new BigNumber(
-            boostedYieldsRewardsPercentage,
-        )
-            .dividedBy(constantsConfig.MAX_PERCENT)
-            .multipliedBy(100);
-
-        const rawBoostedApr = new BigNumber(apr).multipliedBy(
-            bnBoostedRewardsPercentage.dividedBy(100),
-        );
-
-        return rawBoostedApr.toFixed();
     }
 }

--- a/src/modules/staking/services/staking.setter.service.ts
+++ b/src/modules/staking/services/staking.setter.service.ts
@@ -213,28 +213,4 @@ export class StakingSetterService extends GenericSetterService {
             CacheTtlInfo.ContractBalance.localTtl,
         );
     }
-
-    async setStakeFarmBaseAPR(
-        stakeAddress: string,
-        value: string,
-    ): Promise<string> {
-        return await this.setData(
-            this.getCacheKey('stakeFarmBaseAPR', stakeAddress),
-            value,
-            CacheTtlInfo.ContractState.remoteTtl,
-            CacheTtlInfo.ContractState.localTtl,
-        );
-    }
-
-    async setStakeFarmBoostedAPR(
-        stakeAddress: string,
-        value: string,
-    ): Promise<string> {
-        return await this.setData(
-            this.getCacheKey('boostedApr', stakeAddress),
-            value,
-            CacheTtlInfo.ContractState.remoteTtl,
-            CacheTtlInfo.ContractState.localTtl,
-        );
-    }
 }

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -102,7 +102,7 @@ export class StakingResolver {
 
     @ResolveField()
     async boostedApr(@Parent() parent: StakingModel) {
-        return this.stakingCompute.boostedApr(parent.address);
+        return this.stakingCompute.boostedAPR(parent.address);
     }
 
     @ResolveField()

--- a/src/services/crons/staking.cache.warmer.service.ts
+++ b/src/services/crons/staking.cache.warmer.service.ts
@@ -56,16 +56,12 @@ export class StakingCacheWarmerService {
                 divisionSafetyConstant,
                 state,
                 apr,
-                baseApr,
-                boostedApr,
             ] = await Promise.all([
                 this.stakingAbi.getAnnualPercentageRewardsRaw(address),
                 this.stakingAbi.getMinUnbondEpochsRaw(address),
                 this.stakingAbi.getDivisionSafetyConstantRaw(address),
                 this.stakingAbi.getStateRaw(address),
                 this.stakeCompute.computeStakeFarmAPR(address),
-                this.stakeCompute.computeStakeFarmBaseAPR(address),
-                this.stakeCompute.computeBoostedAPR(address),
             ]);
 
             const cacheKeys = await Promise.all([
@@ -83,11 +79,6 @@ export class StakingCacheWarmerService {
                 ),
                 this.stakeSetterService.setState(address, state),
                 this.stakeSetterService.setStakeFarmAPR(address, apr),
-                this.stakeSetterService.setStakeFarmBaseAPR(address, baseApr),
-                this.stakeSetterService.setStakeFarmBoostedAPR(
-                    address,
-                    boostedApr,
-                ),
             ]);
 
             await this.deleteCacheKeys(cacheKeys);

--- a/src/services/crons/staking.cache.warmer.service.ts
+++ b/src/services/crons/staking.cache.warmer.service.ts
@@ -65,7 +65,7 @@ export class StakingCacheWarmerService {
                 this.stakingAbi.getStateRaw(address),
                 this.stakeCompute.computeStakeFarmAPR(address),
                 this.stakeCompute.computeStakeFarmBaseAPR(address),
-                this.stakeCompute.computeBoostedApr(address),
+                this.stakeCompute.computeBoostedAPR(address),
             ]);
 
             const cacheKeys = await Promise.all([


### PR DESCRIPTION
## Reasoning
- compute staking total value locked in USD was wrong
- staking APR should be 0 if no rewards are distributed
  
## Proposed Changes
- fixed computing for staking total value locked in USD
- added checks for computing staking APR to return 0 in case no rewards are distributed
- removed unnecessary caching from staking compute service

## How to test
```
query FilteredStaking {
    filteredStakingFarms(
        filters: {
            searchToken: ""
        }
        sorting: {
            sortField: TVL
            sortOrder: DESC
        }
    ) {
        edges {
            node {
                address
                farmToken {
                    collection
                }
                produceRewardsEnabled
                apr
                boostedApr
            }
        }
    }
}
```