### PR TITLE
[SERVICES-2651] Add extra fields to staking model

### DIFF
--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -34,6 +34,8 @@ export class StakingModel {
     @Field()
     apr: string;
     @Field()
+    aprIfUncapped: string;
+    @Field()
     boostedApr: string;
     @Field(() => Int)
     minUnboundEpochs: number;
@@ -43,6 +45,8 @@ export class StakingModel {
     lastRewardBlockNonce: number;
     @Field()
     rewardsRemainingDays: number;
+    @Field()
+    rewardsRemainingDaysIfUncapped: number;
     @Field()
     divisionSafetyConstant: string;
     @Field()

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -34,7 +34,7 @@ export class StakingModel {
     @Field()
     apr: string;
     @Field()
-    aprIfUncapped: string;
+    aprUncapped: string;
     @Field()
     boostedApr: string;
     @Field(() => Int)
@@ -46,7 +46,7 @@ export class StakingModel {
     @Field()
     rewardsRemainingDays: number;
     @Field()
-    rewardsRemainingDaysIfUncapped: number;
+    rewardsRemainingDaysUncapped: number;
     @Field()
     divisionSafetyConstant: string;
     @Field()

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -209,17 +209,11 @@ export class StakingComputeService {
     }
 
     async computeStakeFarmAPR(stakeAddress: string): Promise<string> {
-        const [accumulatedRewards, rewardsCapacity, produceRewardsEnabled] =
-            await Promise.all([
-                this.stakingAbi.accumulatedRewards(stakeAddress),
-                this.stakingAbi.rewardCapacity(stakeAddress),
-                this.stakingAbi.produceRewardsEnabled(stakeAddress),
-            ]);
+        const rewardsDepletedOrDisabled = await this.rewardsDepletedOrDisabled(
+            stakeAddress,
+        );
 
-        if (
-            !produceRewardsEnabled ||
-            new BigNumber(accumulatedRewards).isEqualTo(rewardsCapacity)
-        ) {
+        if (rewardsDepletedOrDisabled) {
             return '0';
         }
 
@@ -250,6 +244,39 @@ export class StakingComputeService {
             : new BigNumber(annualPercentageRewards)
                   .dividedBy(constantsConfig.MAX_PERCENT)
                   .toFixed();
+    }
+
+    @ErrorLoggerAsync({
+        logArgs: true,
+    })
+    @GetOrSetCache({
+        baseKey: 'stake',
+        remoteTtl: CacheTtlInfo.ContractState.remoteTtl,
+        localTtl: CacheTtlInfo.ContractState.localTtl,
+    })
+    async stakeFarmUncappedAPR(stakeAddress: string): Promise<string> {
+        return await this.computeStakeFarmUncappedAPR(stakeAddress);
+    }
+
+    async computeStakeFarmUncappedAPR(stakeAddress: string): Promise<string> {
+        const rewardsDepletedOrDisabled = await this.rewardsDepletedOrDisabled(
+            stakeAddress,
+        );
+
+        if (rewardsDepletedOrDisabled) {
+            return '0';
+        }
+
+        const [perBlockRewardAmount, farmTokenSupply] = await Promise.all([
+            this.stakingAbi.perBlockRewardsAmount(stakeAddress),
+            this.stakingAbi.farmTokenSupply(stakeAddress),
+        ]);
+
+        const rewardsUnboundedBig = new BigNumber(
+            perBlockRewardAmount,
+        ).multipliedBy(constantsConfig.BLOCKS_IN_YEAR);
+
+        return rewardsUnboundedBig.dividedBy(farmTokenSupply).toFixed();
     }
 
     @ErrorLoggerAsync({
@@ -322,6 +349,25 @@ export class StakingComputeService {
     }
 
     async computeRewardsRemainingDays(stakeAddress: string): Promise<number> {
+        const extraRewardsAPRBoundedPerBlock =
+            await this.computeExtraRewardsAPRBoundedPerBlock(stakeAddress);
+
+        return await this.computeRewardsRemainingDaysBase(
+            stakeAddress,
+            extraRewardsAPRBoundedPerBlock,
+        );
+    }
+
+    async computeRewardsRemainingDaysIfUncapped(
+        stakeAddress: string,
+    ): Promise<number> {
+        return await this.computeRewardsRemainingDaysBase(stakeAddress);
+    }
+
+    async computeRewardsRemainingDaysBase(
+        stakeAddress: string,
+        extraRewardsAPRBoundedPerBlock?: BigNumber,
+    ): Promise<number> {
         const [perBlockRewardAmount, accumulatedRewards, rewardsCapacity] =
             await Promise.all([
                 this.stakingAbi.perBlockRewardsAmount(stakeAddress),
@@ -329,16 +375,15 @@ export class StakingComputeService {
                 this.stakingAbi.rewardCapacity(stakeAddress),
             ]);
 
+        const perBlockRewards = extraRewardsAPRBoundedPerBlock
+            ? BigNumber.min(
+                  extraRewardsAPRBoundedPerBlock,
+                  perBlockRewardAmount,
+              )
+            : new BigNumber(perBlockRewardAmount);
+
         // 10 blocks per minute * 60 minutes per hour * 24 hours per day
         const blocksInDay = 10 * 60 * 24;
-
-        const extraRewardsAPRBoundedPerBlock =
-            await this.computeExtraRewardsAPRBoundedPerBlock(stakeAddress);
-
-        const perBlockRewards = BigNumber.min(
-            extraRewardsAPRBoundedPerBlock,
-            perBlockRewardAmount,
-        );
 
         return parseFloat(
             new BigNumber(rewardsCapacity)
@@ -919,5 +964,25 @@ export class StakingComputeService {
             stakeAddress,
         );
         return deployedAt ?? undefined;
+    }
+
+    private async rewardsDepletedOrDisabled(
+        stakeAddress: string,
+    ): Promise<boolean> {
+        const [accumulatedRewards, rewardsCapacity, produceRewardsEnabled] =
+            await Promise.all([
+                this.stakingAbi.accumulatedRewards(stakeAddress),
+                this.stakingAbi.rewardCapacity(stakeAddress),
+                this.stakingAbi.produceRewardsEnabled(stakeAddress),
+            ]);
+
+        if (
+            !produceRewardsEnabled ||
+            new BigNumber(accumulatedRewards).isEqualTo(rewardsCapacity)
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/modules/staking/services/staking.compute.service.ts
+++ b/src/modules/staking/services/staking.compute.service.ts
@@ -209,11 +209,9 @@ export class StakingComputeService {
     }
 
     async computeStakeFarmAPR(stakeAddress: string): Promise<string> {
-        const rewardsDepletedOrDisabled = await this.rewardsDepletedOrDisabled(
-            stakeAddress,
-        );
+        const isProducingRewards = await this.isProducingRewards(stakeAddress);
 
-        if (rewardsDepletedOrDisabled) {
+        if (isProducingRewards) {
             return '0';
         }
 
@@ -259,11 +257,9 @@ export class StakingComputeService {
     }
 
     async computeStakeFarmUncappedAPR(stakeAddress: string): Promise<string> {
-        const rewardsDepletedOrDisabled = await this.rewardsDepletedOrDisabled(
-            stakeAddress,
-        );
+        const isProducingRewards = await this.isProducingRewards(stakeAddress);
 
-        if (rewardsDepletedOrDisabled) {
+        if (isProducingRewards) {
             return '0';
         }
 
@@ -358,7 +354,7 @@ export class StakingComputeService {
         );
     }
 
-    async computeRewardsRemainingDaysIfUncapped(
+    async computeRewardsRemainingDaysUncapped(
         stakeAddress: string,
     ): Promise<number> {
         return await this.computeRewardsRemainingDaysBase(stakeAddress);
@@ -966,9 +962,7 @@ export class StakingComputeService {
         return deployedAt ?? undefined;
     }
 
-    private async rewardsDepletedOrDisabled(
-        stakeAddress: string,
-    ): Promise<boolean> {
+    private async isProducingRewards(stakeAddress: string): Promise<boolean> {
         const [accumulatedRewards, rewardsCapacity, produceRewardsEnabled] =
             await Promise.all([
                 this.stakingAbi.accumulatedRewards(stakeAddress),

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -145,6 +145,11 @@ export class StakingResolver {
     }
 
     @ResolveField()
+    async aprIfUncapped(@Parent() parent: StakingModel) {
+        return this.stakingCompute.stakeFarmUncappedAPR(parent.address);
+    }
+
+    @ResolveField()
     async boostedApr(@Parent() parent: StakingModel) {
         return this.stakingCompute.boostedAPR(parent.address);
     }
@@ -167,6 +172,13 @@ export class StakingResolver {
     @ResolveField()
     async rewardsRemainingDays(@Parent() parent: StakingModel) {
         return this.stakingCompute.computeRewardsRemainingDays(parent.address);
+    }
+
+    @ResolveField()
+    async rewardsRemainingDaysIfUncapped(@Parent() parent: StakingModel) {
+        return this.stakingCompute.computeRewardsRemainingDaysIfUncapped(
+            parent.address,
+        );
     }
 
     @ResolveField()

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -145,7 +145,7 @@ export class StakingResolver {
     }
 
     @ResolveField()
-    async aprIfUncapped(@Parent() parent: StakingModel) {
+    async aprUncapped(@Parent() parent: StakingModel) {
         return this.stakingCompute.stakeFarmUncappedAPR(parent.address);
     }
 
@@ -175,8 +175,8 @@ export class StakingResolver {
     }
 
     @ResolveField()
-    async rewardsRemainingDaysIfUncapped(@Parent() parent: StakingModel) {
-        return this.stakingCompute.computeRewardsRemainingDaysIfUncapped(
+    async rewardsRemainingDaysUncapped(@Parent() parent: StakingModel) {
+        return this.stakingCompute.computeRewardsRemainingDaysUncapped(
             parent.address,
         );
     }


### PR DESCRIPTION
## Reasoning
- expose values for staking APR and rewards remaining days if not capped by max APR
  
## Proposed Changes
- add `aprIfUncapped` and `rewardsRemainingDaysIfUncapped` fields to Staking model 
- add field resolvers and compute methods
- small refactor to remove duplicate code

## How to test
```
query {
  filteredStakingFarms(filters: {}, pagination: { first: 200 }) {
    edges {
      node {
        address
        farmingToken {
          identifier
        }
        apr
        aprIfUncapped
        rewardsRemainingDays
        rewardsRemainingDaysIfUncapped
      }
    }
  }
}
```
