### PR TITLE
[MEX-507] user positions extra information

### DIFF
--- a/src/modules/pair/services/pair.filtering.service.ts
+++ b/src/modules/pair/services/pair.filtering.service.ts
@@ -50,9 +50,9 @@ export class PairFilteringService {
         pairFilter: PairFilterArgs | PairsFilter,
         pairsMetadata: PairMetadata[],
     ): Promise<PairMetadata[]> {
-        if (pairFilter.address) {
-            pairsMetadata = pairsMetadata.filter(
-                (pair) => pairFilter.address === pair.address,
+        if (pairFilter.addresses) {
+            pairsMetadata = pairsMetadata.filter((pair) =>
+                pairFilter.addresses.includes(pair.address),
             );
         }
         return await Promise.resolve(pairsMetadata);

--- a/src/modules/router/models/filter.args.ts
+++ b/src/modules/router/models/filter.args.ts
@@ -14,8 +14,8 @@ registerEnumType(PairSortableFields, { name: 'PairSortableFields' });
 
 @ArgsType()
 export class PairFilterArgs {
-    @Field({ nullable: true })
-    address: string;
+    @Field(() => [String], { nullable: true })
+    addresses: string[];
     @Field({ nullable: true })
     firstTokenID: string;
     @Field({ nullable: true })
@@ -34,8 +34,8 @@ export class PairFilterArgs {
 
 @InputType()
 export class PairsFilter {
-    @Field({ nullable: true })
-    address: string;
+    @Field(() => [String], { nullable: true })
+    addresses: string[];
     @Field({ nullable: true })
     firstTokenID: string;
     @Field({ nullable: true })

--- a/src/modules/router/services/router.service.ts
+++ b/src/modules/router/services/router.service.ts
@@ -122,9 +122,9 @@ export class RouterService {
         pairFilter: PairFilterArgs,
         pairsMetadata: PairMetadata[],
     ): PairMetadata[] {
-        if (pairFilter.address) {
-            pairsMetadata = pairsMetadata.filter(
-                (pair) => pairFilter.address === pair.address,
+        if (pairFilter.addresses) {
+            pairsMetadata = pairsMetadata.filter((pair) =>
+                pairFilter.addresses.includes(pair.address),
             );
         }
         return pairsMetadata;

--- a/src/modules/router/specs/router.service.spec.ts
+++ b/src/modules/router/specs/router.service.spec.ts
@@ -109,7 +109,7 @@ describe('RouterService', () => {
         const filteredPairs = await service.getAllPairs(0, Number.MAX_VALUE, {
             firstTokenID: 'WEGLD-123456',
             issuedLpToken: true,
-            address: null,
+            addresses: null,
             secondTokenID: null,
             state: null,
             feeState: null,
@@ -146,7 +146,7 @@ describe('RouterService', () => {
         const filteredPairs = await service.getAllPairs(0, Number.MAX_VALUE, {
             firstTokenID: 'WEGLD-123456',
             issuedLpToken: true,
-            address: null,
+            addresses: null,
             secondTokenID: null,
             state: null,
             feeState: false,
@@ -168,7 +168,7 @@ describe('RouterService', () => {
         const filteredPairs = await service.getAllPairs(0, Number.MAX_VALUE, {
             firstTokenID: null,
             issuedLpToken: true,
-            address: null,
+            addresses: null,
             secondTokenID: null,
             state: null,
             feeState: null,

--- a/src/modules/staking-proxy/models/staking.proxy.args.model.ts
+++ b/src/modules/staking-proxy/models/staking.proxy.args.model.ts
@@ -31,14 +31,14 @@ export class UnstakeFarmTokensArgs {
 
 @InputType()
 export class StakingProxiesFilter {
-    @Field({ nullable: true })
-    address: string;
-    @Field({ nullable: true })
-    pairAddress: string;
-    @Field({ nullable: true })
-    stakingFarmAddress: string;
-    @Field({ nullable: true })
-    lpFarmAddress: string;
+    @Field(() => [String], { nullable: true })
+    addresses: string[];
+    @Field(() => [String], { nullable: true })
+    pairAddresses: string[];
+    @Field(() => [String], { nullable: true })
+    stakingFarmAddresses: string[];
+    @Field(() => [String], { nullable: true })
+    lpFarmAddresses: string[];
     @Field(() => String, { nullable: true })
     searchToken?: string;
 }

--- a/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.filtering.service.ts
@@ -17,9 +17,9 @@ export class StakingProxyFilteringService {
         filter: StakingProxiesFilter,
         stakingProxyAddresses: string[],
     ): string[] {
-        if (filter.address) {
-            stakingProxyAddresses = stakingProxyAddresses.filter(
-                (address) => filter.address === address,
+        if (filter.addresses) {
+            stakingProxyAddresses = stakingProxyAddresses.filter((address) =>
+                filter.addresses.includes(address),
             );
         }
         return stakingProxyAddresses;
@@ -29,7 +29,7 @@ export class StakingProxyFilteringService {
         filter: StakingProxiesFilter,
         stakingProxyAddresses: string[],
     ): Promise<string[]> {
-        if (!filter.pairAddress) {
+        if (!filter.pairAddresses) {
             return stakingProxyAddresses;
         }
 
@@ -39,8 +39,8 @@ export class StakingProxyFilteringService {
             ),
         );
 
-        return stakingProxyAddresses.filter(
-            (_, index) => pairAddresses[index] === filter.pairAddress,
+        return stakingProxyAddresses.filter((_, index) =>
+            filter.pairAddresses.includes(pairAddresses[index]),
         );
     }
 
@@ -48,7 +48,7 @@ export class StakingProxyFilteringService {
         filter: StakingProxiesFilter,
         stakingProxyAddresses: string[],
     ): Promise<string[]> {
-        if (!filter.stakingFarmAddress) {
+        if (!filter.stakingFarmAddresses) {
             return stakingProxyAddresses;
         }
 
@@ -58,9 +58,8 @@ export class StakingProxyFilteringService {
             ),
         );
 
-        return stakingProxyAddresses.filter(
-            (_, index) =>
-                stakingFarmAddresses[index] === filter.stakingFarmAddress,
+        return stakingProxyAddresses.filter((_, index) =>
+            filter.stakingFarmAddresses.includes(stakingFarmAddresses[index]),
         );
     }
 
@@ -68,7 +67,7 @@ export class StakingProxyFilteringService {
         filter: StakingProxiesFilter,
         stakingProxyAddresses: string[],
     ): Promise<string[]> {
-        if (!filter.lpFarmAddress) {
+        if (!filter.lpFarmAddresses) {
             return stakingProxyAddresses;
         }
 
@@ -78,8 +77,8 @@ export class StakingProxyFilteringService {
             ),
         );
 
-        return stakingProxyAddresses.filter(
-            (_, index) => lpFarmAddresses[index] === filter.lpFarmAddress,
+        return stakingProxyAddresses.filter((_, index) =>
+            filter.lpFarmAddresses.includes(lpFarmAddresses[index]),
         );
     }
 

--- a/src/modules/user/models/user.model.ts
+++ b/src/modules/user/models/user.model.ts
@@ -59,6 +59,7 @@ export class UserLockedAssetToken extends LockedAssetToken {
 @ObjectType()
 export class UserFarmToken extends FarmToken {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserFarmToken>) {
         super(init);
@@ -69,6 +70,7 @@ export class UserFarmToken extends FarmToken {
 @ObjectType()
 export class UserLockedLPToken extends LockedLpToken {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserLockedLPToken>) {
         super(init);
@@ -79,6 +81,7 @@ export class UserLockedLPToken extends LockedLpToken {
 @ObjectType()
 export class UserLockedFarmToken extends LockedFarmToken {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserLockedFarmToken>) {
         super(init);
@@ -89,6 +92,7 @@ export class UserLockedFarmToken extends LockedFarmToken {
 @ObjectType()
 export class UserLockedLPTokenV2 extends LockedLpTokenV2 {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserLockedLPTokenV2>) {
         super(init);
@@ -99,6 +103,7 @@ export class UserLockedLPTokenV2 extends LockedLpTokenV2 {
 @ObjectType()
 export class UserLockedFarmTokenV2 extends LockedFarmTokenV2 {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserLockedFarmTokenV2>) {
         super(init);
@@ -129,6 +134,7 @@ export class UserUnbondFarmToken extends UnbondFarmToken {
 @ObjectType()
 export class UserDualYiledToken extends DualYieldToken {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserDualYiledToken>) {
         super(init);
@@ -157,6 +163,7 @@ export class UserLockedEsdtToken extends LockedEsdtToken {
 @ObjectType()
 export class UserLockedSimpleLpToken extends LockedSimpleLpToken {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserLockedSimpleLpToken>) {
         super(init);
@@ -167,6 +174,7 @@ export class UserLockedSimpleLpToken extends LockedSimpleLpToken {
 @ObjectType()
 export class UserLockedSimpleFarmToken extends LockedSimpleFarmToken {
     @Field() valueUSD: string;
+    @Field() pairAddress: string;
 
     constructor(init?: Partial<UserLockedSimpleFarmToken>) {
         super(init);

--- a/src/modules/user/models/user.model.ts
+++ b/src/modules/user/models/user.model.ts
@@ -29,6 +29,7 @@ export enum ContractType {
 @ObjectType()
 export class UserToken extends EsdtToken {
     @Field() valueUSD: string;
+    @Field({ nullable: true }) pairAddress: string;
 
     constructor(init?: Partial<UserToken>) {
         super(init);

--- a/src/modules/user/services/esdt.compute.service.ts
+++ b/src/modules/user/services/esdt.compute.service.ts
@@ -37,6 +37,7 @@ export class UserEsdtComputeService {
         return new UserToken({
             ...esdtToken,
             valueUSD: valueUSD,
+            pairAddress,
         });
     }
 }

--- a/src/modules/user/services/metaEsdt.compute.service.ts
+++ b/src/modules/user/services/metaEsdt.compute.service.ts
@@ -114,6 +114,7 @@ export class UserMetaEsdtComputeService {
         return new UserToken({
             ...esdtToken,
             valueUSD: valueUSD,
+            pairAddress,
         });
     }
 

--- a/src/modules/user/services/metaEsdt.compute.service.ts
+++ b/src/modules/user/services/metaEsdt.compute.service.ts
@@ -62,6 +62,7 @@ import { StakingProxyAbiService } from 'src/modules/staking-proxy/services/staki
 import { FarmAbiFactory } from 'src/modules/farm/farm.abi.factory';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
+import { Address } from '@multiversx/sdk-core/out';
 
 @Injectable()
 export class UserMetaEsdtComputeService {
@@ -159,6 +160,7 @@ export class UserMetaEsdtComputeService {
                     tokenPriceUSD,
                 ).toFixed(),
                 decodedAttributes: decodedFarmAttributes,
+                pairAddress: Address.Zero().bech32(),
             });
         }
         const farmTokenBalanceUSD =
@@ -170,6 +172,7 @@ export class UserMetaEsdtComputeService {
             ...nftToken,
             valueUSD: farmTokenBalanceUSD,
             decodedAttributes: decodedFarmAttributes,
+            pairAddress,
         });
     }
 
@@ -265,6 +268,7 @@ export class UserMetaEsdtComputeService {
                 ...nftToken,
                 valueUSD: valueUSD,
                 decodedAttributes: decodedWLPTAttributes,
+                pairAddress,
             });
         }
     }
@@ -289,6 +293,7 @@ export class UserMetaEsdtComputeService {
                 ...nftToken,
                 valueUSD: valueUSD,
                 decodedAttributes: decodedWLPTAttributes,
+                pairAddress,
             });
         }
     }
@@ -325,6 +330,7 @@ export class UserMetaEsdtComputeService {
         return new UserLockedFarmToken({
             ...nftToken,
             valueUSD: userFarmToken.valueUSD,
+            pairAddress: userFarmToken.pairAddress,
             decodedAttributes: decodedWFMTAttributes,
         });
     }
@@ -373,6 +379,7 @@ export class UserMetaEsdtComputeService {
             return new UserLockedFarmTokenV2({
                 ...nftToken,
                 valueUSD: userFarmToken.valueUSD,
+                pairAddress: userFarmToken.pairAddress,
                 decodedAttributes: decodedWFMTAttributes,
             });
         } catch (e) {
@@ -503,6 +510,7 @@ export class UserMetaEsdtComputeService {
         return new UserDualYiledToken({
             ...nftToken,
             valueUSD: farmTokenUSD.valueUSD,
+            pairAddress: farmTokenUSD.pairAddress,
             decodedAttributes: decodedAttributes[0],
         });
     }
@@ -616,6 +624,7 @@ export class UserMetaEsdtComputeService {
             ...nftToken,
             decodedAttributes,
             valueUSD: userEsdtToken.valueUSD,
+            pairAddress,
         });
     }
 
@@ -658,6 +667,7 @@ export class UserMetaEsdtComputeService {
             ...nftToken,
             decodedAttributes,
             valueUSD: userFarmToken.valueUSD,
+            pairAddress: userFarmToken.pairAddress,
         });
     }
 

--- a/src/modules/user/specs/user.service.spec.ts
+++ b/src/modules/user/specs/user.service.spec.ts
@@ -233,6 +233,9 @@ describe('UserService', () => {
                 nonce: 1,
                 royalties: 0,
                 valueUSD: '20',
+                pairAddress: Address.fromHex(
+                    '0000000000000000000000000000000000000000000000000000000000000012',
+                ).bech32(),
                 decodedAttributes: new FarmTokenAttributesModelV1_2({
                     aprMultiplier: 1,
                     attributes: 'AAAABQeMCWDbAAAAAAAAAF8CAQ==',


### PR DESCRIPTION
## Reasoning
- ease the association for multiple user positions to specific pair
  
## Proposed Changes
- added pair address field for user lp tokens and user nfts positions that can be associated with a pair address
- updated filtering on filtered queries to use arrays of addresses

## How to test
```
query UserNfts {
    userNfts {
        userLockedTokenEnergy {
            collection
            name
            identifier
        }
        userFarmToken {
            collection
            valueUSD
            pairAddress
        }
        userDualYieldToken {
            collection
            valueUSD
            pairAddress
        }
        userLockedSimpleFarmToken{
            collection
            pairAddress
        }
        userStakeFarmToken {
            collection
            valueUSD
            creator
        }
        userUnbondFarmToken {
            collection
            creator
        }
    }
}
```
- query should return an pair address associated with the user position