### PR TITLE
[SERVICES-2578] Caching improvements for tokens queries

### DIFF
--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -28,6 +28,7 @@ import { PendingExecutor } from 'src/utils/pending.executor';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { TokenService } from './token.service';
 import { computeValueUSD } from 'src/utils/token.converters';
+import { getAllKeys } from 'src/utils/get.many.utils';
 
 @Injectable()
 export class TokenComputeService implements ITokenComputeService {
@@ -189,6 +190,15 @@ export class TokenComputeService implements ITokenComputeService {
         return priceSoFar;
     }
 
+    async getAllTokensPriceDerivedEGLD(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenPriceDerivedEGLD',
+            this.tokenPriceDerivedEGLD.bind(this),
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })
@@ -222,6 +232,15 @@ export class TokenComputeService implements ITokenComputeService {
             .toFixed();
     }
 
+    async getAllTokensPriceDerivedUSD(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenPriceDerivedUSD',
+            this.tokenPriceDerivedUSD.bind(this),
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })
@@ -241,6 +260,15 @@ export class TokenComputeService implements ITokenComputeService {
         });
 
         return values24h[0]?.value ?? undefined;
+    }
+
+    async getAllTokensPrevious24hPrice(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenPrevious24hPrice',
+            this.tokenPrevious24hPrice.bind(this),
+        );
     }
 
     @ErrorLoggerAsync({
@@ -263,6 +291,15 @@ export class TokenComputeService implements ITokenComputeService {
         });
 
         return values7d[0]?.value ?? undefined;
+    }
+
+    async getAllTokensPrevious7dPrice(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenPrevious7dPrice',
+            this.tokenPrevious7dPrice.bind(this),
+        );
     }
 
     @ErrorLoggerAsync({
@@ -388,6 +425,15 @@ export class TokenComputeService implements ITokenComputeService {
         return valuesLast2Days.current;
     }
 
+    async getAllTokensVolumeUSD24h(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenVolumeUSD24h',
+            this.tokenVolumeUSD24h.bind(this),
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })
@@ -403,6 +449,17 @@ export class TokenComputeService implements ITokenComputeService {
     async computeTokenPrevious24hVolumeUSD(tokenID: string): Promise<string> {
         const valuesLast2Days = await this.tokenLast2DaysVolumeUSD(tokenID);
         return valuesLast2Days.previous;
+    }
+
+    async getAllTokensPrevious24hVolumeUSD(
+        tokenIDs: string[],
+    ): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenPrevious24hVolumeUSD',
+            this.tokenPrevious24hVolumeUSD.bind(this),
+        );
     }
 
     @ErrorLoggerAsync({
@@ -503,6 +560,15 @@ export class TokenComputeService implements ITokenComputeService {
         ).toFixed();
     }
 
+    async getAllTokensLiquidityUSD(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys<string>(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenLiquidityUSD',
+            this.tokenLiquidityUSD.bind(this),
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })
@@ -531,6 +597,15 @@ export class TokenComputeService implements ITokenComputeService {
         }
 
         return undefined;
+    }
+
+    async getAllTokensCreatedAt(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenCreatedAt',
+            this.tokenCreatedAt.bind(this),
+        );
     }
 
     @ErrorLoggerAsync({
@@ -673,5 +748,14 @@ export class TokenComputeService implements ITokenComputeService {
         const trendingScore = volumeScore.plus(priceScore).plus(tradeScore);
 
         return trendingScore.toFixed();
+    }
+
+    async getAllTokensTrendingScore(tokenIDs: string[]): Promise<string[]> {
+        return getAllKeys(
+            this.cachingService,
+            tokenIDs,
+            'token.tokenTrendingScore',
+            this.tokenTrendingScore.bind(this),
+        );
     }
 }

--- a/src/modules/tokens/services/token.filtering.service.ts
+++ b/src/modules/tokens/services/token.filtering.service.ts
@@ -38,15 +38,13 @@ export class TokenFilteringService {
             return tokenIDs;
         }
 
-        const filteredIDs = [];
-        for (const tokenID of tokenIDs) {
-            const tokenType = await this.tokenService.getEsdtTokenType(tokenID);
+        const tokenTypes = await this.tokenService.getAllEsdtTokensType(
+            tokenIDs,
+        );
 
-            if (tokenType === tokensFilter.type) {
-                filteredIDs.push(tokenID);
-            }
-        }
-        return filteredIDs;
+        return tokenIDs.filter(
+            (_, index) => tokenTypes[index] === tokensFilter.type,
+        );
     }
 
     async tokensBySearchTerm(
@@ -84,17 +82,12 @@ export class TokenFilteringService {
             return tokenIDs;
         }
 
-        const filteredIDs = [];
-        for (const tokenID of tokenIDs) {
-            const liquidity = await this.tokenCompute.tokenLiquidityUSD(
-                tokenID,
-            );
+        const tokensLiquidityUSD =
+            await this.tokenCompute.getAllTokensLiquidityUSD(tokenIDs);
 
-            const liquidityBN = new BigNumber(liquidity);
-            if (liquidityBN.gte(tokensFilter.minLiquidity)) {
-                filteredIDs.push(tokenID);
-            }
-        }
-        return filteredIDs;
+        return tokenIDs.filter((_, index) => {
+            const liquidity = new BigNumber(tokensLiquidityUSD[index]);
+            return liquidity.gte(tokensFilter.minLiquidity);
+        });
     }
 }

