### PR TITLE
[SERVICES-2577] Staking farms filter by depleted rewards

### DIFF
--- a/src/modules/staking/models/staking.args.ts
+++ b/src/modules/staking/models/staking.args.ts
@@ -40,7 +40,7 @@ export class StakingFarmsFilter {
     @Field(() => String, { nullable: true })
     searchToken?: string;
     @Field({ nullable: true })
-    rewardsDepleted?: boolean;
+    rewardsDepletedPerFarm?: boolean;
 }
 
 @InputType()

--- a/src/modules/staking/models/staking.args.ts
+++ b/src/modules/staking/models/staking.args.ts
@@ -39,6 +39,8 @@ export class ClaimRewardsWithNewValueArgs extends GenericStakeFarmArgs {
 export class StakingFarmsFilter {
     @Field(() => String, { nullable: true })
     searchToken?: string;
+    @Field({ nullable: true })
+    rewardsDepleted?: boolean;
 }
 
 @InputType()

--- a/src/modules/staking/models/staking.args.ts
+++ b/src/modules/staking/models/staking.args.ts
@@ -40,7 +40,7 @@ export class StakingFarmsFilter {
     @Field(() => String, { nullable: true })
     searchToken?: string;
     @Field({ nullable: true })
-    rewardsDepletedPerFarm?: boolean;
+    rewardsEnded?: boolean;
 }
 
 @InputType()

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -20,6 +20,8 @@ import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { IStakingAbiService } from './interfaces';
 import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
+import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { getAllKeys } from 'src/utils/get.many.utils';
 
 @Injectable()
 export class StakingAbiService
@@ -30,6 +32,7 @@ export class StakingAbiService
         protected readonly mxProxy: MXProxyService,
         private readonly gatewayService: MXGatewayService,
         private readonly apiService: MXApiService,
+        private readonly cachingService: CacheService,
     ) {
         super(mxProxy);
     }
@@ -76,6 +79,15 @@ export class StakingAbiService
             contract.methodsExplicit.getFarmingTokenId();
         const response = await this.getGenericData(interaction);
         return response.firstValue.valueOf().toString();
