### PR TITLE
[MEX-508]: return 24 data points on analytics

### DIFF
--- a/src/modules/analytics/services/analytics.aws.getter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.getter.service.ts
@@ -95,7 +95,7 @@ export class AnalyticsAWSGetterService {
             metric,
         );
         const data = await this.getCachedData<HistoricDataModel[]>(cacheKey);
-        return data !== undefined ? data : [];
+        return data !== undefined ? data.slice(1) : [];
     }
 
     @ErrorLoggerAsync()
@@ -105,7 +105,7 @@ export class AnalyticsAWSGetterService {
     ): Promise<HistoricDataModel[]> {
         const cacheKey = this.getAnalyticsCacheKey('values24h', series, metric);
         const data = await this.getCachedData<HistoricDataModel[]>(cacheKey);
-        return data !== undefined ? data : [];
+        return data !== undefined ? data.slice(1) : [];
     }
 
     private getAnalyticsCacheKey(...args: any) {


### PR DESCRIPTION
## Reasoning
- by default the query returns 25 data points starting with the last 24h ago
- display the latest 24 data points for hourly analytics charts
  
## Proposed Changes
- return the latest 24 data points for hourly analytics charts

## How to test
- N/A
