### PR TITLE
[SERVICES-2569] Caching improvements for pairs

### DIFF
--- a/src/modules/analytics/services/analytics.aws.getter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.getter.service.ts
@@ -4,6 +4,7 @@ import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { HistoricDataModel } from '../models/analytics.model';
 import moment from 'moment';
 import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
+import { parseCachedNullOrUndefined } from 'src/utils/cache.utils';
 
 @Injectable()
 export class AnalyticsAWSGetterService {
@@ -14,7 +15,7 @@ export class AnalyticsAWSGetterService {
         if (!data || data === undefined) {
             return undefined;
         }
-        return data;
+        return parseCachedNullOrUndefined(data);
     }
 
     @ErrorLoggerAsync()

--- a/src/modules/pair/services/pair.abi.loader.ts
+++ b/src/modules/pair/services/pair.abi.loader.ts
@@ -89,23 +89,13 @@ export class PairAbiLoader {
 
     public readonly stateLoader = new DataLoader<string, string>(
         async (addresses: string[]) => {
-            return getAllKeys<string>(
-                this.cacheService,
-                addresses,
-                'pair.state',
-                this.pairAbi.state.bind(this.pairAbi),
-            );
+            return this.pairService.getAllStates(addresses);
         },
     );
 
     public readonly feeStateLoader = new DataLoader<string, boolean>(
         async (addresses: string[]) => {
-            return getAllKeys<boolean>(
-                this.cacheService,
-                addresses,
-                'pair.feeState',
-                this.pairAbi.feeState.bind(this.pairAbi),
-            );
+            return this.pairService.getAllFeeStates(addresses);
         },
     );
 

--- a/src/modules/pair/services/pair.compute.loader.ts
+++ b/src/modules/pair/services/pair.compute.loader.ts
@@ -3,6 +3,7 @@ import { PairComputeService } from './pair.compute.service';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import DataLoader from 'dataloader';
+import { PairService } from './pair.service';
 
 @Injectable({
     scope: Scope.REQUEST,
@@ -10,6 +11,7 @@ import DataLoader from 'dataloader';
 export class PairComputeLoader {
     constructor(
         private readonly pairCompute: PairComputeService,
+        private readonly pairService: PairService,
         private readonly cacheService: CacheService,
     ) {}
 
@@ -94,12 +96,7 @@ export class PairComputeLoader {
 
     public readonly lockedValueUSDLoader = new DataLoader<string, string>(
         async (addresses: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                addresses,
-                'pair.lockedValueUSD',
-                this.pairCompute.lockedValueUSD.bind(this.pairCompute),
-            );
+            return await this.pairService.getAllLockedValueUSD(addresses);
         },
     );
 
@@ -161,45 +158,25 @@ export class PairComputeLoader {
 
     public readonly hasFarmsLoader = new DataLoader<string, boolean>(
         async (addresses: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                addresses,
-                'pair.hasFarms',
-                this.pairCompute.hasFarms.bind(this.pairCompute),
-            );
+            return await this.pairService.getAllHasFarms(addresses);
         },
     );
 
     public readonly hasDualFarmsLoader = new DataLoader<string, boolean>(
         async (addresses: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                addresses,
-                'pair.hasDualFarms',
-                this.pairCompute.hasDualFarms.bind(this.pairCompute),
-            );
+            return await this.pairService.getAllHasDualFarms(addresses);
         },
     );
 
     public readonly tradesCountLoader = new DataLoader<string, number>(
         async (addresses: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                addresses,
-                'pair.tradesCount',
-                this.pairCompute.tradesCount.bind(this.pairCompute),
-            );
+            return await this.pairService.getAllTradesCount(addresses);
         },
     );
 
     public readonly deployedAtLoader = new DataLoader<string, number>(
         async (addresses: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                addresses,
-                'pair.deployedAt',
-                this.pairCompute.deployedAt.bind(this.pairCompute),
-            );
+            return await this.pairService.getAllDeployedAt(addresses);
         },
     );
 }

--- a/src/modules/pair/services/pair.filtering.service.ts
+++ b/src/modules/pair/services/pair.filtering.service.ts
@@ -25,10 +25,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const lpTokensIDs = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairAbi.lpTokenID(pairMetadata.address),
-            ),
+        const lpTokensIDs = await this.pairService.getAllLpTokensIds(
+            pairsMetadata.map((pairMetadata) => pairMetadata.address),
         );
 
         const filteredPairsMetadata = [];
@@ -96,16 +94,15 @@ export class PairFilteringService {
         }
 
         const searchTerm = pairFilter.searchToken.toUpperCase().trim();
-
-        const pairsFirstToken = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairService.getFirstToken(pairMetadata.address),
-            ),
+        const pairsAddresses = pairsMetadata.map(
+            (pairMetadata) => pairMetadata.address,
         );
-        const pairsSecondToken = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairService.getSecondToken(pairMetadata.address),
-            ),
+
+        const pairsFirstToken = await this.pairService.getAllFirstTokens(
+            pairsAddresses,
+        );
+        const pairsSecondToken = await this.pairService.getAllSecondTokens(
+            pairsAddresses,
         );
 
         const filteredPairs: PairMetadata[] = [];
