### PR TITLE
[SERVICES-2600] Add Pair field for trades count in the past 24 hours

### DIFF
--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -201,6 +201,9 @@ export class PairModel {
     @Field()
     tradesCount: number;
 
+    @Field()
+    tradesCount24h: number;
+
     @Field(() => Int, { nullable: true })
     deployedAt: number;
 

--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -198,10 +198,10 @@ export class PairModel {
     @Field()
     hasDualFarms: boolean;
 
-    @Field()
+    @Field(() => Int)
     tradesCount: number;
 
-    @Field()
+    @Field(() => Int)
     tradesCount24h: number;
 
     @Field(() => Int, { nullable: true })

--- a/src/modules/pair/pair.module.ts
+++ b/src/modules/pair/pair.module.ts
@@ -20,13 +20,13 @@ import { CommonAppModule } from 'src/common.app.module';
 import { ComposableTasksModule } from '../composable-tasks/composable.tasks.module';
 import { RemoteConfigModule } from '../remote-config/remote-config.module';
 import { StakingProxyModule } from '../staking-proxy/staking.proxy.module';
-import { ElasticService } from 'src/helpers/elastic.service';
 import { FarmModuleV2 } from '../farm/v2/farm.v2.module';
 import { PairFilteringService } from './services/pair.filtering.service';
 import { StakingModule } from '../staking/staking.module';
 import { EnergyModule } from '../energy/energy.module';
 import { PairAbiLoader } from './services/pair.abi.loader';
 import { PairComputeLoader } from './services/pair.compute.loader';
+import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
 @Module({
     imports: [
         CommonAppModule,
@@ -43,6 +43,7 @@ import { PairComputeLoader } from './services/pair.compute.loader';
         StakingProxyModule,
         StakingModule,
         EnergyModule,
+        ElasticSearchModule,
     ],
     providers: [
         PairService,
@@ -53,9 +54,7 @@ import { PairComputeLoader } from './services/pair.compute.loader';
         PairFilteringService,
         PairAbiLoader,
         PairComputeLoader,
-        ElasticService,
         PairResolver,
-        ElasticService,
         PairFilteringService,
         PairCompoundedAPRResolver,
         PairRewardTokensResolver,

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -401,6 +401,11 @@ export class PairResolver {
     }
 
     @ResolveField()
+    async tradesCount24h(@Parent() parent: PairModel): Promise<number> {
+        return this.pairComputeLoader.tradesCount24hLoader.load(parent.address);
+    }
+
+    @ResolveField()
     async deployedAt(@Parent() parent: PairModel): Promise<number> {
         return this.pairComputeLoader.deployedAtLoader.load(parent.address);
     }

--- a/src/modules/pair/services/pair.compute.loader.ts
+++ b/src/modules/pair/services/pair.compute.loader.ts
@@ -187,6 +187,12 @@ export class PairComputeLoader {
         },
     );
 
+    public readonly tradesCount24hLoader = new DataLoader<string, number>(
+        async (addresses: string[]) => {
+            return await this.pairCompute.getAllTradesCount24h(addresses);
+        },
+    );
+
     public readonly deployedAtLoader = new DataLoader<string, number>(
         async (addresses: string[]) => {
             return await this.pairService.getAllDeployedAt(addresses);

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -719,7 +719,6 @@ export class PairComputeService implements IPairComputeService {
     }
 
     async getAllTradesCount24h(pairAddresses: string[]): Promise<number[]> {
-        console.log('here', pairAddresses);
         return await getAllKeys(
             this.cachingService,
             pairAddresses,

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -17,14 +17,15 @@ import { computeValueUSD, denominateAmount } from 'src/utils/token.converters';
 import { farmsAddresses } from 'src/utils/farm.utils';
 import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
 import { StakingProxyAbiService } from 'src/modules/staking-proxy/services/staking.proxy.abi.service';
-import { ElasticService } from 'src/helpers/elastic.service';
-import { ElasticQuery, QueryType } from '@multiversx/sdk-nestjs-elastic';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { FarmVersion } from 'src/modules/farm/models/farm.model';
 import { FarmAbiServiceV2 } from 'src/modules/farm/v2/services/farm.v2.abi.service';
-import { TransactionStatus } from 'src/utils/transaction.utils';
 import { FarmComputeServiceV2 } from 'src/modules/farm/v2/services/farm.v2.compute.service';
 import { StakingComputeService } from 'src/modules/staking/services/staking.compute.service';
+import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { getAllKeys } from 'src/utils/get.many.utils';
+import { ESTransactionsService } from 'src/services/elastic-search/services/es.transactions.service';
+import moment from 'moment';
 
 @Injectable()
 export class PairComputeService implements IPairComputeService {
@@ -42,10 +43,11 @@ export class PairComputeService implements IPairComputeService {
         private readonly farmAbi: FarmAbiServiceV2,
         private readonly remoteConfigGetterService: RemoteConfigGetterService,
         private readonly stakingProxyAbiService: StakingProxyAbiService,
-        private readonly elasticService: ElasticService,
         private readonly apiService: MXApiService,
         private readonly farmCompute: FarmComputeServiceV2,
         private readonly stakingCompute: StakingComputeService,
+        private readonly cachingService: CacheService,
+        private readonly elasticTransactionsService: ESTransactionsService,
     ) {}
 
     async getTokenPrice(pairAddress: string, tokenID: string): Promise<string> {
@@ -688,20 +690,42 @@ export class PairComputeService implements IPairComputeService {
     }
 
     async computeTradesCount(pairAddress: string): Promise<number> {
-        const elasticQueryAdapter: ElasticQuery = new ElasticQuery();
+        return await this.elasticTransactionsService.computePairSwapCount(
+            pairAddress,
+        );
+    }
 
-        elasticQueryAdapter.condition.must = [
-            QueryType.Match('receiver', pairAddress),
-            QueryType.Match('status', TransactionStatus.success),
-            QueryType.Should([
-                QueryType.Match('function', 'swapTokensFixedInput'),
-                QueryType.Match('function', 'swapTokensFixedOutput'),
-            ]),
-        ];
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'pair',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async tradesCount24h(pairAddress: string): Promise<number> {
+        return await this.computeTradesCount24h(pairAddress);
+    }
 
-        return await this.elasticService.getCount(
-            'transactions',
-            elasticQueryAdapter,
+    async computeTradesCount24h(pairAddress: string): Promise<number> {
+        const end = moment.utc().unix();
+        const start = moment.unix(end).subtract(1, 'day').unix();
+
+        return await this.elasticTransactionsService.computePairSwapCount(
+            pairAddress,
+            start,
+            end,
+        );
+    }
+
+    async getAllTradesCount24h(pairAddresses: string[]): Promise<number[]> {
+        console.log('here', pairAddresses);
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.tradesCount24h',
+            this.tradesCount24h.bind(this),
+            CacheTtlInfo.ContractState,
         );
     }
 

--- a/src/modules/pair/services/pair.filtering.service.ts
+++ b/src/modules/pair/services/pair.filtering.service.ts
@@ -259,6 +259,24 @@ export class PairFilteringService {
         );
     }
 
+    async pairsByTradesCount24h(
+        pairFilter: PairsFilter,
+        pairsMetadata: PairMetadata[],
+    ): Promise<PairMetadata[]> {
+        if (!pairFilter.minTradesCount24h) {
+            return pairsMetadata;
+        }
+
+        const pairsTradesCount24h = await this.pairCompute.getAllTradesCount24h(
+            pairsMetadata.map((pair) => pair.address),
+        );
+
+        return pairsMetadata.filter(
+            (_, index) =>
+                pairsTradesCount24h[index] >= pairFilter.minTradesCount24h,
+        );
+    }
+
     async pairsByHasFarms(
         pairFilter: PairsFilter,
         pairsMetadata: PairMetadata[],

--- a/src/modules/pair/services/pair.metadata.builder.ts
+++ b/src/modules/pair/services/pair.metadata.builder.ts
@@ -123,6 +123,14 @@ export class PairsMetadataBuilder {
         return this;
     }
 
+    async filterByTradesCount24h(): Promise<PairsMetadataBuilder> {
+        this.pairsMetadata = await this.filteringService.pairsByTradesCount24h(
+            this.filters,
+            this.pairsMetadata,
+        );
+        return this;
+    }
+
     async filterByHasFarms(): Promise<PairsMetadataBuilder> {
         this.pairsMetadata = await this.filteringService.pairsByHasFarms(
             this.filters,

--- a/src/modules/pair/services/pair.setter.service.ts
+++ b/src/modules/pair/services/pair.setter.service.ts
@@ -394,6 +394,18 @@ export class PairSetterService extends GenericSetterService {
         );
     }
 
+    async setTradesCount24h(
+        pairAddress: string,
+        value: number,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('tradesCount24h', pairAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+
     async setDeployedAt(pairAddress: string, value: number): Promise<string> {
         return await this.setData(
             this.getCacheKey('deployedAt', pairAddress),

--- a/src/modules/router/models/filter.args.ts
+++ b/src/modules/router/models/filter.args.ts
@@ -3,6 +3,7 @@ import { SortingOrder } from 'src/modules/common/page.data';
 
 export enum PairSortableFields {
     TRADES_COUNT = 'trades_count',
+    TRADES_COUNT_24 = 'trades_count_24h',
     TVL = 'total_value_locked',
     VOLUME_24 = 'volume_24h',
     FEES_24 = 'fees_24h',
@@ -52,6 +53,8 @@ export class PairsFilter {
     minLockedValueUSD: number;
     @Field({ nullable: true })
     minTradesCount: number;
+    @Field({ nullable: true })
+    minTradesCount24h: number;
     @Field({ nullable: true })
     hasFarms: boolean;
     @Field({ nullable: true })

--- a/src/modules/router/services/router.service.ts
+++ b/src/modules/router/services/router.service.ts
@@ -300,6 +300,11 @@ export class RouterService {
                     pairsMetadata.map((pair) => pair.address),
                 );
                 break;
+            case PairSortableFields.TRADES_COUNT_24:
+                sortFieldData = await this.pairCompute.getAllTradesCount24h(
+                    pairsMetadata.map((pair) => pair.address),
+                );
+                break;
             case PairSortableFields.TVL:
                 sortFieldData = await this.pairService.getAllLockedValueUSD(
                     pairsMetadata.map((pair) => pair.address),

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -164,6 +164,7 @@ export class PairCacheWarmerService {
                 hasFarms,
                 hasDualFarms,
                 tradesCount,
+                tradesCount24h,
                 deployedAt,
                 whitelistedAddresses,
                 feeDestinations,
@@ -181,6 +182,7 @@ export class PairCacheWarmerService {
                 this.pairComputeService.computeHasFarms(pairAddress),
                 this.pairComputeService.computeHasDualFarms(pairAddress),
                 this.pairComputeService.computeTradesCount(pairAddress),
+                this.pairComputeService.computeTradesCount24h(pairAddress),
                 this.pairComputeService.computeDeployedAt(pairAddress),
                 this.pairAbi.getWhitelistedAddressesRaw(pairAddress),
                 this.pairAbi.getFeeDestinationsRaw(pairAddress),
@@ -224,6 +226,10 @@ export class PairCacheWarmerService {
                     hasDualFarms,
                 ),
                 this.pairSetterService.setTradesCount(pairAddress, tradesCount),
+                this.pairSetterService.setTradesCount24h(
+                    pairAddress,
+                    tradesCount24h,
+                ),
                 this.pairSetterService.setDeployedAt(pairAddress, deployedAt),
                 this.pairSetterService.setWhitelistedAddresses(
                     pairAddress,


### PR DESCRIPTION
## Reasoning
- front end requires information regarding pair swaps performed in the last 24 hours


## Proposed Changes
- add `tradesCount24h` field to Pair model + resolver method
- refactor compute method for 'tradesCount' to use ESTransactions service
- add bulk get method and dataloader for the new field 
- add new field to pair cache warmer
- add sorting and filtering by tradesCount24h to `filteredPairs` query

## How to test
- Running the query below should return only the pairs with more than 30 trades performed in the last 24 hours 
```
query  {
  filteredPairs(
    filters: {
      minTradesCount24h: 30
    }, 
    pagination: { first: 20 }, 
    sorting: {
    	sortField:TRADES_COUNT_24, 
    	sortOrder:DESC
    }
  ) {
    edges {
      cursor
      node {
        address
        firstToken { identifier }
        secondToken { identifier }
        tradesCount
        tradesCount24h
      }
    }
  }
}
```
