### PR TITLE
[SERVICES-2584] Update cache warmer delay to config value

### DIFF
--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -51,13 +51,13 @@ export class AnalyticsCacheWarmerService {
             awsOneYear(),
             'feeBurned',
         );
-        delay(1000);
+        delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
         const penaltyBurned = await this.analyticsCompute.computeTokenBurned(
             constantsConfig.MEX_TOKEN_ID,
             awsOneYear(),
             'penaltyBurned',
         );
-        delay(1000);
+        delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
         const cachedKeys = await Promise.all([
             this.analyticsSetter.feeTokenBurned(
                 constantsConfig.MEX_TOKEN_ID,

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -90,26 +90,26 @@ export class PairCacheWarmerService {
                     metric: 'firstTokenVolume',
                     time,
                 });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const secondTokenVolume24h =
                 await this.analyticsQuery.getAggregatedValue({
                     series: pairAddress,
                     metric: 'secondTokenVolume',
                     time,
                 });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const volumeUSD24h = await this.analyticsQuery.getAggregatedValue({
                 series: pairAddress,
                 metric: 'volumeUSD',
                 time,
             });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
             const feesUSD24h = await this.analyticsQuery.getAggregatedValue({
                 series: pairAddress,
                 metric: 'feesUSD',
                 time,
             });
-            await delay(1000);
+            await delay(constantsConfig.AWS_QUERY_CACHE_WARMER_DELAY);
 
             const cachedKeys = await Promise.all([
                 this.pairSetterService.setFirstTokenVolume(


### PR DESCRIPTION
## Reasoning
- the delay between timescaledb queries performed in cache warmers is a hardcoded value
  
## Proposed Changes
- use delay value in config

## How to test
- N/A