@@ -136,10 +133,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const lpTokensIDs = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairAbi.lpTokenID(pairMetadata.address),
-            ),
+        const lpTokensIDs = await this.pairService.getAllLpTokensIds(
+            pairsMetadata.map((pairMetadata) => pairMetadata.address),
         );
 
         return pairsMetadata.filter((_, index) =>
@@ -176,10 +171,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsStates = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairAbi.state(pairMetadata.address),
-            ),
+        const pairsStates = await this.pairService.getAllStates(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter((_, index) => {
@@ -202,10 +195,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsFeeStates = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairAbi.feeState(pairMetadata.address),
-            ),
+        const pairsFeeStates = await this.pairService.getAllFeeStates(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter(
@@ -241,10 +232,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsLiquidityUSD = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairCompute.lockedValueUSD(pairMetadata.address),
-            ),
+        const pairsLiquidityUSD = await this.pairService.getAllLockedValueUSD(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter((_, index) => {
@@ -261,10 +250,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsTradesCount = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairCompute.tradesCount(pairMetadata.address),
-            ),
+        const pairsTradesCount = await this.pairService.getAllTradesCount(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter(
@@ -283,10 +270,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsHasFarms = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairCompute.hasFarms(pairMetadata.address),
-            ),
+        const pairsHasFarms = await this.pairService.getAllHasFarms(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter(
@@ -305,10 +290,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsHasDualFarms = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairCompute.hasDualFarms(pairMetadata.address),
-            ),
+        const pairsHasDualFarms = await this.pairService.getAllHasDualFarms(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter(
@@ -324,10 +307,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsDeployedAt = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairCompute.deployedAt(pairMetadata.address),
-            ),
+        const pairsDeployedAt = await this.pairService.getAllDeployedAt(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter(

--- a/src/modules/pair/services/pair.service.ts
+++ b/src/modules/pair/services/pair.service.ts
@@ -74,15 +74,82 @@ export class PairService {
             : await this.tokenService.tokenMetadata(lpTokenID);
     }
 
-    async getAllLpTokens(pairAddresses: string[]): Promise<EsdtToken[]> {
-        const tokenIDs = await getAllKeys<string>(
+    async getAllLpTokensIds(pairAddresses: string[]): Promise<string[]> {
+        return await getAllKeys<string>(
             this.cachingService,
             pairAddresses,
             'pair.lpTokenID',
             this.pairAbi.lpTokenID.bind(this.pairAbi),
         );
+    }
+
+    async getAllLpTokens(pairAddresses: string[]): Promise<EsdtToken[]> {
+        const tokenIDs = await this.getAllLpTokensIds(pairAddresses);
 
         return this.tokenService.getAllTokensMetadata(tokenIDs);
+    }
+
+    async getAllStates(pairAddresses: string[]): Promise<string[]> {
+        return await getAllKeys<string>(
+            this.cachingService,
+            pairAddresses,
+            'pair.state',
+            this.pairAbi.state.bind(this.pairAbi),
+        );
+    }
+
+    async getAllFeeStates(pairAddresses: string[]): Promise<boolean[]> {
+        return await getAllKeys<boolean>(
+            this.cachingService,
+            pairAddresses,
+            'pair.feeState',
+            this.pairAbi.feeState.bind(this.pairAbi),
+        );
+    }
+
+    async getAllLockedValueUSD(pairAddresses: string[]): Promise<string[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.lockedValueUSD',
+            this.pairCompute.lockedValueUSD.bind(this.pairCompute),
+        );
+    }
+
+    async getAllDeployedAt(pairAddresses: string[]): Promise<number[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.deployedAt',
+            this.pairCompute.deployedAt.bind(this.pairCompute),
+        );
+    }
+
+    async getAllTradesCount(pairAddresses: string[]): Promise<number[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.tradesCount',
+            this.pairCompute.tradesCount.bind(this.pairCompute),
+        );
+    }
+
+    async getAllHasFarms(pairAddresses: string[]): Promise<boolean[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.hasFarms',
+            this.pairCompute.hasFarms.bind(this.pairCompute),
+        );
+    }
+
+    async getAllHasDualFarms(pairAddresses: string[]): Promise<boolean[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.hasDualFarms',
+            this.pairCompute.hasDualFarms.bind(this.pairCompute),
+        );
     }
 
     async getAmountOut(


### PR DESCRIPTION
## Reasoning
- the `pairs` and `filteredPairs` queries rely on Promise.all() for getting field data needed for sorting and filtering. Although most data is coming from cache, this still causes degradation in performance due to the large number of pairs


## Proposed Changes
- add pairs bulk getter methods for the following fields : `lpTokenID`, `state`, `feeState`, `lockedValueUSD`, `deployedAt`, `tradesCount`, `hasFarms`, `hasDualFarms`
- refactor pair dataloaders to use bulk getter methods
- refactor pairs filtering and sorting to use bulk getters

## How to test
- N/A
