### PR TITLE
[SERVICES-2586] Add staking min unbound epochs field to staking proxy model

### DIFF
--- a/src/modules/staking-proxy/models/staking.proxy.model.ts
+++ b/src/modules/staking-proxy/models/staking.proxy.model.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { RewardsModel } from 'src/modules/farm/models/farm.model';
@@ -13,6 +13,8 @@ export class StakingProxyModel {
     lpFarmAddress: string;
     @Field()
     stakingFarmAddress: string;
+    @Field(() => Int)
+    stakingMinUnboundEpochs: number;
     @Field()
     pairAddress: string;
     @Field()

--- a/src/modules/staking-proxy/services/staking.proxy.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.service.ts
@@ -28,12 +28,14 @@ import { CollectionType } from 'src/modules/common/collection.type';
 import { PaginationArgs } from 'src/modules/dex.model';
 import { StakingProxiesFilter } from '../models/staking.proxy.args.model';
 import { StakingProxyFilteringService } from './staking.proxy.filtering.service';
+import { StakingAbiService } from 'src/modules/staking/services/staking.abi.service';
 
 @Injectable()
 export class StakingProxyService {
     constructor(
         private readonly stakingProxyAbi: StakingProxyAbiService,
         private readonly stakingService: StakingService,
+        private readonly stakingAbiService: StakingAbiService,
         private readonly farmFactory: FarmFactoryService,
         private readonly pairService: PairService,
         private readonly tokenService: TokenService,
@@ -304,5 +306,14 @@ export class StakingProxyService {
         }
 
         return undefined;
+    }
+
+    async getStakingFarmMinUnboundEpochs(
+        stakingProxyAddress: string,
+    ): Promise<number> {
+        const stakingFarmAddress =
+            await this.stakingProxyAbi.stakingFarmAddress(stakingProxyAddress);
+
+        return await this.stakingAbiService.minUnbondEpochs(stakingFarmAddress);
     }
 }

--- a/src/modules/staking-proxy/staking.proxy.resolver.ts
+++ b/src/modules/staking-proxy/staking.proxy.resolver.ts
@@ -54,6 +54,15 @@ export class StakingProxyResolver {
     }
 
     @ResolveField()
+    async stakingMinUnboundEpochs(
+        @Parent() parent: StakingProxyModel,
+    ): Promise<number> {
+        return this.stakingProxyService.getStakingFarmMinUnboundEpochs(
+            parent.address,
+        );
+    }
+
+    @ResolveField()
     async pairAddress(@Parent() parent: StakingProxyModel): Promise<string> {
         return this.stakingProxyAbi.pairAddress(parent.address);
     }


### PR DESCRIPTION
## Reasoning
- Currently, the front end needs to perform an additional query for fetching` minUnbondEpochs` for a staking farm corresponding to a staking proxy

  
## Proposed Changes
- add `stakingMinUnboundEpochs` field to StakingProxy model 
- add resolver method for the newly added field

## How to test
```
stakingProxies {
    address
    stakingFarmAddress
    stakingMinUnboundEpochs
    farmToken {
      ticker
    }
    lpFarmToken {
      ticker
    }
  }
  ```
