### PR TITLE
[MEX-519] remove optional validation method from native auth guard

### DIFF
--- a/src/modules/auth/native.auth.guard.ts
+++ b/src/modules/auth/native.auth.guard.ts
@@ -1,7 +1,4 @@
-import {
-    NativeAuthError,
-    NativeAuthServer,
-} from '@multiversx/sdk-native-auth-server';
+import { NativeAuthServer } from '@multiversx/sdk-native-auth-server';
 import {
     Injectable,
     CanActivate,
@@ -50,7 +47,6 @@ export class NativeAuthGuard implements CanActivate {
                     await this.cachingService.set(key, value, ttl);
                 },
             },
-            validateImpersonateCallback: this.validateImpersonateAddress,
         });
     }
 
@@ -110,17 +106,5 @@ export class NativeAuthGuard implements CanActivate {
             this.logger.error(`${NativeAuthGuard.name}: ${error.message}`);
             return false;
         }
-    }
-
-    private async validateImpersonateAddress(
-        signerAddress: string,
-        _impersonateAddress: string,
-    ): Promise<boolean> {
-        const admins = process.env.SECURITY_ADMINS.split(',');
-        if (admins.find((admin) => admin === signerAddress) === undefined) {
-            throw new NativeAuthError('Impersonation not allowed');
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
## Reasoning
- validation for impersonate address is done using the request headers instead of optional arguments from native auth token
  
## Proposed Changes
- removed optional validation method for impersonate address

## How to test
- N/A
