### PR TITLE
[MEX-517] fix user accumulated rewards

### DIFF
--- a/src/modules/farm/specs/farm.v2.compute.service.spec.ts
+++ b/src/modules/farm/specs/farm.v2.compute.service.spec.ts
@@ -132,15 +132,9 @@ describe('FarmServiceV2', () => {
             totalLockedTokens: '1',
             lastUpdateEpoch: 256,
         });
-        jest.spyOn(
-            weeklyRewardsSplittingAbi,
-            'totalRewardsForWeek',
-        ).mockResolvedValue([
-            new EsdtTokenPayment({
-                amount: '60480000000000000000000',
-                tokenID: 'MEX-123456',
-            }),
-        ]);
+        jest.spyOn(farmAbi, 'accumulatedRewardsForWeek').mockResolvedValue(
+            '60480000000000000000000',
+        );
         jest.spyOn(farmAbi, 'farmTokenSupply').mockResolvedValue('2');
         jest.spyOn(farmAbi, 'rewardsPerBlock').mockResolvedValue(
             '1000000000000000000',
@@ -155,6 +149,6 @@ describe('FarmServiceV2', () => {
             1,
         );
 
-        expect(accumulatedRewards[0].amount).toEqual('60480000000000000000000');
+        expect(accumulatedRewards).toEqual('60480000000000000000000');
     });
 });

--- a/src/modules/farm/specs/farm.v2.compute.service.spec.ts
+++ b/src/modules/farm/specs/farm.v2.compute.service.spec.ts
@@ -132,9 +132,16 @@ describe('FarmServiceV2', () => {
             totalLockedTokens: '1',
             lastUpdateEpoch: 256,
         });
-        jest.spyOn(farmAbi, 'accumulatedRewardsForWeek').mockResolvedValue(
-            '60480000000000000000000',
-        );
+        jest.spyOn(
+            weeklyRewardsSplittingAbi,
+            'totalRewardsForWeek',
+        ).mockResolvedValue([
+            new EsdtTokenPayment({
+                tokenID: 'MEX-123456',
+                nonce: 0,
+                amount: '60480000000000000000000',
+            }),
+        ]);
         jest.spyOn(farmAbi, 'farmTokenSupply').mockResolvedValue('2');
         jest.spyOn(farmAbi, 'rewardsPerBlock').mockResolvedValue(
             '1000000000000000000',

--- a/src/modules/user/user.info-by-week.resolver.ts
+++ b/src/modules/user/user.info-by-week.resolver.ts
@@ -58,14 +58,14 @@ export class UserInfoByWeekResolver {
 
         const stakingAddresses = await this.remoteConfig.getStakingAddresses();
         if (stakingAddresses.includes(parent.scAddress)) {
-            return this.stakingCompute.computeUserRewardsForWeek(
+            return this.stakingCompute.userRewardsForWeek(
                 parent.scAddress,
                 parent.userAddress,
                 parent.week,
             );
         }
 
-        return this.farmComputeV2.computeUserRewardsForWeek(
+        return this.farmComputeV2.userRewardsForWeek(
             parent.scAddress,
             parent.userAddress,
             parent.week,


### PR DESCRIPTION
## Reasoning
- on farms & stakings accumulated rewards should be used to get the boosted accumulated rewards
  
## Proposed Changes
- changed the view method to get accumulated rewards on both farms & stakings to use `accumulatedRewardsForWeek`
- small refactor on `computeUserRewardsForWeek` method

## How to test
```
query FarmBoostedRewards {
    getFarmBoostedRewardsBatch(
        farmsAddresses: [<farm_address>, ...]
    ) {
        accumulatedRewards
    }
}
```

```
query StakingBoostedRewards {
    getStakingBoostedRewardsBatch(
        stakingAddresses: [<staking_address>, ...]
    ) {
        accumulatedRewards
    }
}
```

- both queries should return accumulating rewards for current week