### PR TITLE
[MEX-514] compute user boosted apr

### DIFF
--- a/src/modules/farm/mocks/farm.v2.abi.service.mock.ts
+++ b/src/modules/farm/mocks/farm.v2.abi.service.mock.ts
@@ -73,6 +73,13 @@ export class FarmAbiServiceMockV2
     async farmPositionMigrationNonce(farmAddress: string): Promise<number> {
         return 10;
     }
+
+    async farmSupplyForWeek(
+        farmAddress: string,
+        week: number,
+    ): Promise<string> {
+        return '2';
+    }
 }
 
 export const FarmAbiServiceProviderV2 = {

--- a/src/modules/farm/models/farm.model.ts
+++ b/src/modules/farm/models/farm.model.ts
@@ -47,12 +47,18 @@ export class RewardsModel {
 export class BoostedRewardsModel {
     @Field()
     farmAddress: string;
+    @Field()
+    userAddress: string;
     @Field(() => [UserInfoByWeekModel], { nullable: true })
     boostedRewardsWeeklyInfo: UserInfoByWeekModel[];
     @Field(() => ClaimProgress, { nullable: true })
     claimProgress: ClaimProgress;
     @Field({ nullable: true })
     accumulatedRewards: string;
+    @Field({ nullable: true })
+    curentBoostedAPR: number;
+    @Field({ nullable: true })
+    maximumBoostedAPR: number;
 
     constructor(init?: Partial<BoostedRewardsModel>) {
         Object.assign(this, init);

--- a/src/modules/farm/specs/farm.v2.compute.service.spec.ts
+++ b/src/modules/farm/specs/farm.v2.compute.service.spec.ts
@@ -29,6 +29,7 @@ import { FarmAbiServiceV2 } from '../v2/services/farm.v2.abi.service';
 import { Address } from '@multiversx/sdk-core/out';
 import { ContextGetterService } from 'src/services/context/context.getter.service';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { EsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
 
 describe('FarmServiceV2', () => {
     let module: TestingModule;
@@ -131,13 +132,22 @@ describe('FarmServiceV2', () => {
             totalLockedTokens: '1',
             lastUpdateEpoch: 256,
         });
+        jest.spyOn(
+            weeklyRewardsSplittingAbi,
+            'totalRewardsForWeek',
+        ).mockResolvedValue([
+            new EsdtTokenPayment({
+                amount: '60480000000000000000000',
+                tokenID: 'MEX-123456',
+            }),
+        ]);
         jest.spyOn(farmAbi, 'farmTokenSupply').mockResolvedValue('2');
         jest.spyOn(farmAbi, 'rewardsPerBlock').mockResolvedValue(
             '1000000000000000000',
         );
         jest.spyOn(farmAbi, 'userTotalFarmPosition').mockResolvedValue('2');
 
-        const accumulatedRewards = await service.computeUserAccumulatedRewards(
+        const accumulatedRewards = await service.computeUserRewardsForWeek(
             Address.fromBech32(
                 'erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqsdtp6mh',
             ).bech32(),
@@ -145,6 +155,6 @@ describe('FarmServiceV2', () => {
             1,
         );
 
-        expect(accumulatedRewards).toEqual('60480000000000000000000');
+        expect(accumulatedRewards[0].amount).toEqual('60480000000000000000000');
     });
 });

--- a/src/modules/farm/v2/farm.v2.module.ts
+++ b/src/modules/farm/v2/farm.v2.module.ts
@@ -3,7 +3,7 @@ import { TokenModule } from 'src/modules/tokens/token.module';
 import { ContextModule } from 'src/services/context/context.module';
 import { MXCommunicationModule } from 'src/services/multiversx-communication/mx.communication.module';
 import { FarmAbiServiceV2 } from './services/farm.v2.abi.service';
-import { FarmResolverV2 } from './farm.v2.resolver';
+import { FarmBoostedRewardsResolver, FarmResolverV2 } from './farm.v2.resolver';
 import { FarmServiceV2 } from './services/farm.v2.service';
 import { FarmComputeServiceV2 } from './services/farm.v2.compute.service';
 import { PairModule } from 'src/modules/pair/pair.module';
@@ -36,6 +36,7 @@ import { FarmComputeLoaderV2 } from './services/farm.v2.compute.loader';
         FarmTransactionServiceV2,
         FarmResolverV2,
         FarmTransactionResolverV2,
+        FarmBoostedRewardsResolver,
     ],
     exports: [
         FarmServiceV2,

--- a/src/modules/farm/v2/farm.v2.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.resolver.ts
@@ -26,6 +26,31 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { FarmAbiLoaderV2 } from './services/farm.v2.abi.loader';
 import { FarmComputeLoaderV2 } from './services/farm.v2.compute.loader';
 
+@Resolver(() => BoostedRewardsModel)
+export class FarmBoostedRewardsResolver {
+    constructor(private readonly farmCompute: FarmComputeServiceV2) {}
+
+    @ResolveField()
+    async curentBoostedAPR(
+        @Parent() parent: BoostedRewardsModel,
+    ): Promise<number> {
+        return this.farmCompute.computeUserCurentBoostedAPR(
+            parent.farmAddress,
+            parent.userAddress,
+        );
+    }
+
+    @ResolveField()
+    async maximumBoostedAPR(
+        @Parent() parent: BoostedRewardsModel,
+    ): Promise<number> {
+        return this.farmCompute.computeUserMaxBoostedAPR(
+            parent.farmAddress,
+            parent.userAddress,
+        );
+    }
+}
+
 @Resolver(() => FarmModelV2)
 export class FarmResolverV2 extends FarmResolver {
     constructor(

--- a/src/modules/farm/v2/farm.v2.resolver.ts
+++ b/src/modules/farm/v2/farm.v2.resolver.ts
@@ -33,20 +33,41 @@ export class FarmBoostedRewardsResolver {
     @ResolveField()
     async curentBoostedAPR(
         @Parent() parent: BoostedRewardsModel,
+        @Args('additionalUserFarmAmount', {
+            type: () => String,
+            nullable: true,
+            defaultValue: '0',
+        })
+        additionalUserFarmAmount: string,
+        @Args('additionalUserEnergy', {
+            type: () => String,
+            nullable: true,
+            defaultValue: '0',
+        })
+        additionalUserEnergy: string,
     ): Promise<number> {
         return this.farmCompute.computeUserCurentBoostedAPR(
             parent.farmAddress,
             parent.userAddress,
+            additionalUserFarmAmount,
+            additionalUserEnergy,
         );
     }
 
     @ResolveField()
     async maximumBoostedAPR(
         @Parent() parent: BoostedRewardsModel,
+        @Args('additionalUserFarmAmount', {
+            type: () => String,
+            nullable: true,
+            defaultValue: '0',
+        })
+        additionalUserFarmAmount: string,
     ): Promise<number> {
         return this.farmCompute.computeUserMaxBoostedAPR(
             parent.farmAddress,
             parent.userAddress,
+            additionalUserFarmAmount,
         );
     }
 }

--- a/src/modules/farm/v2/services/farm.v2.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.service.ts
@@ -207,6 +207,7 @@ export class FarmServiceV2 extends FarmServiceBase {
 
         return new BoostedRewardsModel({
             farmAddress,
+            userAddress,
             boostedRewardsWeeklyInfo: modelsList,
             claimProgress: currentClaimProgress,
             accumulatedRewards: userAccumulatedRewards,

--- a/src/modules/farm/v2/services/interfaces.ts
+++ b/src/modules/farm/v2/services/interfaces.ts
@@ -1,4 +1,3 @@
-import { TokenDistributionModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import {
     IFarmAbiService,
     IFarmComputeService,
@@ -25,6 +24,7 @@ export interface IFarmAbiServiceV2 extends IFarmAbiService {
         userAddress: string,
     ): Promise<string>;
     farmPositionMigrationNonce(farmAddress: string): Promise<number>;
+    farmSupplyForWeek(farmAddress: string, week: number): Promise<string>;
 }
 
 export interface IFarmComputeServiceV2 extends IFarmComputeService {

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -9,6 +9,7 @@ import {
     UserInfoByWeekModel,
 } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
+import { BoostedRewardsModel } from 'src/modules/farm/models/farm.model';
 
 @ObjectType()
 export class StakingModel {
@@ -106,6 +107,13 @@ export class StakingRewardsModel {
 
     constructor(init?: Partial<StakingRewardsModel>) {
         Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class StakingBoostedRewardsModel extends BoostedRewardsModel {
+    constructor(init?: Partial<StakingBoostedRewardsModel>) {
+        super(init);
     }
 }
 

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -10,7 +10,6 @@ import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { computeValueUSD, denominateAmount } from 'src/utils/token.converters';
 import { OptimalCompoundModel } from '../models/staking.model';
-import { TokenService } from 'src/modules/tokens/services/token.service';
 import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
 import { TokenDistributionModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
@@ -18,6 +17,7 @@ import { WeekTimekeepingComputeService } from 'src/submodules/week-timekeeping/s
 import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
 import { EsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
+import { WeekTimekeepingAbiService } from 'src/submodules/week-timekeeping/services/week-timekeeping.abi.service';
 
 @Injectable()
 export class StakingComputeService {
@@ -26,9 +26,9 @@ export class StakingComputeService {
         @Inject(forwardRef(() => StakingService))
         private readonly stakingService: StakingService,
         private readonly contextGetter: ContextGetterService,
-        private readonly tokenService: TokenService,
         private readonly tokenCompute: TokenComputeService,
         private readonly weekTimekeepingCompute: WeekTimekeepingComputeService,
+        private readonly weekTimeKeepingAbi: WeekTimekeepingAbiService,
         private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
         private readonly weeklyRewardsSplittingCompute: WeeklyRewardsSplittingComputeService,
         private readonly apiService: MXApiService,
@@ -476,119 +476,53 @@ export class StakingComputeService {
         userAddress: string,
         week: number,
     ): Promise<string> {
-        return this.computeUserAccumulatedRewards(scAddress, userAddress, week);
-    }
-
-    async computeUserAccumulatedRewards(
-        scAddress: string,
-        userAddress: string,
-        week: number,
-    ): Promise<string> {
-        const [
-            boostedYieldsFactors,
-            boostedYieldsRewardsPercenatage,
-            userEnergy,
-            totalRewards,
-            rewardsPerBlock,
-            farmTokenSupply,
-            totalEnergy,
-            blocksInWeek,
-            liquidity,
-        ] = await Promise.all([
-            this.stakingAbi.boostedYieldsFactors(scAddress),
-            this.stakingAbi.boostedYieldsRewardsPercenatage(scAddress),
-            this.weeklyRewardsSplittingAbi.userEnergyForWeek(
-                scAddress,
-                userAddress,
-                week,
-            ),
-            this.stakingAbi.accumulatedRewardsForWeek(scAddress, week),
-            this.stakingAbi.perBlockRewardsAmount(scAddress),
-            this.stakingAbi.farmTokenSupply(scAddress),
-            this.weeklyRewardsSplittingAbi.totalEnergyForWeek(scAddress, week),
-            this.computeBlocksInWeek(scAddress, week),
-            this.stakingAbi.userTotalStakePosition(scAddress, userAddress),
-        ]);
-
-        const energyAmount = userEnergy.amount;
-
-        const userHasMinEnergy = new BigNumber(energyAmount).isGreaterThan(
-            boostedYieldsFactors.minEnergyAmount,
+        const rewards = await this.computeUserRewardsForWeek(
+            scAddress,
+            userAddress,
+            week,
         );
-        if (!userHasMinEnergy) {
-            return '0';
-        }
 
-        const userMinFarmAmount = new BigNumber(liquidity).isGreaterThan(
-            boostedYieldsFactors.minFarmAmount,
-        );
-        if (!userMinFarmAmount) {
-            return '0';
-        }
-
-        if (totalRewards.length === 0) {
-            return '0';
-        }
-
-        const userMaxBoostedRewardsPerBlock = new BigNumber(rewardsPerBlock)
-            .multipliedBy(boostedYieldsRewardsPercenatage)
-            .dividedBy(constantsConfig.MAX_PERCENT)
-            .multipliedBy(liquidity)
-            .dividedBy(farmTokenSupply);
-
-        const userRewardsForWeek = new BigNumber(
-            boostedYieldsFactors.maxRewardsFactor,
-        )
-            .multipliedBy(userMaxBoostedRewardsPerBlock)
-            .multipliedBy(blocksInWeek);
-
-        const boostedRewardsByEnergy = new BigNumber(totalRewards)
-            .multipliedBy(boostedYieldsFactors.userRewardsEnergy)
-            .multipliedBy(userEnergy.amount)
-            .dividedBy(totalEnergy);
-
-        const boostedRewardsByTokens = new BigNumber(totalRewards)
-            .multipliedBy(boostedYieldsFactors.userRewardsFarm)
-            .multipliedBy(liquidity)
-            .dividedBy(farmTokenSupply);
-
-        const constantsBase = new BigNumber(
-            boostedYieldsFactors.userRewardsEnergy,
-        ).plus(boostedYieldsFactors.userRewardsFarm);
-
-        const boostedRewardAmount = boostedRewardsByEnergy
-            .plus(boostedRewardsByTokens)
-            .dividedBy(constantsBase);
-
-        const paymentAmount =
-            boostedRewardAmount.comparedTo(userRewardsForWeek) < 1
-                ? boostedRewardAmount
-                : userRewardsForWeek;
-
-        return paymentAmount.integerValue().toFixed();
+        return rewards[0] ? rewards[0].amount : '0';
     }
 
     async computeUserRewardsForWeek(
         scAddress: string,
         userAddress: string,
         week: number,
+        rewardsPerWeek?: EsdtTokenPayment[],
     ): Promise<EsdtTokenPayment[]> {
-        const payments: EsdtTokenPayment[] = [];
-        const [
-            totalRewardsForWeek,
-            userEnergyForWeek,
-            totalEnergyForWeek,
-            liquidity,
-        ] = await Promise.all([
-            this.weeklyRewardsSplittingAbi.totalRewardsForWeek(scAddress, week),
-            this.weeklyRewardsSplittingAbi.userEnergyForWeek(
+        const userRewardsForWeek = [];
+
+        const [currentWeek, userEnergyForWeek, totalEnergyForWeek, liquidity] =
+            await Promise.all([
+                this.weekTimeKeepingAbi.currentWeek(scAddress),
+                this.weeklyRewardsSplittingAbi.userEnergyForWeek(
+                    scAddress,
+                    userAddress,
+                    week,
+                ),
+                this.weeklyRewardsSplittingAbi.totalEnergyForWeek(
+                    scAddress,
+                    week,
+                ),
+
+                this.stakingAbi.userTotalStakePosition(scAddress, userAddress),
+            ]);
+
+        const rewardsForWeek =
+            rewardsPerWeek ??
+            (await this.weeklyRewardsSplittingAbi.totalRewardsForWeek(
                 scAddress,
-                userAddress,
                 week,
-            ),
-            this.weeklyRewardsSplittingAbi.totalEnergyForWeek(scAddress, week),
-            this.stakingAbi.userTotalStakePosition(scAddress, userAddress),
-        ]);
+            ));
+
+        if (rewardsForWeek.length === 0) {
+            return userRewardsForWeek;
+        }
+
+        if (rewardsForWeek.length !== 1) {
+            throw new Error('Invalid boosted yields rewards');
+        }
 
         const boostedYieldsFactors = await this.stakingAbi.boostedYieldsFactors(
             scAddress,
@@ -598,76 +532,168 @@ export class StakingComputeService {
             userEnergyForWeek.amount,
         ).isGreaterThan(boostedYieldsFactors.minEnergyAmount);
         if (!userHasMinEnergy) {
-            return payments;
+            return userRewardsForWeek;
         }
 
         const userMinFarmAmount = new BigNumber(liquidity).isGreaterThan(
             boostedYieldsFactors.minFarmAmount,
         );
         if (!userMinFarmAmount) {
-            return payments;
+            return userRewardsForWeek;
         }
 
-        if (totalRewardsForWeek.length === 0) {
-            return payments;
+        const farmTokenSupply =
+            week === currentWeek
+                ? await this.stakingAbi.farmTokenSupply(scAddress)
+                : await this.stakingAbi.farmSupplyForWeek(scAddress, week);
+
+        const rewardForWeek = rewardsForWeek[0];
+
+        const weeklyRewardsAmount = new BigNumber(rewardForWeek.amount);
+        if (weeklyRewardsAmount.isZero()) {
+            return userRewardsForWeek;
         }
 
+        const userMaxRewards = weeklyRewardsAmount
+            .multipliedBy(liquidity)
+            .multipliedBy(boostedYieldsFactors.maxRewardsFactor)
+            .dividedBy(farmTokenSupply)
+            .integerValue();
+
+        const boostedRewardsByEnergy = weeklyRewardsAmount
+            .multipliedBy(boostedYieldsFactors.userRewardsEnergy)
+            .multipliedBy(userEnergyForWeek.amount)
+            .dividedBy(totalEnergyForWeek)
+            .integerValue();
+
+        const boostedRewardsByTokens = weeklyRewardsAmount
+            .multipliedBy(boostedYieldsFactors.userRewardsFarm)
+            .multipliedBy(liquidity)
+            .dividedBy(farmTokenSupply)
+            .integerValue();
+
+        const constantsBase = new BigNumber(
+            boostedYieldsFactors.userRewardsEnergy,
+        ).plus(boostedYieldsFactors.userRewardsFarm);
+
+        const boostedRewardAmount = boostedRewardsByEnergy
+            .plus(boostedRewardsByTokens)
+            .dividedBy(constantsBase)
+            .integerValue();
+
+        const userRewardForWeek =
+            boostedRewardAmount.comparedTo(userMaxRewards) < 1
+                ? boostedRewardAmount
+                : userMaxRewards;
+
+        if (userRewardForWeek.isPositive()) {
+            userRewardsForWeek.push(
+                new EsdtTokenPayment({
+                    tokenID: rewardForWeek.tokenID,
+                    nonce: rewardForWeek.nonce,
+                    amount: userRewardForWeek.toFixed(),
+                }),
+            );
+        }
+
+        return userRewardsForWeek;
+    }
+
+    async computeUserCurentBoostedAPR(
+        scAddress: string,
+        userAddress: string,
+    ): Promise<number> {
+        const [currentWeek, boostedRewardsPerWeek, userTotalStakePosition] =
+            await Promise.all([
+                this.weekTimeKeepingAbi.currentWeek(scAddress),
+                this.computeBoostedRewardsPerWeek(scAddress),
+                this.stakingAbi.userTotalStakePosition(scAddress, userAddress),
+            ]);
+
+        const userRewardsPerWeek = await this.computeUserRewardsForWeek(
+            scAddress,
+            userAddress,
+            currentWeek,
+            boostedRewardsPerWeek,
+        );
+
+        return new BigNumber(userRewardsPerWeek[0].amount)
+            .multipliedBy(52)
+            .dividedBy(userTotalStakePosition)
+            .toNumber();
+    }
+
+    async computeUserMaxBoostedAPR(
+        scAddress: string,
+        userAddress: string,
+    ): Promise<number> {
         const [
-            rewardsPerBlock,
+            boostedRewardsPerWeek,
+            boostedYieldsFactors,
             farmTokenSupply,
-            boostedYieldsRewardsPercenatage,
+            userTotalStakePosition,
         ] = await Promise.all([
+            this.computeBoostedRewardsPerWeek(scAddress),
+            this.stakingAbi.boostedYieldsFactors(scAddress),
+            this.stakingAbi.farmTokenSupply(scAddress),
+            this.stakingAbi.userTotalStakePosition(scAddress, userAddress),
+        ]);
+
+        const userMaxRewardsPerWeek = new BigNumber(
+            boostedRewardsPerWeek[0].amount,
+        )
+            .multipliedBy(boostedYieldsFactors.maxRewardsFactor)
+            .multipliedBy(userTotalStakePosition)
+            .dividedBy(farmTokenSupply);
+
+        return userMaxRewardsPerWeek
+            .multipliedBy(52)
+            .dividedBy(userTotalStakePosition)
+            .toNumber();
+    }
+
+    async computeBoostedRewardsPerWeek(
+        scAddress: string,
+    ): Promise<EsdtTokenPayment[]> {
+        const [
+            rewardTokenID,
+            rewardsPerBlock,
+            annualPercentageRewards,
+            farmTokenSupply,
+            boostedYieldsRewardsPercentage,
+        ] = await Promise.all([
+            this.stakingAbi.rewardTokenID(scAddress),
             this.stakingAbi.perBlockRewardsAmount(scAddress),
+            this.stakingAbi.annualPercentageRewards(scAddress),
             this.stakingAbi.farmTokenSupply(scAddress),
             this.stakingAbi.boostedYieldsRewardsPercenatage(scAddress),
         ]);
 
-        const userMaxBoostedRewardsPerBlock = new BigNumber(rewardsPerBlock)
-            .multipliedBy(boostedYieldsRewardsPercenatage)
+        const rewardsPerBlockAPRBound = new BigNumber(farmTokenSupply)
+            .multipliedBy(annualPercentageRewards)
             .dividedBy(constantsConfig.MAX_PERCENT)
-            .multipliedBy(liquidity)
-            .dividedBy(farmTokenSupply);
+            .dividedBy(constantsConfig.BLOCKS_IN_YEAR);
 
-        const userRewardsForWeek = new BigNumber(
-            boostedYieldsFactors.maxRewardsFactor,
+        const actualRewardsPerBlock = new BigNumber(rewardsPerBlock).isLessThan(
+            rewardsPerBlockAPRBound,
         )
-            .multipliedBy(userMaxBoostedRewardsPerBlock)
-            .multipliedBy(constantsConfig.BLOCKS_PER_WEEK);
+            ? new BigNumber(rewardsPerBlock)
+            : rewardsPerBlockAPRBound;
+        const blocksInWeek = 14440 * 7;
+        const totalRewardsPerWeek =
+            actualRewardsPerBlock.multipliedBy(blocksInWeek);
 
-        for (const weeklyRewards of totalRewardsForWeek) {
-            const boostedRewardsByEnergy = new BigNumber(weeklyRewards.amount)
-                .multipliedBy(boostedYieldsFactors.userRewardsEnergy)
-                .multipliedBy(userEnergyForWeek.amount)
-                .dividedBy(totalEnergyForWeek);
-
-            const boostedRewardsByTokens = new BigNumber(weeklyRewards.amount)
-                .multipliedBy(boostedYieldsFactors.userRewardsFarm)
-                .multipliedBy(liquidity)
-                .dividedBy(farmTokenSupply);
-
-            const constantsBase = new BigNumber(
-                boostedYieldsFactors.userRewardsEnergy,
-            ).plus(boostedYieldsFactors.userRewardsFarm);
-
-            const boostedRewardAmount = boostedRewardsByEnergy
-                .plus(boostedRewardsByTokens)
-                .dividedBy(constantsBase);
-
-            const paymentAmount =
-                boostedRewardAmount.comparedTo(userRewardsForWeek) < 1
-                    ? boostedRewardAmount
-                    : userRewardsForWeek;
-            if (paymentAmount.isPositive()) {
-                const payment = new EsdtTokenPayment();
-                payment.amount = paymentAmount.integerValue().toFixed();
-                payment.nonce = 0;
-                payment.tokenID = weeklyRewards.tokenID;
-                payment.tokenType = weeklyRewards.tokenType;
-                payments.push(payment);
-            }
-        }
-
-        return payments;
+        return [
+            new EsdtTokenPayment({
+                tokenID: rewardTokenID,
+                nonce: 0,
+                amount: totalRewardsPerWeek
+                    .multipliedBy(boostedYieldsRewardsPercentage)
+                    .dividedBy(constantsConfig.MAX_PERCENT)
+                    .integerValue()
+                    .toFixed(),
+            }),
+        ];
     }
 
     @ErrorLoggerAsync({

--- a/src/modules/staking/services/staking.service.ts
+++ b/src/modules/staking/services/staking.service.ts
@@ -9,7 +9,11 @@ import { DecodeAttributesArgs } from 'src/modules/proxy/models/proxy.args';
 import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
 import { ContextGetterService } from 'src/services/context/context.getter.service';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
-import { StakingModel, StakingRewardsModel } from '../models/staking.model';
+import {
+    StakingBoostedRewardsModel,
+    StakingModel,
+    StakingRewardsModel,
+} from '../models/staking.model';
 import {
     StakingTokenAttributesModel,
     UnbondTokenAttributesModel,
@@ -26,7 +30,6 @@ import {
 import { WeekTimekeepingAbiService } from 'src/submodules/week-timekeeping/services/week-timekeeping.abi.service';
 import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
 import { constantsConfig } from 'src/config';
-import { BoostedRewardsModel } from 'src/modules/farm/models/farm.model';
 import { CollectionType } from 'src/modules/common/collection.type';
 import { PaginationArgs } from 'src/modules/dex.model';
 import {
@@ -255,7 +258,7 @@ export class StakingService {
     async getStakingBoostedRewardsBatch(
         stakingAddresses: string[],
         userAddress: string,
-    ): Promise<BoostedRewardsModel[]> {
+    ): Promise<StakingBoostedRewardsModel[]> {
         const promises = stakingAddresses.map(async (address) => {
             return await this.getStakingBoostedRewards(address, userAddress);
         });
@@ -265,7 +268,7 @@ export class StakingService {
     async getStakingBoostedRewards(
         stakingAddress: string,
         userAddress: string,
-    ): Promise<BoostedRewardsModel> {
+    ): Promise<StakingBoostedRewardsModel> {
         const currentWeek = await this.weekTimekeepingAbi.currentWeek(
             stakingAddress,
         );
@@ -309,8 +312,9 @@ export class StakingService {
                 currentWeek,
             );
 
-        return new BoostedRewardsModel({
+        return new StakingBoostedRewardsModel({
             farmAddress: stakingAddress,
+            userAddress: userAddress,
             boostedRewardsWeeklyInfo: modelsList,
             claimProgress: currentClaimProgress,
             accumulatedRewards: userAccumulatedRewards,

--- a/src/modules/staking/staking.module.ts
+++ b/src/modules/staking/staking.module.ts
@@ -9,7 +9,10 @@ import { StakingComputeService } from './services/staking.compute.service';
 import { StakingService } from './services/staking.service';
 import { StakingSetterService } from './services/staking.setter.service';
 import { StakingTransactionService } from './services/staking.transactions.service';
-import { StakingResolver } from './staking.resolver';
+import {
+    StakingBoostedRewardsResolver,
+    StakingResolver,
+} from './staking.resolver';
 import { WeekTimekeepingModule } from 'src/submodules/week-timekeeping/week-timekeeping.module';
 import { WeeklyRewardsSplittingModule } from 'src/submodules/weekly-rewards-splitting/weekly-rewards-splitting.module';
 import { StakingFilteringService } from './services/staking.filtering.service';
@@ -30,8 +33,9 @@ import { StakingFilteringService } from './services/staking.filtering.service';
         StakingSetterService,
         StakingComputeService,
         StakingTransactionService,
-        StakingResolver,
         StakingFilteringService,
+        StakingResolver,
+        StakingBoostedRewardsResolver,
     ],
     exports: [
         StakingAbiService,

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -49,20 +49,41 @@ export class StakingBoostedRewardsResolver {
     @ResolveField()
     async curentBoostedAPR(
         @Parent() parent: StakingBoostedRewardsModel,
+        @Args('additionalUserFarmAmount', {
+            type: () => String,
+            nullable: true,
+            defaultValue: '0',
+        })
+        additionalUserFarmAmount: string,
+        @Args('additionalUserEnergy', {
+            type: () => String,
+            nullable: true,
+            defaultValue: '0',
+        })
+        additionalUserEnergy: string,
     ): Promise<number> {
         return this.stakingCompute.computeUserCurentBoostedAPR(
             parent.farmAddress,
             parent.userAddress,
+            additionalUserFarmAmount,
+            additionalUserEnergy,
         );
     }
 
     @ResolveField()
     async maximumBoostedAPR(
         @Parent() parent: StakingBoostedRewardsModel,
+        @Args('additionalUserFarmAmount', {
+            type: () => String,
+            nullable: true,
+            defaultValue: '0',
+        })
+        additionalUserFarmAmount: string,
     ): Promise<number> {
         return this.stakingCompute.computeUserMaxBoostedAPR(
             parent.farmAddress,
             parent.userAddress,
+            additionalUserFarmAmount,
         );
     }
 }


### PR DESCRIPTION
## Reasoning
- move compute for user current boosted APR and maximum boosted APR in backend side
  
## Proposed Changes
- added new fields `currentBoostedAPR` and `maximumBoostedAPR` for `BoostedRewardsModel`
- updated computes methods in farm and staking for current and maximum boosted APR specific for users
- added options to put arbitrary values for user farm amount and energy to compute APRs

## How to test
```
query StakingBoostedRewards {
    getStakingBoostedRewardsBatch(
        stakingAddresses: [
            "erd1qqqqqqqqqqqqqpgqcedkmj8ezme6mtautj79ngv7fez978le2jps8jtawn"
        ]
    ) {
        curentBoostedAPR(
            additionalUserFarmAmount: <amount(can be negative)>
            additionalUserEnergy: <amount(can be negative)>
        )
        maximumBoostedAPR(
            additionalUserFarmAmount: <amount(can be negative)>    
        )
    }
}
```