### PR TITLE
[SERVICES-2582] Set local cache in getAllKeys utility function

### DIFF
--- a/src/modules/farm/base-module/services/farm.abi.loader.ts
+++ b/src/modules/farm/base-module/services/farm.abi.loader.ts
@@ -6,6 +6,7 @@ import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { FarmAbiService } from './farm.abi.service';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { getAllKeys } from 'src/utils/get.many.utils';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 @Injectable({
     scope: Scope.REQUEST,
@@ -44,6 +45,7 @@ export class FarmAbiLoader {
             addresses,
             'farm.produceRewardsEnabled',
             this.farmAbi.produceRewardsEnabled.bind(this.farmAbi),
+            CacheTtlInfo.ContractState,
         );
     });
 
@@ -54,6 +56,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.perBlockRewards',
                 this.farmAbi.rewardsPerBlock.bind(this.farmAbi),
+                CacheTtlInfo.ContractState,
             );
         },
     );
@@ -65,6 +68,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.farmTokenSupply',
                 this.farmAbi.farmTokenSupply.bind(this.farmAbi),
+                CacheTtlInfo.ContractInfo,
             );
         },
     );
@@ -76,6 +80,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.penaltyPercent',
                 this.farmAbi.penaltyPercent.bind(this.farmAbi),
+                CacheTtlInfo.ContractState,
             );
         },
     );
@@ -87,6 +92,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.minimumFarmingEpochs',
                 this.farmAbi.minimumFarmingEpochs.bind(this.farmAbi),
+                CacheTtlInfo.ContractState,
             );
         },
     );
@@ -98,6 +104,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.rewardPerShare',
                 this.farmAbi.rewardPerShare.bind(this.farmAbi),
+                CacheTtlInfo.ContractInfo,
             );
         },
     );
@@ -109,6 +116,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.rewardReserve',
                 this.farmAbi.rewardReserve.bind(this.farmAbi),
+                CacheTtlInfo.ContractInfo,
             );
         },
     );
@@ -120,6 +128,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.lastRewardBlockNonce',
                 this.farmAbi.lastRewardBlockNonce.bind(this.farmAbi),
+                CacheTtlInfo.ContractInfo,
             );
         },
     );
@@ -133,6 +142,7 @@ export class FarmAbiLoader {
             addresses,
             'farm.divisionSafetyConstant',
             this.farmAbi.divisionSafetyConstant.bind(this.farmAbi),
+            CacheTtlInfo.ContractInfo,
         );
     });
 
@@ -143,6 +153,7 @@ export class FarmAbiLoader {
                 addresses,
                 'farm.state',
                 this.farmAbi.state.bind(this.farmAbi),
+                CacheTtlInfo.ContractState,
             );
         },
     );

--- a/src/modules/farm/base-module/services/farm.base.service.ts
+++ b/src/modules/farm/base-module/services/farm.base.service.ts
@@ -17,6 +17,7 @@ import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { Inject, forwardRef } from '@nestjs/common';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 export abstract class FarmServiceBase {
     constructor(
@@ -39,6 +40,7 @@ export abstract class FarmServiceBase {
             farmAddresses,
             'farm.farmedTokenID',
             this.farmAbi.farmedTokenID.bind(this.farmAbi),
+            CacheTtlInfo.Token,
         );
         return this.tokenService.getAllTokensMetadata(farmedTokenIDs);
     }
@@ -54,6 +56,7 @@ export abstract class FarmServiceBase {
             farmAddresses,
             'farm.farmTokenID',
             this.farmAbi.farmTokenID.bind(this.farmAbi),
+            CacheTtlInfo.Token,
         );
         return this.tokenService.getAllNftsCollectionMetadata(farmTokenIDs);
     }
@@ -69,6 +72,7 @@ export abstract class FarmServiceBase {
             farmAddresses,
             'farm.farmingTokenID',
             this.farmAbi.farmingTokenID.bind(this.farmAbi),
+            CacheTtlInfo.Token,
         );
         return this.tokenService.getAllTokensMetadata(farmingTokenIDs);
     }

