### PR TITLE
[MEX-518] fix generate transaction for enable pair swap

### DIFF
--- a/src/config/test.json
+++ b/src/config/test.json
@@ -31,6 +31,9 @@
         "MAX_SWAP_SPREAD": 1,
         "MEX_TOKEN_ID": "MEX-123456",
         "USDC_TOKEN_ID": "USDC-123456",
-        "COMPOUND_TRANSACTION_FEE": 0.1
+        "COMPOUND_TRANSACTION_FEE": 0.1,
+        "roundedSwapEnable": {
+            "USDC-123456": "5000000"
+        }
     }
 }

--- a/src/modules/router/services/router.transactions.service.ts
+++ b/src/modules/router/services/router.transactions.service.ts
@@ -463,7 +463,9 @@ export class RouterTransactionService {
         }
         if (
             new BigNumber(commonTokenValue).isLessThan(
-                swapEnableConfig.minLockedTokenValue,
+                new BigNumber(swapEnableConfig.minLockedTokenValue).minus(
+                    constantsConfig.roundedSwapEnable[commonToken],
+                ),
             )
         ) {
             throw new Error('Not enough value locked');


### PR DESCRIPTION
## Reasoning
- minimum locked value for pair creation needed from smart contract is less than what is displayed
  
## Proposed Changes
- check for exact minimum amount needed for swap enable that is checked in smart contract

## How to test
- N/A
