### PR TITLE
[MEX-520] Remove min swap amount

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -611,7 +611,7 @@
             "SLIPPAGE_VALUES": [0.001, 0.005, 0.01],
             "MAX_SLIPPAGE": 0.05
         },
-        "MIN_SWAP_AMOUNT": 0.0005,
+        "MIN_SWAP_AMOUNT": 0,
         "roundedSwapEnable": {
             "USDC-8d4068": "5000000",
             "WEGLD-d7c6bb": "100000000000000000",


### PR DESCRIPTION
## Reasoning
- remove minimum swap amount from trade modal
  
## Proposed Changes
- updated `MIN_SWAP_AMOUNT` to `0`

## How to test
- N/A