--- a/src/modules/farm/base-module/services/farm.compute.loader.ts
+++ b/src/modules/farm/base-module/services/farm.compute.loader.ts
@@ -3,6 +3,7 @@ import { FarmComputeService } from './farm.compute.service';
 import DataLoader from 'dataloader';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { getAllKeys } from 'src/utils/get.many.utils';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 @Injectable({
     scope: Scope.REQUEST,
@@ -20,6 +21,7 @@ export class FarmComputeLoader {
                 addresses,
                 'farm.farmLockedValueUSD',
                 this.farmCompute.farmLockedValueUSD.bind(this.farmCompute),
+                CacheTtlInfo.ContractState,
             );
         },
     );
@@ -31,6 +33,7 @@ export class FarmComputeLoader {
                 addresses,
                 'farm.farmedTokenPriceUSD',
                 this.farmCompute.farmedTokenPriceUSD.bind(this.farmCompute),
+                CacheTtlInfo.Price,
             );
         },
     );
@@ -42,6 +45,7 @@ export class FarmComputeLoader {
                 addresses,
                 'farm.farmingTokenPriceUSD',
                 this.farmCompute.farmingTokenPriceUSD.bind(this.farmCompute),
+                CacheTtlInfo.Price,
             );
         },
     );

--- a/src/modules/pair/services/pair.abi.loader.ts
+++ b/src/modules/pair/services/pair.abi.loader.ts
@@ -7,6 +7,7 @@ import { PairService } from './pair.service';
 import { PairInfoModel } from '../models/pair-info.model';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import { constantsConfig } from 'src/config';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 @Injectable({
     scope: Scope.REQUEST,
@@ -44,6 +45,7 @@ export class PairAbiLoader {
                 addresses,
                 'pair.pairInfoMetadata',
                 this.pairAbi.pairInfoMetadata.bind(this.pairAbi),
+                CacheTtlInfo.ContractBalance,
             );
         },
     );
@@ -55,6 +57,7 @@ export class PairAbiLoader {
                 addresses,
                 'pair.totalFeePercent',
                 this.pairAbi.totalFeePercent.bind(this.pairAbi),
+                CacheTtlInfo.ContractState,
             );
         },
     );
@@ -66,6 +69,7 @@ export class PairAbiLoader {
                 addresses,
                 'pair.specialFeePercent',
                 this.pairAbi.specialFeePercent.bind(this.pairAbi),
+                CacheTtlInfo.ContractState,
             );
         },
     );
@@ -79,6 +83,7 @@ export class PairAbiLoader {
             addresses,
             'pair.feesCollectorCutPercentage',
             this.pairAbi.feesCollectorCutPercentage.bind(this.pairAbi),
+            CacheTtlInfo.ContractState,
         );
 
         return percentages.map(
@@ -108,6 +113,7 @@ export class PairAbiLoader {
             addresses,
             'pair.initialLiquidityAdder',
             this.pairAbi.initialLiquidityAdder.bind(this.pairAbi),
+            CacheTtlInfo.ContractState,
         );
     });
 }

--- a/src/modules/pair/services/pair.compute.loader.ts
+++ b/src/modules/pair/services/pair.compute.loader.ts
@@ -4,6 +4,7 @@ import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import DataLoader from 'dataloader';
 import { PairService } from './pair.service';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 @Injectable({
     scope: Scope.REQUEST,
@@ -22,6 +23,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.firstTokenPrice',
                 this.pairCompute.firstTokenPrice.bind(this.pairCompute),
+                CacheTtlInfo.Price,
             );
         },
     );
@@ -33,6 +35,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.secondTokenPrice',
                 this.pairCompute.secondTokenPrice.bind(this.pairCompute),
+                CacheTtlInfo.Price,
             );
         },
     );
@@ -44,6 +47,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.firstTokenPriceUSD',
                 this.pairCompute.firstTokenPriceUSD.bind(this.pairCompute),
+                CacheTtlInfo.Price,
             );
         },
     );
@@ -55,6 +59,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.secondTokenPriceUSD',
                 this.pairCompute.secondTokenPriceUSD.bind(this.pairCompute),
+                CacheTtlInfo.Price,
             );
         },
     );