+    }
+
+    async getAllFarmingTokensIds(stakeAddresses: string[]): Promise<string[]> {
+        return await getAllKeys<string>(
+            this.cachingService,
+            stakeAddresses,
+            'stake.farmingTokenID',
+            this.farmingTokenID.bind(this),
+        );
     }
 
     @ErrorLoggerAsync({
@@ -166,6 +178,17 @@ export class StakingAbiService
         return response.firstValue.valueOf().toFixed();
     }
 
+    async getAllAccumulatedRewards(
+        stakeAddresses: string[],
+    ): Promise<string[]> {
+        return await getAllKeys<string>(
+            this.cachingService,
+            stakeAddresses,
+            'stake.accumulatedRewards',
+            this.accumulatedRewards.bind(this),
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })
@@ -186,6 +209,15 @@ export class StakingAbiService
             contract.methodsExplicit.getRewardCapacity();
         const response = await this.getGenericData(interaction);
         return response.firstValue.valueOf().toFixed();
+    }
+
+    async getAllRewardCapacity(stakeAddresses: string[]): Promise<string[]> {
+        return await getAllKeys<string>(
+            this.cachingService,
+            stakeAddresses,
+            'stake.rewardCapacity',
+            this.rewardCapacity.bind(this),
+        );
     }
 
     @ErrorLoggerAsync({
@@ -316,6 +348,17 @@ export class StakingAbiService
             'produce_rewards_enabled',
         );
         return response === '01';
+    }
+
+    async getAllProduceRewardsEnabled(
+        stakeAddresses: string[],
+    ): Promise<boolean[]> {
+        return await getAllKeys<boolean>(
+            this.cachingService,
+            stakeAddresses,
+            'stake.produceRewardsEnabled',
+            this.produceRewardsEnabled.bind(this),
+        );
     }
 
     @ErrorLoggerAsync({

--- a/src/modules/staking/services/staking.filtering.service.ts
+++ b/src/modules/staking/services/staking.filtering.service.ts
@@ -47,8 +47,8 @@ export class StakingFilteringService {
         stakeAddresses: string[],
     ): Promise<string[]> {
         if (
-            typeof stakingFilter.rewardsDepleted === 'undefined' ||
-            stakingFilter.rewardsDepleted === null
+            typeof stakingFilter.rewardsDepletedPerFarm === 'undefined' ||
+            stakingFilter.rewardsDepletedPerFarm === null
         ) {
             return stakeAddresses;
         }
@@ -70,7 +70,7 @@ export class StakingFilteringService {
 
         return stakeAddresses.filter(
             (_, index) =>
-                rewardsDepleted[index] === stakingFilter.rewardsDepleted,
+                rewardsDepleted[index] === stakingFilter.rewardsDepletedPerFarm,
         );
     }
 }

--- a/src/modules/staking/services/staking.service.ts
+++ b/src/modules/staking/services/staking.service.ts
@@ -39,8 +39,6 @@ import {
 } from '../models/staking.args';
 import { SortingOrder } from 'src/modules/common/page.data';
 import { StakingFilteringService } from './staking.filtering.service';
-import { getAllKeys } from 'src/utils/get.many.utils';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
 
 @Injectable()
 export class StakingService {
@@ -56,7 +54,6 @@ export class StakingService {
         private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
         @Inject(forwardRef(() => StakingFilteringService))
         private readonly stakingFilteringService: StakingFilteringService,
-        private readonly cachingService: CacheService,
     ) {}
 
     async getFarmsStaking(): Promise<StakingModel[]> {
@@ -118,37 +115,6 @@ export class StakingService {
         });
     }
 
-    async getAllAccumulatedRewards(
-        stakeAddresses: string[],
-    ): Promise<string[]> {
-        return await getAllKeys<string>(
-            this.cachingService,
-            stakeAddresses,
-            'stake.accumulatedRewards',
-            this.stakingAbi.accumulatedRewards.bind(this.stakingAbi),
-        );
-    }
-
-    async getAllRewardCapacity(stakeAddresses: string[]): Promise<string[]> {
-        return await getAllKeys<string>(
-            this.cachingService,
-            stakeAddresses,
-            'stake.rewardCapacity',
-            this.stakingAbi.rewardCapacity.bind(this.stakingAbi),
-        );
-    }
-
-    async getAllProduceRewardsEnabled(
-        stakeAddresses: string[],
-    ): Promise<boolean[]> {
-        return await getAllKeys<boolean>(
-            this.cachingService,
-            stakeAddresses,
-            'stake.produceRewardsEnabled',
-            this.stakingAbi.produceRewardsEnabled.bind(this.stakingAbi),
-        );
-    }
-
     async getFarmToken(stakeAddress: string): Promise<NftCollection> {
         const farmTokenID = await this.stakingAbi.farmTokenID(stakeAddress);
         return await this.tokenService.getNftCollectionMetadata(farmTokenID);
@@ -161,17 +127,8 @@ export class StakingService {
         return await this.tokenService.tokenMetadata(farmingTokenID);
     }
 
-    async getAllFarmingTokensIds(stakeAddresses: string[]): Promise<string[]> {
-        return await getAllKeys<string>(
-            this.cachingService,
-            stakeAddresses,
-            'stake.farmingTokenID',
-            this.stakingAbi.farmingTokenID.bind(this.stakingAbi),
-        );
-    }
-
     async getAllFarmingTokens(stakeAddresses: string[]): Promise<EsdtToken[]> {
-        const farmingTokenIDs = await this.getAllFarmingTokensIds(
+        const farmingTokenIDs = await this.stakingAbi.getAllFarmingTokensIds(
             stakeAddresses,
         );
 


### PR DESCRIPTION
## Reasoning
- The front-end needs a way to filter out staking farms with depleted rewards on the `filteredStakingFarms` query

  
## Proposed Changes
- add `rewardsDepleted` boolean filter to `filteredStakingFarms` query


## How to test
- the query below should only return staking farms with remaining rewards
```
query {
  filteredStakingFarms(
    filters:{
      rewardsDepleted: false
    }
    pagination:{
      first:1
    }
    sorting: {
      sortField: TVL
      sortOrder: DESC
    }
  ) {
    edges {
      cursor
      node {
        address
        apr
        farmingToken {
          identifier
        }
        farmToken {
          ticker
        }
      }
    }
    pageData {
      count
      limit
      offset
    }
  }
}
```
