### PR TITLE
[MEX-495] fix migrate staking positions transactions

### DIFF
--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -531,7 +531,9 @@ export class PairComputeService implements IPairComputeService {
             ),
         );
 
-        return actualFees24hBig.times(365).div(lockedValueUSD).toFixed();
+        const feesAPR = actualFees24hBig.times(365).div(lockedValueUSD);
+
+        return !feesAPR.isNaN() ? feesAPR.toFixed() : '0';
     }
 
     @ErrorLoggerAsync({

--- a/src/modules/staking/services/staking.transactions.service.ts
+++ b/src/modules/staking/services/staking.transactions.service.ts
@@ -9,7 +9,7 @@ import {
 } from '@multiversx/sdk-core';
 import { Injectable } from '@nestjs/common';
 import { BigNumber } from 'bignumber.js';
-import { mxConfig, gasConfig } from 'src/config';
+import { mxConfig, gasConfig, constantsConfig } from 'src/config';
 import { InputTokenModel } from 'src/models/inputToken.model';
 import { TransactionModel } from 'src/models/transaction.model';
 import { MXProxyService } from 'src/services/multiversx-communication/mx.proxy.service';
@@ -226,7 +226,11 @@ export class StakingTransactionService {
 
         const promises: Promise<TransactionModel>[] = [];
         userNfts.forEach((nft) => {
-            if (nft.nonce < migrationNonce) {
+            if (
+                nft.nonce < migrationNonce &&
+                nft.attributes.length >
+                    constantsConfig.STAKING_UNBOND_ATTRIBUTES_LEN
+            ) {
                 promises.push(
                     this.claimRewards(userAddress, stakingAddress, {
                         tokenID: nft.collection,


### PR DESCRIPTION
## Reasoning
- migrate staking positions transactions should not include unbonding tokens
  
## Proposed Changes
- added check to exclude unbonding tokens from migrate staking positions transactions

## How to test
- N/A