@@ -66,6 +71,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.lpTokenPriceUSD',
                 this.pairCompute.lpTokenPriceUSD.bind(this.pairCompute),
+                CacheTtlInfo.Price,
             );
         },
     );
@@ -79,6 +85,7 @@ export class PairComputeLoader {
             addresses,
             'pair.firstTokenLockedValueUSD',
             this.pairCompute.firstTokenLockedValueUSD.bind(this.pairCompute),
+            CacheTtlInfo.ContractInfo,
         );
     });
 
@@ -91,6 +98,7 @@ export class PairComputeLoader {
             addresses,
             'pair.secondTokenLockedValueUSD',
             this.pairCompute.secondTokenLockedValueUSD.bind(this.pairCompute),
+            CacheTtlInfo.ContractInfo,
         );
     });
 
@@ -109,6 +117,7 @@ export class PairComputeLoader {
             addresses,
             'pair.previous24hLockedValueUSD',
             this.pairCompute.previous24hLockedValueUSD.bind(this.pairCompute),
+            CacheTtlInfo.ContractInfo,
         );
     });
 
@@ -119,6 +128,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.previous24hVolumeUSD',
                 this.pairCompute.previous24hVolumeUSD.bind(this.pairCompute),
+                CacheTtlInfo.Analytics,
             );
         },
     );
@@ -130,6 +140,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.previous24hFeesUSD',
                 this.pairCompute.previous24hFeesUSD.bind(this.pairCompute),
+                CacheTtlInfo.Analytics,
             );
         },
     );
@@ -141,6 +152,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.feesAPR',
                 this.pairCompute.feesAPR.bind(this.pairCompute),
+                CacheTtlInfo.ContractState,
             );
         },
     );
@@ -152,6 +164,7 @@ export class PairComputeLoader {
                 addresses,
                 'pair.type',
                 this.pairCompute.type.bind(this.pairCompute),
+                CacheTtlInfo.ContractState,
             );
         },
     );

--- a/src/modules/pair/services/pair.service.ts
+++ b/src/modules/pair/services/pair.service.ts
@@ -20,6 +20,7 @@ import { PairComputeService } from './pair.compute.service';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 @Injectable()
 export class PairService {
@@ -46,6 +47,7 @@ export class PairService {
             pairAddresses,
             'pair.firstTokenID',
             this.pairAbi.firstTokenID.bind(this.pairAbi),
+            CacheTtlInfo.Token,
         );
 
         return this.tokenService.getAllTokensMetadata(tokenIDs);
@@ -62,6 +64,7 @@ export class PairService {
             pairAddresses,
             'pair.secondTokenID',
             this.pairAbi.secondTokenID.bind(this.pairAbi),
+            CacheTtlInfo.Token,
         );
 
         return this.tokenService.getAllTokensMetadata(tokenIDs);
@@ -80,6 +83,7 @@ export class PairService {
             pairAddresses,
             'pair.lpTokenID',
             this.pairAbi.lpTokenID.bind(this.pairAbi),
+            CacheTtlInfo.Token,
         );
     }
 
@@ -95,6 +99,7 @@ export class PairService {
             pairAddresses,
             'pair.state',
             this.pairAbi.state.bind(this.pairAbi),
+            CacheTtlInfo.ContractState,
         );
     }
 
@@ -104,6 +109,7 @@ export class PairService {
             pairAddresses,
             'pair.feeState',
             this.pairAbi.feeState.bind(this.pairAbi),
+            CacheTtlInfo.ContractState,
         );
     }
 
@@ -113,6 +119,7 @@ export class PairService {
             pairAddresses,
             'pair.lockedValueUSD',
             this.pairCompute.lockedValueUSD.bind(this.pairCompute),
+            CacheTtlInfo.ContractInfo,
         );
     }
 
@@ -122,6 +129,7 @@ export class PairService {
             pairAddresses,
             'pair.deployedAt',
             this.pairCompute.deployedAt.bind(this.pairCompute),
+            CacheTtlInfo.ContractState,
         );
     }
 
