### PR TITLE
[MEX-522] fix type on multi pair swap transaction

### DIFF
--- a/src/modules/auto-router/services/auto-router.transactions.service.ts
+++ b/src/modules/auto-router/services/auto-router.transactions.service.ts
@@ -6,6 +6,7 @@ import {
     Token,
     TokenTransfer,
     TypedValue,
+    VariadicValue,
 } from '@multiversx/sdk-core';
 import { Injectable } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
@@ -72,8 +73,16 @@ export class AutoRouterTransactionService {
             function: 'multiPairSwap',
             arguments:
                 args.swapType == SWAP_TYPE.fixedInput
-                    ? this.multiPairFixedInputSwaps(args)
-                    : this.multiPairFixedOutputSwaps(args),
+                    ? [
+                          VariadicValue.fromItems(
+                              ...this.multiPairFixedInputSwaps(args),
+                          ),
+                      ]
+                    : [
+                          VariadicValue.fromItems(
+                              ...this.multiPairFixedOutputSwaps(args),
+                          ),
+                      ],
             tokenTransfers: [
                 new TokenTransfer({
                     token: new Token({


### PR DESCRIPTION
## Reasoning
- multi pair swap endpoint require a variadic type
  
## Proposed Changes
- wrap the multi pair swap arguments into a variadic value

## How to test
```
query Swap {
    swap(
  amountIn: "1000000",
  tokenInID: "USDC-c76f1f",
  tokenOutID: "MEX-455c57",
  tolerance: 0.001
    ) {
        transactions {
            receiver
            value
            data
            gasLimit
        }
    }
}
```