### PR TITLE
[MEX-515] Add query metrics plugin for apollo server

### DIFF
--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -39,6 +39,7 @@ import '@multiversx/sdk-nestjs-common/lib/utils/extensions/array.extensions';
 import { PositionCreatorModule } from './modules/position-creator/position.creator.module';
 import { ComposableTasksModule } from './modules/composable-tasks/composable.tasks.module';
 import { TradingViewModule } from './modules/trading-view/trading.view.module';
+import { QueryMetricsPlugin } from './utils/query.metrics.plugin';
 
 @Module({
     imports: [
@@ -103,6 +104,7 @@ import { TradingViewModule } from './modules/trading-view/trading.view.module';
         DynamicModuleUtils.getCacheModule(),
         TradingViewModule,
     ],
+    providers: [QueryMetricsPlugin],
 })
 export class PublicAppModule {
     configure(consumer: MiddlewareConsumer) {

--- a/src/utils/logging.interceptor.ts
+++ b/src/utils/logging.interceptor.ts
@@ -6,10 +6,6 @@ import {
 } from '@nestjs/common';
 import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
-import { CpuProfiler } from '@multiversx/sdk-nestjs-monitoring';
-import { MetricsCollector } from './metrics.collector';
-import { PerformanceProfiler } from './performance.profiler';
 import { ContextTracker } from '@multiversx/sdk-nestjs-common';
 
 @Injectable()
@@ -17,44 +13,17 @@ export class LoggingInterceptor implements NestInterceptor {
     intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
         if (context.getType<GqlContextType>() === 'graphql') {
             const gqlContext = GqlExecutionContext.create(context);
-            const info = gqlContext.getInfo();
-            const parentType = info.parentType.name;
-            const fieldName = info.fieldName;
 
             const { req } = gqlContext.getContext();
 
-            let origin = 'Unknown';
             let timestamp: number = undefined;
             if (req !== undefined) {
-                origin = req?.headers?.['origin'] ?? 'Unknown';
                 timestamp = req?.headers?.['timestamp'];
                 ContextTracker.assign({
                     deepHistoryTimestamp: timestamp,
                 });
             }
-
-            const profiler = new PerformanceProfiler();
-            const cpuProfiler = new CpuProfiler();
-
-            return next.handle().pipe(
-                tap(() => {
-                    profiler.stop();
-                    const cpuTime = cpuProfiler.stop();
-                    if (parentType === 'Query') {
-                        MetricsCollector.setQueryDuration(
-                            fieldName,
-                            origin,
-                            profiler.duration,
-                        );
-
-                        MetricsCollector.setQueryCpu(
-                            fieldName,
-                            origin,
-                            cpuTime,
-                        );
-                    }
-                }),
-            );
+            return next.handle().pipe();
         }
         return next.handle();
     }

--- a/src/utils/query.metrics.plugin.ts
+++ b/src/utils/query.metrics.plugin.ts
@@ -1,0 +1,50 @@
+import {
+    ApolloServerPlugin,
+    GraphQLRequestContext,
+    GraphQLRequestExecutionListener,
+    GraphQLRequestListener,
+} from '@apollo/server';
+import { Plugin } from '@nestjs/apollo';
+import { PerformanceProfiler } from './performance.profiler';
+import { CpuProfiler } from '@multiversx/sdk-nestjs-monitoring';
+import { MetricsCollector } from './metrics.collector';
+
+@Plugin()
+export class QueryMetricsPlugin implements ApolloServerPlugin {
+    async requestDidStart(): Promise<GraphQLRequestListener<any>> {
+        let profiler: PerformanceProfiler;
+        let cpuProfiler: CpuProfiler;
+        let operationName: string;
+        let origin: string;
+
+        return {
+            async executionDidStart(
+                requestContext: GraphQLRequestContext<any>,
+            ): Promise<void | GraphQLRequestExecutionListener<any>> {
+                operationName = requestContext.operationName;
+                if (!operationName) {
+                    operationName = requestContext.queryHash;
+                }
+                origin =
+                    requestContext.request.http?.headers.get('origin') ??
+                    'Unknown';
+
+                profiler = new PerformanceProfiler();
+                cpuProfiler = new CpuProfiler();
+                profiler.start(operationName);
+            },
+            async willSendResponse(): Promise<void> {
+                profiler.stop(operationName);
+                const cpuTime = cpuProfiler.stop();
+
+                MetricsCollector.setQueryDuration(
+                    operationName,
+                    origin,
+                    profiler.duration,
+                );
+
+                MetricsCollector.setQueryCpu(operationName, origin, cpuTime);
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Reasoning
- query metrics didn't take into account the execution for each field resolver
  
## Proposed Changes
- added a graphql plugin to measure the full query execution time including the filed resolvers

## How to test
- N/A
