### PR TITLE
[MEX-514] fix compute user APR if no total staked amount

### DIFF
--- a/src/modules/farm/v2/services/farm.v2.compute.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.compute.service.ts
@@ -327,6 +327,10 @@ export class FarmComputeServiceV2
             .plus(additionalUserFarmAmount)
             .toFixed();
 
+        if (userTotalFarmPosition === '0') {
+            return 0;
+        }
+
         const userRewardsPerWeek = await this.computeUserRewardsForWeek(
             scAddress,
             userAddress,
@@ -384,6 +388,10 @@ export class FarmComputeServiceV2
         userTotalFarmPosition = new BigNumber(userTotalFarmPosition)
             .plus(additionalUserFarmAmount)
             .toFixed();
+
+        if (userTotalFarmPosition === '0') {
+            return 0;
+        }
 
         const userMaxRewardsPerWeek = new BigNumber(
             boostedRewardsPerWeek[0].amount,

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -671,6 +671,10 @@ export class StakingComputeService {
             .plus(additionalUserStakeAmount)
             .toFixed();
 
+        if (userTotalStakePosition === '0') {
+            return 0;
+        }
+
         const userRewardsPerWeek = await this.computeUserRewardsForWeek(
             scAddress,
             userAddress,
@@ -725,6 +729,10 @@ export class StakingComputeService {
         userTotalStakePosition = new BigNumber(userTotalStakePosition)
             .plus(additionalUserStakeAmount)
             .toFixed();
+
+        if (userTotalStakePosition === '0') {
+            return 0;
+        }
 
         const userMaxRewardsPerWeek = new BigNumber(
             boostedRewardsPerWeek[0].amount,


### PR DESCRIPTION
## Reasoning
- if user doesn't have any total staked amount registered, the query would return an error for non-nullable field
- if user doesn't have any total farm amount registered, the query would return an error for non-nullable field
  
## Proposed Changes
- check for user total staked amount when computing boosted APR for staking
- check for user total farm amount when computing boosted APR for farms

## How to test
```
query StakingBoostedRewards {
    getStakingBoostedRewardsBatch(
        stakingAddresses: [
            <staking_address>
        ]
    ) {
        curentBoostedAPR
        maximumBoostedAPR
    }
}
```
- query should return 0 for both fields if no total staked amount for user