### PR TITLE
[MEX-514] return 0 APR for stakings with no rewards

### DIFF
--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -616,6 +616,20 @@ export class StakingComputeService {
         additionalUserStakeAmount = '0',
         additionalUserEnergy = '0',
     ): Promise<number> {
+        const [produceRewardsEnabled, accumulatedRewards, rewardsCapacity] =
+            await Promise.all([
+                this.stakingAbi.produceRewardsEnabled(scAddress),
+                this.stakingAbi.accumulatedRewards(scAddress),
+                this.stakingAbi.rewardCapacity(scAddress),
+            ]);
+
+        if (
+            !produceRewardsEnabled ||
+            new BigNumber(accumulatedRewards).isEqualTo(rewardsCapacity)
+        ) {
+            return 0;
+        }
+
         const [currentWeek, boostedRewardsPerWeek] = await Promise.all([
             this.weekTimeKeepingAbi.currentWeek(scAddress),
             this.computeBoostedRewardsPerWeek(
@@ -652,6 +666,20 @@ export class StakingComputeService {
         userAddress: string,
         additionalUserStakeAmount = '0',
     ): Promise<number> {
+        const [produceRewardsEnabled, accumulatedRewards, rewardsCapacity] =
+            await Promise.all([
+                this.stakingAbi.produceRewardsEnabled(scAddress),
+                this.stakingAbi.accumulatedRewards(scAddress),
+                this.stakingAbi.rewardCapacity(scAddress),
+            ]);
+
+        if (
+            !produceRewardsEnabled ||
+            new BigNumber(accumulatedRewards).isEqualTo(rewardsCapacity)
+        ) {
+            return 0;
+        }
+
         const [boostedRewardsPerWeek, boostedYieldsFactors] = await Promise.all(
             [
                 this.computeBoostedRewardsPerWeek(


### PR DESCRIPTION
## Reasoning
- user boosted APR for stakings that doesn't produce rewards should be 0
  
## Proposed Changes
- add check for produce rewards in compute user boosted APR

## How to test
- N/A
