### PR TITLE
[SERVICES-2632] Update transaction generation for Locked Asset Factory, Simple Lock SCs

### DIFF
--- a/src/modules/locked-asset-factory/locked-asset.resolver.ts
+++ b/src/modules/locked-asset-factory/locked-asset.resolver.ts
@@ -89,8 +89,12 @@ export class LockedAssetResolver {
     @Query(() => TransactionModel)
     async lockAssets(
         @Args('inputToken') inputToken: InputTokenModel,
+        @AuthUser() user: UserAuthResult,
     ): Promise<TransactionModel> {
-        return await this.transactionsService.lockAssets(inputToken);
+        return await this.transactionsService.lockAssets(
+            user.address,
+            inputToken,
+        );
     }
 
     @UseGuards(JwtOrNativeAuthGuard)

--- a/src/modules/simple-lock/services/simple.lock.transactions.service.ts
+++ b/src/modules/simple-lock/services/simple.lock.transactions.service.ts
@@ -1,11 +1,8 @@
 import {
-    Address,
     BigUIntValue,
-    ContractFunction,
     EnumValue,
-    Interaction,
+    Token,
     TokenTransfer,
-    TypedValue,
     U64Value,
 } from '@multiversx/sdk-core';
 import { Injectable } from '@nestjs/common';
@@ -28,6 +25,7 @@ import { SimpleLockService } from './simple.lock.service';
 import { WrapAbiService } from 'src/modules/wrapping/services/wrap.abi.service';
 import { PairAbiService } from 'src/modules/pair/services/pair.abi.service';
 import { SimpleLockAbiService } from './simple.lock.abi.service';
+import { TransactionOptions } from 'src/modules/common/transaction.options';
 
 @Injectable()
 export class SimpleLockTransactionService {
@@ -43,29 +41,31 @@ export class SimpleLockTransactionService {
     ) {}
 
     async lockTokens(
+        sender: string,
         inputTokens: InputTokenModel,
         lockEpochs: number,
         simpleLockAddress: string,
     ): Promise<TransactionModel> {
-        const [contract, currentEpoch] = await Promise.all([
-            this.mxProxy.getSimpleLockSmartContract(simpleLockAddress),
-            this.contextGetter.getCurrentEpoch(),
-        ]);
-
+        const currentEpoch = await this.contextGetter.getCurrentEpoch();
         const unlockEpoch = currentEpoch + lockEpochs;
 
-        return contract.methodsExplicit
-            .lockTokens([new U64Value(new BigNumber(unlockEpoch))])
-            .withSingleESDTTransfer(
-                TokenTransfer.fungibleFromBigInteger(
-                    inputTokens.tokenID,
-                    new BigNumber(inputTokens.amount),
-                ),
-            )
-            .withGasLimit(gasConfig.simpleLock.lockTokens)
-            .withChainID(mxConfig.chainID)
-            .buildTransaction()
-            .toPlainObject();
+        return await this.mxProxy.getSimpleLockSmartContractTransaction(
+            simpleLockAddress,
+            new TransactionOptions({
+                sender: sender,
+                gasLimit: gasConfig.simpleLock.lockTokens,
+                function: 'lockTokens',
+                arguments: [new U64Value(new BigNumber(unlockEpoch))],
+                tokenTransfers: [
+                    new TokenTransfer({
+                        token: new Token({
+                            identifier: inputTokens.tokenID,
+                        }),
+                        amount: BigInt(inputTokens.amount),
+                    }),
+                ],
+            }),
+        );
     }
 
     async unlockTokens(
@@ -73,24 +73,23 @@ export class SimpleLockTransactionService {
         sender: string,
         inputTokens: InputTokenModel,
     ): Promise<TransactionModel> {
-        const contract = await this.mxProxy.getSimpleLockSmartContract(
+        return await this.mxProxy.getSimpleLockSmartContractTransaction(
             simpleLockAddress,
+            new TransactionOptions({
+                sender: sender,
+                gasLimit: gasConfig.simpleLock.unlockTokens,
+                function: 'unlockTokens',
+                tokenTransfers: [
+                    new TokenTransfer({
+                        token: new Token({
+                            identifier: inputTokens.tokenID,
+                            nonce: BigInt(inputTokens.nonce),
+                        }),
+                        amount: BigInt(inputTokens.amount),
+                    }),
+                ],
+            }),
         );
-
-        return contract.methodsExplicit
-            .unlockTokens()
-            .withSingleESDTNFTTransfer(
-                TokenTransfer.metaEsdtFromBigInteger(
-                    inputTokens.tokenID,
-                    inputTokens.nonce,
-                    new BigNumber(inputTokens.amount),
-                ),
-            )
-            .withSender(Address.fromString(sender))
-            .withGasLimit(gasConfig.simpleLock.unlockTokens)
-            .withChainID(mxConfig.chainID)
-            .buildTransaction()
-            .toPlainObject();
     }
 
     async addLiquidityLockedTokenBatch(
@@ -152,12 +151,10 @@ export class SimpleLockTransactionService {
     ): Promise<TransactionModel> {
         let [firstInputToken, secondInputToken] = inputTokens;
 
-        const [pairFirstTokenID, pairSecondTokenID, contract] =
-            await Promise.all([
-                this.pairAbi.firstTokenID(pairAddress),
-                this.pairAbi.secondTokenID(pairAddress),
-                this.mxProxy.getSimpleLockSmartContract(simpleLockAddress),
-            ]);
+        const [pairFirstTokenID, pairSecondTokenID] = await Promise.all([
+            this.pairAbi.firstTokenID(pairAddress),
+            this.pairAbi.secondTokenID(pairAddress),
+        ]);
 
         let [firstTokenID, secondTokenID] = [
             firstInputToken.tokenID,
@@ -196,30 +193,34 @@ export class SimpleLockTransactionService {
         const amount0Min = amount0.multipliedBy(1 - tolerance).integerValue();
         const amount1Min = amount1.multipliedBy(1 - tolerance).integerValue();
 
-        const endpointArgs: TypedValue[] = [
-            new BigUIntValue(amount0Min),
-            new BigUIntValue(amount1Min),
-        ];
-
-        return contract.methodsExplicit
-            .addLiquidityLockedToken(endpointArgs)
-            .withMultiESDTNFTTransfer([
-                TokenTransfer.metaEsdtFromBigInteger(
-                    firstInputToken.tokenID,
-                    firstInputToken.nonce,
-                    new BigNumber(firstInputToken.amount),
-                ),
-                TokenTransfer.metaEsdtFromBigInteger(
-                    secondInputToken.tokenID,
-                    secondInputToken.nonce,
-                    new BigNumber(secondInputToken.amount),
-                ),
-            ])
-            .withSender(Address.fromString(sender))
-            .withGasLimit(gasConfig.simpleLock.addLiquidityLockedToken)
-            .withChainID(mxConfig.chainID)
-            .buildTransaction()
-            .toPlainObject();
+        return await this.mxProxy.getSimpleLockSmartContractTransaction(
+            simpleLockAddress,
+            new TransactionOptions({
+                sender: sender,
+                gasLimit: gasConfig.simpleLock.addLiquidityLockedToken,
+                function: 'addLiquidityLockedToken',
+                arguments: [
+                    new BigUIntValue(amount0Min),
+                    new BigUIntValue(amount1Min),
+                ],
+                tokenTransfers: [
+                    new TokenTransfer({
+                        token: new Token({
+                            identifier: firstInputToken.tokenID,
+                            nonce: BigInt(firstInputToken.nonce),
+                        }),
+                        amount: BigInt(firstInputToken.amount),
+                    }),
+                    new TokenTransfer({
+                        token: new Token({
+                            identifier: secondInputToken.tokenID,
+                            nonce: BigInt(secondInputToken.nonce),
+                        }),
+                        amount: BigInt(secondInputToken.amount),
+                    }),
+                ],
+            }),
+        );
     }
 
     async removeLiquidityLockedToken(
@@ -230,9 +231,6 @@ export class SimpleLockTransactionService {
         tolerance: number,
     ): Promise<TransactionModel[]> {
         const transactions = [];
-        const contract = await this.mxProxy.getSimpleLockSmartContract(
-            simpleLockAddress,
-        );
 
         const lpProxyTokenAttributes =
             this.simpleLockService.decodeLpProxyTokenAttributes({
@@ -259,27 +257,29 @@ export class SimpleLockTransactionService {
             .multipliedBy(1 - tolerance)
             .integerValue();
 
-        const endpointArgs = [
-            new BigUIntValue(amount0Min),
-            new BigUIntValue(amount1Min),
-        ];
-
-        transactions.push(
-            contract.methodsExplicit
-                .removeLiquidityLockedToken(endpointArgs)
-                .withSingleESDTNFTTransfer(
-                    TokenTransfer.metaEsdtFromBigInteger(
-                        inputTokens.tokenID,
-                        inputTokens.nonce,
-                        new BigNumber(inputTokens.amount),
-                    ),
-                )
-                .withSender(Address.fromString(sender))
-                .withGasLimit(gasConfig.simpleLock.removeLiquidityLockedToken)
-                .withChainID(mxConfig.chainID)
-                .buildTransaction()
-                .toPlainObject(),
-        );
+        const transaction =
+            await this.mxProxy.getSimpleLockSmartContractTransaction(
+                simpleLockAddress,
+                new TransactionOptions({
+                    sender: sender,
+                    gasLimit: gasConfig.simpleLock.removeLiquidityLockedToken,
+                    function: 'removeLiquidityLockedToken',
+                    arguments: [
+                        new BigUIntValue(amount0Min),
+                        new BigUIntValue(amount1Min),
+                    ],
+                    tokenTransfers: [
+                        new TokenTransfer({
+                            token: new Token({
+                                identifier: inputTokens.tokenID,
+                                nonce: BigInt(inputTokens.nonce),
+                            }),
+                            amount: BigInt(inputTokens.amount),
+                        }),
+                    ],
+                }),
+            );
+        transactions.push(transaction);
 
         return transactions;
     }
@@ -311,34 +311,35 @@ export class SimpleLockTransactionService {
                 .name,
         );
 
-        const contract = await this.mxProxy.getSimpleLockSmartContract(
-            simpleLockAddress,
-        );
-
         const gasLimit =
             inputTokens.length > 1
                 ? gasConfig.simpleLock.enterFarmLockedToken.withTokenMerge
                 : gasConfig.simpleLock.enterFarmLockedToken.default;
-        const mappedPayments = inputTokens.map((inputToken) =>
-            TokenTransfer.metaEsdtFromBigInteger(
-                inputToken.tokenID,
-                inputToken.nonce,
-                new BigNumber(inputToken.amount),
-            ),
-        );
-        return contract.methodsExplicit
-            .enterFarmLockedToken([
-                EnumValue.fromDiscriminant(
-                    FarmTypeEnumType,
-                    farmTypeDiscriminant,
+
+        return await this.mxProxy.getSimpleLockSmartContractTransaction(
+            simpleLockAddress,
+            new TransactionOptions({
+                sender: sender,
+                gasLimit: gasLimit,
+                function: 'enterFarmLockedToken',
+                arguments: [
+                    EnumValue.fromDiscriminant(
+                        FarmTypeEnumType,
+                        farmTypeDiscriminant,
+                    ),
+                ],
+                tokenTransfers: inputTokens.map(
+                    (inputToken) =>
+                        new TokenTransfer({
+                            token: new Token({
+                                identifier: inputToken.tokenID,
+                                nonce: BigInt(inputToken.nonce),
+                            }),
+                            amount: BigInt(inputToken.amount),
+                        }),
                 ),
-            ])
-            .withMultiESDTNFTTransfer(mappedPayments)
-            .withSender(Address.fromString(sender))
-            .withGasLimit(gasLimit)
-            .withChainID(mxConfig.chainID)
-            .buildTransaction()
-            .toPlainObject();
+            }),
+        );
     }
 
     async exitFarmLockedToken(
@@ -348,33 +349,33 @@ export class SimpleLockTransactionService {
         farmVersion: FarmVersion,
         exitAmount?: string,
     ): Promise<TransactionModel> {
-        await this.validateInputFarmProxyToken(inputTokens, simpleLockAddress);
-
-        const contract = await this.mxProxy.getSimpleLockSmartContract(
-            simpleLockAddress,
-        );
         if (!exitAmount && farmVersion === FarmVersion.V2) {
             throw new Error('Invalid exit amount!');
         }
-        const endpointArgs =
-            farmVersion === FarmVersion.V2
-                ? [new BigUIntValue(new BigNumber(exitAmount))]
-                : [];
 
-        return contract.methodsExplicit
-            .exitFarmLockedToken(endpointArgs)
-            .withSingleESDTNFTTransfer(
-                TokenTransfer.metaEsdtFromBigInteger(
-                    inputTokens.tokenID,
-                    inputTokens.nonce,
-                    new BigNumber(inputTokens.amount),
-                ),
-            )
-            .withSender(Address.fromString(sender))
-            .withGasLimit(gasConfig.simpleLock.exitFarmLockedToken)
-            .withChainID(mxConfig.chainID)
-            .buildTransaction()
-            .toPlainObject();
+        await this.validateInputFarmProxyToken(inputTokens, simpleLockAddress);
+
+        return await this.mxProxy.getSimpleLockSmartContractTransaction(
+            simpleLockAddress,
+            new TransactionOptions({
+                sender: sender,
+                gasLimit: gasConfig.simpleLock.exitFarmLockedToken,
+                function: 'exitFarmLockedToken',
+                arguments:
+                    farmVersion === FarmVersion.V2
+                        ? [new BigUIntValue(new BigNumber(exitAmount))]
+                        : [],
+                tokenTransfers: [
+                    new TokenTransfer({
+                        token: new Token({
+                            identifier: inputTokens.tokenID,
+                            nonce: BigInt(inputTokens.nonce),
+                        }),
+                        amount: BigInt(inputTokens.amount),
+                    }),
+                ],
+            }),
+        );
     }
 
     async farmClaimRewardsLockedToken(
@@ -384,24 +385,23 @@ export class SimpleLockTransactionService {
     ): Promise<TransactionModel> {
         await this.validateInputFarmProxyToken(inputTokens, simpleLockAddress);
 
-        const contract = await this.mxProxy.getSimpleLockSmartContract(
+        return await this.mxProxy.getSimpleLockSmartContractTransaction(
             simpleLockAddress,
+            new TransactionOptions({
+                sender: sender,
+                gasLimit: gasConfig.simpleLock.claimRewardsFarmLockedToken,
+                function: 'farmClaimRewardsLockedToken',
+                tokenTransfers: [
+                    new TokenTransfer({
+                        token: new Token({
+                            identifier: inputTokens.tokenID,
+                            nonce: BigInt(inputTokens.nonce),
+                        }),
+                        amount: BigInt(inputTokens.amount),
+                    }),
+                ],
+            }),
         );
-
-        return contract.methodsExplicit
-            .farmClaimRewardsLockedToken()
-            .withSingleESDTNFTTransfer(
-                TokenTransfer.metaEsdtFromBigInteger(
-                    inputTokens.tokenID,
-                    inputTokens.nonce,
-                    new BigNumber(inputTokens.amount),
-                ),
-            )
-            .withSender(Address.fromString(sender))
-            .withGasLimit(gasConfig.simpleLock.claimRewardsFarmLockedToken)
-            .withChainID(mxConfig.chainID)
-            .buildTransaction()
-            .toPlainObject();
     }
 
     async exitFarmOldToken(
@@ -411,27 +411,23 @@ export class SimpleLockTransactionService {
     ): Promise<TransactionModel> {
         await this.validateInputFarmProxyToken(inputTokens, simpleLockAddress);
 
-        const contract = await this.mxProxy.getSimpleLockSmartContract(
+        return await this.mxProxy.getSimpleLockSmartContractTransaction(
             simpleLockAddress,
+            new TransactionOptions({
+                sender: sender,
+                gasLimit: gasConfig.simpleLock.exitFarmLockedToken,
+                function: 'exitFarmOldToken',
+                tokenTransfers: [
+                    new TokenTransfer({
+                        token: new Token({
+                            identifier: inputTokens.tokenID,
+                            nonce: BigInt(inputTokens.nonce),
+                        }),
+                        amount: BigInt(inputTokens.amount),
+                    }),
+                ],
+            }),
         );
-
-        return new Interaction(
-            contract,
-            new ContractFunction('exitFarmOldToken'),
-            [],
-        )
-            .withSingleESDTNFTTransfer(
-                TokenTransfer.metaEsdtFromBigInteger(
-                    inputTokens.tokenID,
-                    inputTokens.nonce,
-                    new BigNumber(inputTokens.amount),
-                ),
-            )
-            .withSender(Address.fromString(sender))
-            .withGasLimit(gasConfig.simpleLock.exitFarmLockedToken)
-            .withChainID(mxConfig.chainID)
-            .buildTransaction()
-            .toPlainObject();
     }
 
     private async validateInputEnterFarmProxyToken(

--- a/src/modules/simple-lock/transaction.resolver.ts
+++ b/src/modules/simple-lock/transaction.resolver.ts
@@ -32,8 +32,10 @@ export class TransactionResolver {
         @Args('inputTokens') inputTokens: InputTokenModel,
         @Args('lockEpochs') lockEpochs: number,
         @Args('simpleLockAddress') simpleLockAddress: string,
+        @AuthUser() user: UserAuthResult,
     ): Promise<TransactionModel> {
         return this.simpleLockTransactions.lockTokens(
+            user.address,
             inputTokens,
             lockEpochs,
             simpleLockAddress,

--- a/src/services/multiversx-communication/mx.proxy.service.ts
+++ b/src/services/multiversx-communication/mx.proxy.service.ts
@@ -192,6 +192,17 @@ export class MXProxyService {
         );
     }
 
+    async getLockedAssetFactorySmartContractTransaction(
+        options: TransactionOptions,
+    ): Promise<TransactionModel> {
+        return this.getSmartContractTransaction(
+            scAddress.lockedAssetAddress,
+            abiConfig.lockedAssetFactory,
+            'LockedAssetFactory',
+            options,
+        );
+    }
+
     async getPriceDiscoverySmartContract(
         priceDiscoveryAddress: string,
     ): Promise<SmartContract> {

--- a/src/services/multiversx-communication/mx.proxy.service.ts
+++ b/src/services/multiversx-communication/mx.proxy.service.ts
@@ -212,6 +212,18 @@ export class MXProxyService {
         );
     }
 
+    async getSimpleLockSmartContractTransaction(
+        simpleLockAddress: string,
+        options: TransactionOptions,
+    ): Promise<TransactionModel> {
+        return this.getSmartContractTransaction(
+            simpleLockAddress,
+            abiConfig.simpleLock,
+            'SimpleLock',
+            options,
+        );
+    }
+
     async getSimpleLockEnergySmartContract(): Promise<SmartContract> {
         return this.getSmartContract(
             scAddress.simpleLockEnergy,


### PR DESCRIPTION
## Reasoning
- use SmartContractTransactionsFactory for generating transactions for Locked Asset Factory, Simple Lock SCs
  
## Proposed Changes
- update TransactionsLockedAssetService methods
- update SimpleLockTransactionService methods
- add sender parameter where needed + update resolver methods

## How to test
- N/A