--- a/src/modules/tokens/services/token.loader.ts
+++ b/src/modules/tokens/services/token.loader.ts
@@ -17,12 +17,7 @@ export class TokenLoader {
 
     public readonly tokenTypeLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                tokenIDs,
-                'token.getEsdtTokenType',
-                this.tokenService.getEsdtTokenType.bind(this.tokenService),
-            );
+            return await this.tokenService.getAllEsdtTokensType(tokenIDs);
         },
     );
 
@@ -30,21 +25,13 @@ export class TokenLoader {
         string,
         string
     >(async (tokenIDs: string[]) => {
-        return await getAllKeys(
-            this.cacheService,
-            tokenIDs,
-            'token.tokenPriceDerivedEGLD',
-            this.tokenCompute.tokenPriceDerivedEGLD.bind(this.tokenCompute),
-        );
+        return await this.tokenCompute.getAllTokensPriceDerivedEGLD(tokenIDs);
     });
 
     public readonly tokenPriceDerivedUSDLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
+            return await this.tokenCompute.getAllTokensPriceDerivedUSD(
                 tokenIDs,
-                'token.tokenPriceDerivedUSD',
-                this.tokenCompute.tokenPriceDerivedUSD.bind(this.tokenCompute),
             );
         },
     );
@@ -53,33 +40,20 @@ export class TokenLoader {
         string,
         string
     >(async (tokenIDs: string[]) => {
-        return await getAllKeys(
-            this.cacheService,
-            tokenIDs,
-            'token.tokenPrevious24hPrice',
-            this.tokenCompute.tokenPrevious24hPrice.bind(this.tokenCompute),
-        );
+        return await this.tokenCompute.getAllTokensPrevious24hPrice(tokenIDs);
     });
 
     public readonly tokenPrevious7dPriceLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
+            return await this.tokenCompute.getAllTokensPrevious7dPrice(
                 tokenIDs,
-                'token.tokenPrevious7dPrice',
-                this.tokenCompute.tokenPrevious7dPrice.bind(this.tokenCompute),
             );
         },
     );
 
     public readonly tokenVolumeUSD24hLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                tokenIDs,
-                'token.tokenVolumeUSD24h',
-                this.tokenCompute.tokenVolumeUSD24h.bind(this.tokenCompute),
-            );
+            return await this.tokenCompute.getAllTokensVolumeUSD24h(tokenIDs);
         },
     );
 
@@ -87,33 +61,20 @@ export class TokenLoader {
         string,
         string
     >(async (tokenIDs: string[]) => {
-        return await getAllKeys(
-            this.cacheService,
+        return await this.tokenCompute.getAllTokensPrevious24hVolumeUSD(
             tokenIDs,
-            'token.tokenPrevious24hVolumeUSD',
-            this.tokenCompute.tokenPrevious24hVolumeUSD.bind(this.tokenCompute),
         );
     });
 
     public readonly tokenLiquidityUSDLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                tokenIDs,
-                'token.tokenLiquidityUSD',
-                this.tokenCompute.tokenLiquidityUSD.bind(this.tokenCompute),
-            );
+            return await this.tokenCompute.getAllTokensLiquidityUSD(tokenIDs);
         },
     );
 
     public readonly tokenCreatedAtLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                tokenIDs,
-                'token.tokenCreatedAt',
-                this.tokenCompute.tokenCreatedAt.bind(this.tokenCompute),
-            );
+            return await this.tokenCompute.getAllTokensCreatedAt(tokenIDs);
         },
     );
 
@@ -142,12 +103,7 @@ export class TokenLoader {
 
     public readonly tokenTrendingScoreLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
-                tokenIDs,
-                'token.tokenTrendingScore',
-                this.tokenCompute.tokenTrendingScore.bind(this.tokenCompute),
-            );
+            return await this.tokenCompute.getAllTokensTrendingScore(tokenIDs);
         },
     );
 }

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -128,7 +128,6 @@ export class TokenService {
             tokenIDs,
             'token.getEsdtTokenType',
             this.getEsdtTokenType.bind(this),
-            CacheTtlInfo.Token,
         );
     }
 


### PR DESCRIPTION
## Reasoning
- the `tokens` and `filteredTokens` queries rely on Promise.all() for getting field data needed for sorting and filtering. Although most data is coming from cache, this still causes degradation in performance due to the large number of tokens

## Proposed Changes
- add bulk getter methods in tokens.compute service
- refactor tokens filtering and sorting to use bulk methods
- refactor token dataloaders to use bulk methods

## How to test
- N/A
