### PR TITLE
[MEX-503] user energy league

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -629,5 +629,34 @@
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"
-    }
+    },
+    "leagues": [
+        {
+            "name": "Bronze",
+            "minEnergy": "720000000",
+            "maxEnergy": "7200000000"
+        },
+        {
+            "name": "Silver",
+            "minEnergy": "7200000000",
+            "maxEnergy": "72000000000"
+        
+        },
+        {
+            "name": "Gold",
+            "minEnergy": "72000000000",
+            "maxEnergy": "720000000000"
+        
+        },
+        {
+            "name": "Platinum",
+            "minEnergy": "720000000000",
+            "maxEnergy": "7200000000000"
+        
+        },
+        {
+            "name": "Diamond",
+            "minEnergy": "7200000000000"
+        }
+    ]
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,3 +32,5 @@ export const cachedTokensPriceConfig = config.get('cachedTokensPrice');
 export const constantsConfig = config.get('constants');
 
 export const dataApiConfig = config.get('dataApi');
+
+export const leaguesConfig = config.get('leagues');

--- a/src/modules/energy/energy.module.ts
+++ b/src/modules/energy/energy.module.ts
@@ -3,7 +3,7 @@ import { CommonAppModule } from 'src/common.app.module';
 import { ContextModule } from 'src/services/context/context.module';
 import { MXCommunicationModule } from 'src/services/multiversx-communication/mx.communication.module';
 import { TokenModule } from '../tokens/token.module';
-import { EnergyResolver } from './energy.resolver';
+import { EnergyResolver, UserEnergyResolver } from './energy.resolver';
 import { EnergyAbiService } from './services/energy.abi.service';
 import { EnergyComputeService } from './services/energy.compute.service';
 import { EnergyService } from './services/energy.service';
@@ -26,6 +26,7 @@ import { EnergyUpdateResolver } from './energy.update.resolver';
         EnergyTransactionService,
         EnergyResolver,
         EnergyUpdateResolver,