@@ -131,6 +139,7 @@ export class PairService {
             pairAddresses,
             'pair.tradesCount',
             this.pairCompute.tradesCount.bind(this.pairCompute),
+            CacheTtlInfo.ContractState,
         );
     }
 
@@ -140,6 +149,7 @@ export class PairService {
             pairAddresses,
             'pair.hasFarms',
             this.pairCompute.hasFarms.bind(this.pairCompute),
+            CacheTtlInfo.ContractState,
         );
     }
 
@@ -149,6 +159,7 @@ export class PairService {
             pairAddresses,
             'pair.hasDualFarms',
             this.pairCompute.hasDualFarms.bind(this.pairCompute),
+            CacheTtlInfo.ContractState,
         );
     }
 

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -196,6 +196,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenPriceDerivedEGLD',
             this.tokenPriceDerivedEGLD.bind(this),
+            CacheTtlInfo.Price,
         );
     }
 
@@ -238,6 +239,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenPriceDerivedUSD',
             this.tokenPriceDerivedUSD.bind(this),
+            CacheTtlInfo.Price,
         );
     }
 
@@ -268,6 +270,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenPrevious24hPrice',
             this.tokenPrevious24hPrice.bind(this),
+            CacheTtlInfo.TokenAnalytics,
         );
     }
 
@@ -299,6 +302,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenPrevious7dPrice',
             this.tokenPrevious7dPrice.bind(this),
+            CacheTtlInfo.TokenAnalytics,
         );
     }
 
@@ -431,6 +435,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenVolumeUSD24h',
             this.tokenVolumeUSD24h.bind(this),
+            CacheTtlInfo.Token,
         );
     }
 
@@ -459,6 +464,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenPrevious24hVolumeUSD',
             this.tokenPrevious24hVolumeUSD.bind(this),
+            CacheTtlInfo.Token,
         );
     }
 
@@ -566,6 +572,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenLiquidityUSD',
             this.tokenLiquidityUSD.bind(this),
+            CacheTtlInfo.TokenAnalytics,
         );
     }
 
@@ -605,6 +612,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenCreatedAt',
             this.tokenCreatedAt.bind(this),
+            CacheTtlInfo.Token,
         );
     }
 
@@ -756,6 +764,7 @@ export class TokenComputeService implements ITokenComputeService {
             tokenIDs,
             'token.tokenTrendingScore',
             this.tokenTrendingScore.bind(this),
+            CacheTtlInfo.Token,
         );
     }
 }

--- a/src/modules/tokens/services/token.loader.ts
+++ b/src/modules/tokens/services/token.loader.ts
@@ -4,6 +4,7 @@ import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import DataLoader from 'dataloader';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import { TokenService } from './token.service';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
 @Injectable({
     scope: Scope.REQUEST,
@@ -85,6 +86,7 @@ export class TokenLoader {
                 tokenIDs,
                 'token.tokenSwapCount',
                 this.tokenCompute.tokenSwapCount.bind(this.tokenCompute),
+                CacheTtlInfo.Token,
             );
         },
     );
@@ -98,6 +100,7 @@ export class TokenLoader {
             tokenIDs,
             'token.tokenPrevious24hSwapCount',
             this.tokenCompute.tokenPrevious24hSwapCount.bind(this.tokenCompute),
+            CacheTtlInfo.Token,
         );
     });
 

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -128,6 +128,7 @@ export class TokenService {
             tokenIDs,
             'token.getEsdtTokenType',
             this.getEsdtTokenType.bind(this),
+            CacheTtlInfo.Token,
         );
     }
 
@@ -149,6 +150,7 @@ export class TokenService {
             tokenIDs,
             'token.tokenMetadata',
             this.tokenMetadata.bind(this),
+            CacheTtlInfo.Token,
         );
     }
 
@@ -176,6 +178,7 @@ export class TokenService {
             collections,
             'token.getNftCollectionMetadata',
             this.getNftCollectionMetadata.bind(this),
+            CacheTtlInfo.Token,
         );
     }
 


### PR DESCRIPTION
## Reasoning
- values fetched from remote cache are not updated in local cache
  
## Proposed Changes
- add `ttlOptions` parameter to `getAllKeys` function and use it to set local cache if needed


## How to test
- N/A

