### PR TITLE
[SERVICES-2416] use maximum boosted APR for pair dual farm APR

### DIFF
--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -162,7 +162,7 @@ export class PairCompoundedAPRResolver extends GenericResolver {
             return '0';
         }
 
-        return await this.stakingCompute.boostedAPR(stakingAddress);
+        return await this.stakingCompute.maxBoostedAPR(stakingAddress);
     }
 }
 


### PR DESCRIPTION
## Reasoning
- dual farm boosted APR reported on pair model isn't the maximum value that can be achieved
  
## Proposed Changes
- added new method to compute maximum boosted APR for staking contracts
- updated dual farm boosted APR from pair model to use maximum boosted APR from staking


## How to test
- N/A
