### PR TITLE
[MEX-505] Fix token trending score

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -504,7 +504,7 @@
                 "liquidityPosition": 57500000,
                 "farmPosition": 87000000,
                 "dualFarmPosition": 115000000,
-                "stakingPosition": 70000000
+                "stakingPosition": 80000000
             },
             "dualTokens": {
                 "farmPosition": 50000000,

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -232,7 +232,7 @@ export class TokenComputeService implements ITokenComputeService {
             metric: 'priceUSD',
         });
 
-        return values24h.find((item) => item.value !== '0')?.value ?? undefined;
+        return values24h[0]?.value ?? undefined;
     }
 
     @ErrorLoggerAsync({


### PR DESCRIPTION
## Reasoning
- trending score isn't performing right on edge cases
  
## Proposed Changes
- added minimum score to be used in case of edge cases on token metrics changes

## How to test
```
query Tokens {
    filteredTokens(
        pagination: {
            first: 200
        }
        filters: {
            enabledSwaps: false
        }
        sorting: {
            sortField: TRENDING_SCORE
            sortOrder: DESC
        }
    ) {
        edges {
            node {
                identifier
                trendingScore
            }
        }
    }
}
```