+        UserEnergyResolver,
     ],
     exports: [
         EnergyAbiService,

--- a/src/modules/energy/energy.resolver.ts
+++ b/src/modules/energy/energy.resolver.ts
@@ -30,7 +30,15 @@ import { ApolloServerErrorCode } from '@apollo/server/errors';
 
 @Resolver(() => UserEnergyModel)
 export class UserEnergyResolver {
-    constructor(private readonly energyService: EnergyService) {}
+    constructor(
+        private readonly energyService: EnergyService,
+        private readonly energyCompute: EnergyComputeService,
+    ) {}
+
+    @ResolveField()
+    async league(@Parent() parent: UserEnergyModel): Promise<string> {
+        return this.energyCompute.computeLeagueByEnergy(parent.amount);
+    }
 
     @UseGuards(JwtOrNativeAuthGuard)
     @Query(() => UserEnergyModel)

--- a/src/modules/energy/energy.resolver.ts
+++ b/src/modules/energy/energy.resolver.ts
@@ -7,7 +7,7 @@ import {
     ResolveField,
     Resolver,
 } from '@nestjs/graphql';
-import { scAddress } from 'src/config';
+import { leaguesConfig, scAddress } from 'src/config';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
 import { InputTokenModel } from 'src/models/inputToken.model';
@@ -15,7 +15,11 @@ import { TransactionModel } from 'src/models/transaction.model';
 import { JwtOrNativeAuthGuard } from '../auth/jwt.or.native.auth.guard';
 import { EsdtToken } from '../tokens/models/esdtToken.model';
 import { NftCollection } from '../tokens/models/nftCollection.model';
-import { UnlockType, UserEnergyModel } from './models/energy.model';
+import {
+    LeagueModel,
+    UnlockType,
+    UserEnergyModel,
+} from './models/energy.model';
 import {
     LockOption,
     SimpleLockEnergyModel,
@@ -28,6 +32,7 @@ import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 import { EnergyComputeService } from './services/energy.compute.service';
+import BigNumber from 'bignumber.js';
 
 @Resolver(() => UserEnergyModel)
 export class UserEnergyResolver {
@@ -267,5 +272,18 @@ export class EnergyResolver {
     @Query(() => String)
     async userEnergyAmount(@AuthUser() user: UserAuthResult): Promise<string> {
         return this.energyAbi.energyAmountForUser(user.address);
+    }
+
+    @Query(() => [LeagueModel])
+    async leagues(): Promise<LeagueModel[]> {
+        return leaguesConfig.map(
+            (league) =>
+                new LeagueModel({
+                    name: league.name,
+                    minEnergy: league.minEnergy ?? '0',
+                    maxEnergy:
+                        league.maxEnergy ?? new BigNumber(Infinity).toFixed(),
+                }),
+        );
     }
 }

--- a/src/modules/energy/energy.resolver.ts
+++ b/src/modules/energy/energy.resolver.ts
@@ -27,6 +27,7 @@ import { EnergyAbiService } from './services/energy.abi.service';
 import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
 import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
+import { EnergyComputeService } from './services/energy.compute.service';
 
 @Resolver(() => UserEnergyModel)
 export class UserEnergyResolver {

--- a/src/modules/energy/models/energy.model.ts
+++ b/src/modules/energy/models/energy.model.ts
@@ -30,8 +30,22 @@ export class UserEnergyModel extends EnergyModel {
     @Field(() => String)
     league: string;
 
-    constructor(init?: Partial<EnergyType>) {
+    constructor(init?: Partial<UserEnergyModel>) {
         super(init);
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class LeagueModel {
+    @Field()
+    name: string;
+    @Field()
+    minEnergy: string;
+    @Field()
+    maxEnergy: string;
+
+    constructor(init?: Partial<LeagueModel>) {
         Object.assign(this, init);
     }
 }

--- a/src/modules/energy/models/energy.model.ts
+++ b/src/modules/energy/models/energy.model.ts
@@ -24,3 +24,14 @@ export class EnergyModel {
         Object.assign(this, init);
     }
 }
+
+@ObjectType()
+export class UserEnergyModel extends EnergyModel {
+    @Field(() => String)
+    league: string;
+
+    constructor(init?: Partial<EnergyType>) {
+        super(init);
+        Object.assign(this, init);
+    }
+}

--- a/src/modules/energy/services/energy.service.ts
+++ b/src/modules/energy/services/energy.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { InputTokenModel } from 'src/models/inputToken.model';
 import { ContextGetterService } from 'src/services/context/context.getter.service';
-import { EnergyModel } from '../models/energy.model';
+import { UserEnergyModel } from '../models/energy.model';
 import { EnergyAbiService } from './energy.abi.service';
 import { EnergyComputeService } from './energy.compute.service';
 import { constantsConfig } from '../../../config';
@@ -38,11 +38,11 @@ export class EnergyService {
     async getUserEnergy(
         userAddress: string,
         vmQuery = false,
-    ): Promise<EnergyModel> {
+    ): Promise<UserEnergyModel> {
         if (vmQuery) {
             const userEnergyEntry =
                 await this.energyAbi.getEnergyEntryForUserRaw(userAddress);
-            return new EnergyModel(userEnergyEntry);
+            return new UserEnergyModel(userEnergyEntry);
         }
         const [userEnergyEntry, currentEpoch] = await Promise.all([
             this.energyAbi.energyEntryForUser(userAddress),
@@ -54,7 +54,7 @@ export class EnergyService {
             currentEpoch,
         );
 
-        return new EnergyModel(depletedEnergy);
+        return new UserEnergyModel(depletedEnergy);
     }
 
     async getPenaltyAmount(

--- a/src/modules/fees-collector/specs/fees.collector.compute.service.spec.ts
+++ b/src/modules/fees-collector/specs/fees.collector.compute.service.spec.ts
@@ -22,7 +22,10 @@ import { PairService } from 'src/modules/pair/services/pair.service';
 import { WrapAbiServiceProvider } from 'src/modules/wrapping/mocks/wrap.abi.service.mock';
 import { TokenServiceProvider } from 'src/modules/tokens/mocks/token.service.mock';
 import { RouterAbiServiceProvider } from 'src/modules/router/mocks/router.abi.service.mock';
-import { EnergyModel } from 'src/modules/energy/models/energy.model';
+import {
+    EnergyModel,
+    UserEnergyModel,
+} from 'src/modules/energy/models/energy.model';
 import BigNumber from 'bignumber.js';
 import { EnergyService } from 'src/modules/energy/services/energy.service';
 import { EnergyComputeService } from 'src/modules/energy/services/energy.compute.service';
@@ -228,11 +231,12 @@ describe('FeesCollectorComputeService', () => {
             const totalLockedTokensForWeek = '1000000000000000000000000';
             const user1EnergyAmount = new BigNumber(totalEnergyForWeek);
 
-            const user1Energy = new EnergyModel({
+            const user1Energy = new UserEnergyModel({
                 amount: user1EnergyAmount.toFixed(),
                 totalLockedTokens: new BigNumber(
                     totalLockedTokensForWeek,
                 ).toFixed(),
+                league: 'Bronze',
             });
 
             const service = module.get<FeesCollectorComputeService>(
@@ -285,11 +289,12 @@ describe('FeesCollectorComputeService', () => {
             const totalLockedTokensForWeek = '1000000000000000000000000';
             const user1EnergyAmount = new BigNumber(totalEnergyForWeek);
 
-            const user1Energy = new EnergyModel({
+            const user1Energy = new UserEnergyModel({
                 amount: user1EnergyAmount.dividedBy(4).toFixed(),
                 totalLockedTokens: new BigNumber(
                     totalLockedTokensForWeek,
                 ).toFixed(),
+                league: 'Bronze',
             });
 
             const service = module.get<FeesCollectorComputeService>(
@@ -345,11 +350,12 @@ describe('FeesCollectorComputeService', () => {
             const totalLockedTokensForWeek = '1000000000000000000000000';
             const user1EnergyAmount = new BigNumber(totalEnergyForWeek);
 
-            const user1Energy = new EnergyModel({
+            const user1Energy = new UserEnergyModel({
                 amount: user1EnergyAmount.dividedBy(4).toFixed(),
                 totalLockedTokens: new BigNumber(totalLockedTokensForWeek)
                     .dividedBy(4)
                     .toFixed(),
+                league: 'Bronze',
             });
 
             const service = module.get<FeesCollectorComputeService>(


### PR DESCRIPTION
## Reasoning
- move user energy league information to xExchange backend
  
## Proposed Changes
- added new user energy model
- added energy leagues information
- added computation for energy league
- added resolver for user energy model

## How to test
```
query {
    userEnergy {
        amount
        lastUpdateEpoch
        totalLockedTokens
        league
    }
}
```
- query should return league for user energy