### PR TITLE
[MEX-516] fix missing user outdated contracts

### DIFF
--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -313,7 +313,7 @@ export class UserEnergyComputeService {
             (token) => token.creator,
         );
         const promisesDualYieldTokens = dualYieldTokens.map((token) => {
-            return this.getFarmAddressForDualYieldToken(token.collection);
+            return this.getStakeAddressForDualYieldToken(token.collection);
         });
 
         userActiveStakeAddresses = userActiveStakeAddresses.concat(
@@ -716,14 +716,14 @@ export class UserEnergyComputeService {
         return this.stakeProxyAbi.lpFarmAddress(stakingProxyAddress);
     }
 
-    async getStakeAddressForDualYieldToken(token: UserDualYiledToken) {
-        if (!token || token === undefined) {
+    async getStakeAddressForDualYieldToken(collection: string) {
+        if (!collection || collection === undefined) {
             return undefined;
         }
 
         const stakingProxyAddress =
             await this.stakeProxyService.getStakingProxyAddressByDualYieldTokenID(
-                token.collection,
+                collection,
             );
         return this.stakeProxyAbi.stakingFarmAddress(stakingProxyAddress);
     }


### PR DESCRIPTION
## Reasoning
- active staking farms should include staking coming from dual farm tokens
  
## Proposed Changes
- user correct methods to get staking address from dual farm token

## How to test
```
query UserOutdatedContracts {
    userOutdatedContracts {
        address
        type
        farmToken
        claimProgressOutdated
    }
}
```
- query should return a farm address and staking address for users with dual farm tokens