### PR TITLE
[SERVICES-2660] Add missing unit tests for transaction generation

### DIFF
--- a/src/helpers/proxy.network.provider.profiler.ts
+++ b/src/helpers/proxy.network.provider.profiler.ts
@@ -6,7 +6,6 @@ import { PerformanceProfiler } from '../utils/performance.profiler';
 import { MetricsCollector } from '../utils/metrics.collector';
 import { IContractQuery } from '@multiversx/sdk-network-providers/out/interface';
 import { ContextTracker } from '@multiversx/sdk-nestjs-common';
-import { AxiosRequestConfig } from 'axios';
 import { ApiConfigService } from './api.config.service';
 import { NetworkProviderConfig } from '@multiversx/sdk-core/out/networkProviders/networkProviderConfig';
 

--- a/src/helpers/proxy.network.provider.profiler.ts
+++ b/src/helpers/proxy.network.provider.profiler.ts
@@ -8,12 +8,13 @@ import { IContractQuery } from '@multiversx/sdk-network-providers/out/interface'
 import { ContextTracker } from '@multiversx/sdk-nestjs-common';
 import { AxiosRequestConfig } from 'axios';
 import { ApiConfigService } from './api.config.service';
+import { NetworkProviderConfig } from '@multiversx/sdk-core/out/networkProviders/networkProviderConfig';
 
 export class ProxyNetworkProviderProfiler extends ProxyNetworkProvider {
     constructor(
         private readonly apiConfigService: ApiConfigService,
         url: string,
-        config?: AxiosRequestConfig,
+        config?: NetworkProviderConfig,
     ) {
         super(url, config);
     }

--- a/src/modules/auto-router/specs/auto-router.service.spec.ts
+++ b/src/modules/auto-router/specs/auto-router.service.spec.ts
@@ -32,6 +32,7 @@ import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { ComposableTasksTransactionService } from 'src/modules/composable-tasks/services/composable.tasks.transaction';
 import { MXApiServiceProvider } from 'src/services/multiversx-communication/mx.api.service.mock';
 import { PairFilteringService } from 'src/modules/pair/services/pair.filtering.service';
+import { gasConfig, scAddress } from 'src/config';
 
 describe('AutoRouterService', () => {
     let service: AutoRouterService;
@@ -340,6 +341,64 @@ describe('AutoRouterService', () => {
                 gasPrice: 1000000000,
                 gasLimit: 75200000,
                 data: 'RVNEVFRyYW5zZmVyQDU1NTM0NDQzMmQzMTMyMzMzNDM1MzZAMDcwY2VmOWY1ZWRmY2YyOEA2MzZmNmQ3MDZmNzM2NTU0NjE3MzZiNzNAMDAwMDAwMDQ0NTQ3NGM0NDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwODA2ZjA1YjU5ZDNiMjAwMDBAMDNAMDAwMDAwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEzMDAwMDAwMTU3Mzc3NjE3MDU0NmY2YjY1NmU3MzQ2Njk3ODY1NjQ0Zjc1NzQ3MDc1NzQwMDAwMDAwYzU3NDU0NzRjNDQyZDMxMzIzMzM0MzUzNjAwMDAwMDA1OTJhZmQ4YjAyZjAwMDAwMDIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMjAwMDAwMDE1NzM3NzYxNzA1NDZmNmI2NTZlNzM0NjY5Nzg2NTY0NGY3NTc0NzA3NTc0MDAwMDAwMGE0ZDQ1NTgyZDMxMzIzMzM0MzUzNjAwMDAwMDA4MDZmMDViNTlkM2IyMDAwMEAwMUA=',
+                chainID: 'T',
+                version: 2,
+                options: undefined,
+                signature: undefined,
+                guardian: undefined,
+                guardianSignature: undefined,
+            },
+        ]);
+    });
+
+    it('should get a fixed output multi swap tx', async () => {
+        const transactions = await service.getTransactions(
+            senderAddress,
+            new AutoRouteModel({
+                swapType: 1,
+                tokenInID: 'USDC-123456',
+                tokenOutID: 'MEX-123456',
+                tokenInExchangeRate: '99201792616073289490',
+                tokenOutExchangeRate: '10080',
+                tokenInExchangeRateDenom: '99.20179261607328949',
+                tokenOutExchangeRateDenom: '0.01008',
+                tokenInPriceUSD: '1',
+                tokenOutPriceUSD: '0.01',
+                amountIn: '10181267',
+                amountOut: '1000000000000000000000',
+                intermediaryAmounts: [
+                    '10080463',
+                    '1004013040121365097',
+                    '1000000000000000000000',
+                ],
+                tokenRoute: ['USDC-123456', 'WEGLD-123456', 'MEX-123456'],
+                pairs: [
+                    new PairModel({
+                        address: Address.newFromHex(
+                            '0000000000000000000000000000000000000000000000000000000000000013',
+                        ).toBech32(),
+                    }),
+                    new PairModel({
+                        address: Address.newFromHex(
+                            '0000000000000000000000000000000000000000000000000000000000000012',
+                        ).toBech32(),
+                    }),
+                ],
+                tolerance: 0.01,
+            }),
+        );
+
+        expect(transactions).toEqual([
+            {
+                nonce: 0,
+                value: '0',
+                receiver: scAddress.routerAddress,
+                sender: senderAddress,
+                receiverUsername: undefined,
+                senderUsername: undefined,
+                gasPrice: 1000000000,
+                gasLimit: gasConfig.router.multiPairSwapMultiplier * 2,
+                data: 'RVNEVFRyYW5zZmVyQDU1NTM0NDQzMmQzMTMyMzMzNDM1MzZAOWI1YTkzQDZkNzU2Yzc0Njk1MDYxNjk3MjUzNzc2MTcwQDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTNANzM3NzYxNzA1NDZmNmI2NTZlNzM0NjY5Nzg2NTY0NGY3NTc0NzA3NTc0QDU3NDU0NzRjNDQyZDMxMzIzMzM0MzUzNkAwZTAwY2U0MzYxNTM1MGQyQDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTJANzM3NzYxNzA1NDZmNmI2NTZlNzM0NjY5Nzg2NTY0NGY3NTc0NzA3NTc0QDRkNDU1ODJkMzEzMjMzMzQzNTM2QDM2MzVjOWFkYzVkZWEwMDAwMA==',
                 chainID: 'T',
                 version: 2,
                 options: undefined,

--- a/src/modules/farm/v2/services/farm.v2.abi.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.service.ts
@@ -287,10 +287,6 @@ export class FarmAbiServiceV2
     async calculateRewardsForGivenPosition(
         args: CalculateRewardsArgs,
     ): Promise<BigNumber> {
-        console.log({
-            service: FarmAbiServiceV2.name,
-            method: this.calculateRewardsForGivenPosition.name,
-        });
         const contract = await this.mxProxy.getFarmSmartContract(
             args.farmAddress,
         );

--- a/src/modules/fees-collector/services/fees-collector.compute.service.ts
+++ b/src/modules/fees-collector/services/fees-collector.compute.service.ts
@@ -186,13 +186,6 @@ export class FeesCollectorComputeService {
             .dividedBy(userLockedTokensValueUSD)
             .multipliedBy(100);
 
-        console.log({
-            userEnergy,
-            totalRewardsForWeekUSD,
-            userRewardsForWeekUSD: userRewardsForWeekUSD.toFixed(),
-            userAPRForWeek: userAPRForWeek.toFixed(),
-        });
-
         return userAPRForWeek;
     }
 

--- a/src/modules/router/services/router.transactions.service.ts
+++ b/src/modules/router/services/router.transactions.service.ts
@@ -447,7 +447,6 @@ export class RouterTransactionService {
         const lockedTokensAttributes = LockedTokenAttributes.fromAttributes(
             inputTokens.attributes,
         );
-        console.log(lockedTokensAttributes);
         const pairAddress = await this.pairService.getPairAddressByLpTokenID(
             lockedTokensAttributes.originalTokenID,
         );

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -455,7 +455,6 @@ export class StakingAbiService
         const interaction: Interaction =
             contract.methodsExplicit.isWhitelisted(transactionArgs);
         const response = await this.getGenericData(interaction);
-        console.log(response);
         return response.firstValue.valueOf();
     }
 

--- a/src/modules/user/specs/user.energy.transaction.service.spec.ts
+++ b/src/modules/user/specs/user.energy.transaction.service.spec.ts
@@ -1,0 +1,250 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PairService } from '../../pair/services/pair.service';
+import { ProxyService } from '../../proxy/services/proxy.service';
+import { UserMetaEsdtService } from '../services/user.metaEsdt.service';
+import { LockedAssetService } from '../../locked-asset-factory/services/locked-asset.service';
+import { MXApiServiceProvider } from '../../../services/multiversx-communication/mx.api.service.mock';
+import { UserMetaEsdtComputeService } from '../services/metaEsdt.compute.service';
+import { LockedAssetGetterService } from '../../locked-asset-factory/services/locked.asset.getter.service';
+import { AbiLockedAssetServiceProvider } from '../../locked-asset-factory/mocks/abi.locked.asset.service.mock';
+import { ContextGetterServiceProvider } from 'src/services/context/mocks/context.getter.service.mock';
+import { StakingServiceProvider } from '../../staking/mocks/staking.service.mock';
+import { PriceDiscoveryServiceProvider } from '../../price-discovery/mocks/price.discovery.service.mock';
+import { SimpleLockService } from '../../simple-lock/services/simple.lock.service';
+import { RemoteConfigGetterServiceProvider } from '../../remote-config/mocks/remote-config.getter.mock';
+import { TokenServiceProvider } from '../../tokens/mocks/token.service.mock';
+import { UserEsdtComputeService } from '../services/esdt.compute.service';
+import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
+import { FarmServiceV1_3 } from 'src/modules/farm/v1.3/services/farm.v1.3.service';
+import { FarmComputeServiceV1_3 } from 'src/modules/farm/v1.3/services/farm.v1.3.compute.service';
+import { FarmFactoryService } from 'src/modules/farm/farm.factory';
+import { FarmServiceV1_2 } from 'src/modules/farm/v1.2/services/farm.v1.2.service';
+import { FarmServiceV2 } from 'src/modules/farm/v2/services/farm.v2.service';
+import { FarmComputeServiceV1_2 } from 'src/modules/farm/v1.2/services/farm.v1.2.compute.service';
+import { FarmComputeServiceV2 } from 'src/modules/farm/v2/services/farm.v2.compute.service';
+import { FarmAbiServiceV2 } from 'src/modules/farm/v2/services/farm.v2.abi.service';
+import { WeekTimekeepingComputeService } from '../../../submodules/week-timekeeping/services/week-timekeeping.compute.service';
+import { LockedTokenWrapperService } from '../../locked-token-wrapper/services/locked-token-wrapper.service';
+import { MXDataApiServiceProvider } from 'src/services/multiversx-communication/mx.data.api.service.mock';
+import { EnergyAbiServiceProvider } from 'src/modules/energy/mocks/energy.abi.service.mock';
+import { WrapAbiServiceProvider } from 'src/modules/wrapping/mocks/wrap.abi.service.mock';
+import { WeekTimekeepingAbiServiceProvider } from 'src/submodules/week-timekeeping/mocks/week.timekeeping.abi.service.mock';
+import { WeeklyRewardsSplittingAbiServiceProvider } from 'src/submodules/weekly-rewards-splitting/mocks/weekly.rewards.splitting.abi.mock';
+import { PairAbiServiceProvider } from 'src/modules/pair/mocks/pair.abi.service.mock';
+import { PairComputeServiceProvider } from 'src/modules/pair/mocks/pair.compute.service.mock';
+import {
+    ProxyAbiServiceMock,
+    ProxyAbiServiceProvider,
+    ProxyFarmAbiServiceProvider,
+    ProxyPairAbiServiceProvider,
+} from 'src/modules/proxy/mocks/proxy.abi.service.mock';
+import { ProxyAbiServiceV2 } from 'src/modules/proxy/v2/services/proxy.v2.abi.service';
+import { RouterAbiServiceProvider } from 'src/modules/router/mocks/router.abi.service.mock';
+import { StakingAbiServiceProvider } from 'src/modules/staking/mocks/staking.abi.service.mock';
+import { SimpleLockAbiServiceProvider } from 'src/modules/simple-lock/mocks/simple.lock.abi.service.mock';
+import { PriceDiscoveryAbiServiceProvider } from 'src/modules/price-discovery/mocks/price.discovery.abi.service.mock';
+import { PriceDiscoveryComputeServiceProvider } from 'src/modules/price-discovery/mocks/price.discovery.compute.service.mock';
+import { LockedTokenWrapperAbiServiceProvider } from 'src/modules/locked-token-wrapper/mocks/locked.token.wrapper.abi.service.mock';
+import { FarmAbiServiceMock } from 'src/modules/farm/mocks/farm.abi.service.mock';
+import { FarmAbiServiceProviderV1_2 } from 'src/modules/farm/mocks/farm.v1.2.abi.service.mock';
+import { FarmAbiServiceProviderV1_3 } from 'src/modules/farm/mocks/farm.v1.3.abi.service.mock';
+import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
+import { FarmAbiFactory } from 'src/modules/farm/farm.abi.factory';
+import { StakingProxyService } from '../../staking-proxy/services/staking.proxy.service';
+import { StakingProxyAbiService } from '../../staking-proxy/services/staking.proxy.abi.service';
+import { UserEnergyComputeService } from '../services/userEnergy/user.energy.compute.service';
+import { MXProxyServiceProvider } from '../../../services/multiversx-communication/mx.proxy.service.mock';
+import { Address } from '@multiversx/sdk-core/out';
+import { gasConfig, mxConfig, scAddress } from 'src/config';
+import { ConfigModule } from '@nestjs/config';
+import { WinstonModule } from 'nest-winston';
+import { ApiConfigService } from 'src/helpers/api.config.service';
+import winston from 'winston';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { MetabondingAbiServiceMockProvider } from 'src/modules/metabonding/mocks/metabonding.abi.service.mock';
+import { AnalyticsQueryServiceProvider } from 'src/services/analytics/mocks/analytics.query.service.mock';
+import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { StakingProxyFilteringService } from 'src/modules/staking-proxy/services/staking.proxy.filtering.service';
+import { UserEnergyTransactionService } from '../services/userEnergy/user.energy.transaction.service';
+import { encodeTransactionData } from 'src/helpers/helpers';
+import { TransactionModel } from 'src/models/transaction.model';
+import { ContractType } from '../models/user.model';
+
+describe('UserEnergyTransactionService', () => {
+    let module: TestingModule;
+
+    beforeAll(async () => {
+        module = await Test.createTestingModule({
+            imports: [
+                WinstonModule.forRoot({
+                    transports: [new winston.transports.Console({})],
+                }),
+                ConfigModule.forRoot({}),
+                DynamicModuleUtils.getCacheModule(),
+                ElasticSearchModule,
+            ],
+            providers: [
+                UserEnergyTransactionService,
+                UserEnergyComputeService,
+                ContextGetterServiceProvider,
+                TokenServiceProvider,
+                TokenComputeService,
+                RouterAbiServiceProvider,
+                PairService,
+                PairAbiServiceProvider,
+                PairComputeServiceProvider,
+                ProxyAbiServiceProvider,
+                {
+                    provide: ProxyAbiServiceV2,
+                    useClass: ProxyAbiServiceMock,
+                },
+                FarmServiceV1_2,
+                FarmServiceV1_3,
+                FarmServiceV2,
+                FarmComputeServiceV1_2,
+                FarmComputeServiceV1_3,
+                FarmComputeServiceV2,
+                FarmAbiServiceProviderV1_2,
+                FarmAbiServiceProviderV1_3,
+                LockedTokenWrapperService,
+                {
+                    provide: FarmAbiServiceV2,
+                    useClass: FarmAbiServiceMock,
+                },
+                LockedTokenWrapperAbiServiceProvider,
+                LockedAssetService,
+                FarmAbiFactory,
+                FarmFactoryService,
+                WeekTimekeepingAbiServiceProvider,
+                WeeklyRewardsSplittingAbiServiceProvider,
+                WeekTimekeepingComputeService,
+                WeeklyRewardsSplittingComputeService,
+                UserMetaEsdtService,
+                UserEsdtComputeService,
+                StakingProxyService,
+                StakingProxyAbiService,
+                StakingProxyFilteringService,
+                SimpleLockAbiServiceProvider,
+                SimpleLockService,
+                StakingAbiServiceProvider,
+                StakingServiceProvider,
+                PriceDiscoveryServiceProvider,
+                PriceDiscoveryAbiServiceProvider,
+                PriceDiscoveryComputeServiceProvider,
+                EnergyAbiServiceProvider,
+                ProxyService,
+                ProxyPairAbiServiceProvider,
+                ProxyFarmAbiServiceProvider,
+                UserMetaEsdtComputeService,
+                WrapAbiServiceProvider,
+                MXDataApiServiceProvider,
+                MXApiServiceProvider,
+                MXProxyServiceProvider,
+                LockedAssetGetterService,
+                MetabondingAbiServiceMockProvider,
+                RemoteConfigGetterServiceProvider,
+                AbiLockedAssetServiceProvider,
+                AnalyticsQueryServiceProvider,
+                ApiConfigService,
+            ],
+        }).compile();
+    });
+
+    it('should be defined', () => {
+        const service = module.get<UserEnergyTransactionService>(
+            UserEnergyTransactionService,
+        );
+
+        expect(service).toBeDefined();
+    });
+
+    it('should get update farms energy transaction - all contracts', async () => {
+        const service = module.get<UserEnergyTransactionService>(
+            UserEnergyTransactionService,
+        );
+
+        const userEnergyCompute = module.get<UserEnergyComputeService>(
+            UserEnergyComputeService,
+        );
+
+        const farmAddress = Address.fromHex(
+            '0000000000000000000000000000000000000000000000000000000000000041',
+        ).bech32();
+        jest.spyOn(userEnergyCompute, 'userActiveFarmsV2').mockResolvedValue([
+            farmAddress,
+        ]);
+
+        const transaction = await service.updateFarmsEnergyForUser(
+            Address.Zero().bech32(),
+            true,
+        );
+
+        expect(transaction).toEqual(
+            new TransactionModel({
+                chainID: mxConfig.chainID,
+                nonce: 0,
+                gasLimit: gasConfig.energyUpdate.updateFarmsEnergyForUser * 2,
+                gasPrice: 1000000000,
+                value: '0',
+                sender: Address.Zero().bech32(),
+                receiver: scAddress.energyUpdate,
+                data: encodeTransactionData(
+                    `updateFarmsEnergyForUser@${Address.Zero().bech32()}@${farmAddress}@${
+                        scAddress.feesCollector
+                    }`,
+                ),
+                options: undefined,
+                signature: undefined,
+                version: 2,
+            }),
+        );
+    });
+
+    it('should get update farms energy transaction - outdated contracts', async () => {
+        const service = module.get<UserEnergyTransactionService>(
+            UserEnergyTransactionService,
+        );
+
+        const userEnergyCompute = module.get<UserEnergyComputeService>(
+            UserEnergyComputeService,
+        );
+
+        jest.spyOn(userEnergyCompute, 'userActiveFarmsV2').mockResolvedValue(
+            [],
+        );
+        jest.spyOn(userEnergyCompute, 'userActiveStakings').mockResolvedValue(
+            [],
+        );
+        jest.spyOn(userEnergyCompute, 'outdatedContract').mockResolvedValue({
+            address: scAddress.feesCollector,
+            type: ContractType.FeesCollector,
+            claimProgressOutdated: false,
+            farmToken: null,
+        });
+
+        const transaction = await service.updateFarmsEnergyForUser(
+            Address.Zero().bech32(),
+            false,
+        );
+
+        expect(transaction).toEqual(
+            new TransactionModel({
+                chainID: mxConfig.chainID,
+                nonce: 0,
+                gasLimit: gasConfig.energyUpdate.updateFarmsEnergyForUser,
+                gasPrice: 1000000000,
+                value: '0',
+                sender: Address.Zero().bech32(),
+                receiver: scAddress.energyUpdate,
+                data: encodeTransactionData(
+                    `updateFarmsEnergyForUser@${Address.Zero().bech32()}@${
+                        scAddress.feesCollector
+                    }`,
+                ),
+                options: undefined,
+                signature: undefined,
+                version: 2,
+            }),
+        );
+    });
+});

--- a/src/services/multiversx-communication/mx.api.service.ts
+++ b/src/services/multiversx-communication/mx.api.service.ts
@@ -56,6 +56,7 @@ export class MXApiService {
                 headers: {
                     origin: 'xExchangeService',
                 },
+                clientName: 'xExchangeService',
             },
         );
         this.genericGetExecutor = new PendingExecutor(

--- a/src/services/multiversx-communication/mx.proxy.service.ts
+++ b/src/services/multiversx-communication/mx.proxy.service.ts
@@ -49,7 +49,7 @@ export class MXProxyService {
                 headers: {
                     origin: 'xExchangeService',
                 },
-                clientName: 'xexchange-api',
+                clientName: 'xExchangeService',
             },
         );
 

--- a/src/services/multiversx-communication/mx.proxy.service.ts
+++ b/src/services/multiversx-communication/mx.proxy.service.ts
@@ -47,8 +47,9 @@ export class MXProxyService {
                 httpAgent: mxConfig.keepAlive ? httpAgent : null,
                 httpsAgent: mxConfig.keepAlive ? httpsAgent : null,
                 headers: {
-                    origin: 'MaiarExchangeService',
+                    origin: 'xExchangeService',
                 },
+                clientName: 'xexchange-api',
             },
         );
 


### PR DESCRIPTION
## Reasoning
- missing unit tests for multi-swap and update farms energy transactions
- latest version of network providers print a warning to console if `clientName` parameter is omitted
  
## Proposed Changes
- add unit tests for update farms energy transaction
- add unit test for multi-swap transaction
- add `clientName` to proxy and api network providers

## How to test
- N/A
