### PR TITLE
[SERVICES-2644] Fix token previous 24h price

### DIFF
--- a/src/modules/analytics/services/analytics.aws.getter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.getter.service.ts
@@ -106,7 +106,7 @@ export class AnalyticsAWSGetterService {
     ): Promise<HistoricDataModel[]> {
         const cacheKey = this.getAnalyticsCacheKey('values24h', series, metric);
         const data = await this.getCachedData<HistoricDataModel[]>(cacheKey);
-        return data !== undefined ? data.slice(1) : [];
+        return data !== undefined ? data : [];
     }
 
     private getAnalyticsCacheKey(...args: any) {

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -260,8 +260,21 @@ export class TokenComputeService implements ITokenComputeService {
             series: tokenID,
             metric: 'priceUSD',
         });
-
+        if (values24h.length > 0 && values24h[0]?.value === '0') {
+            return await this.computeMissingPrevious24hPrice(tokenID);
+        }
         return values24h[0]?.value ?? undefined;
+    }
+
+    async computeMissingPrevious24hPrice(tokenID: string): Promise<string> {
+        const [wrappedEGLDPrev24hPrice, derivedEGLD] = await Promise.all([
+            this.tokenPrevious24hPrice(tokenProviderUSD),
+            this.tokenPriceDerivedEGLD(tokenID),
+        ]);
+
+        return new BigNumber(derivedEGLD)
+            .times(wrappedEGLDPrev24hPrice)
+            .toFixed();
     }
 
     async getAllTokensPrevious24hPrice(tokenIDs: string[]): Promise<string[]> {


### PR DESCRIPTION
## Reasoning
- `previous24hPrice` field on token model is 0 when data is missing in timescaledb hourly aggregate (tokens with no activity)
  
## Proposed Changes
- compute previous 24h price using the price of WEGLD

## How to test
```
query {
  filteredTokens(
    filters: {}
    pagination: { first: 400 }
    sorting: { sortField: PREVIOUS_24H_PRICE, sortOrder: ASC }
  ) {
    edges {
      cursor
      node {
        identifier
        price
        previous24hPrice
      }
    }
  }
}
```
