### PR TITLE
[SERVICES-2548] Fix timescaledb query for fetching all series start date

### DIFF
--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -439,10 +439,10 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     }
 
     private async allStartDatesRaw(): Promise<object> {
-        const startDateRows = await this.dexAnalytics
+        const startDateRows = await this.closeDaily
             .createQueryBuilder()
             .select('series')
-            .addSelect('min(timestamp) as earliest_timestamp')
+            .addSelect('min(time) as earliest_timestamp')
             .groupBy('series')
             .getRawMany();
 


### PR DESCRIPTION
## Reasoning
- query for fetching all series start dates has poor performance
  
## Proposed Changes
- run query on close `close_daily` aggregate instead of `hyper_dex_analytics` table

## How to test
- N/A
