### PR TITLE
[SERVICES-2682] Fix staking outdated contracts

### DIFF
--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -13,7 +13,6 @@ import { ClaimProgress } from '../../../../submodules/weekly-rewards-splitting/m
 import {
     ContractType,
     OutdatedContract,
-    UserDualYiledToken,
     UserNegativeEnergyCheck,
 } from '../../models/user.model';
 import { ProxyService } from '../../../proxy/services/proxy.service';
@@ -40,6 +39,7 @@ import { LockedAssetGetterService } from 'src/modules/locked-asset-factory/servi
 import { MetabondingAbiService } from 'src/modules/metabonding/services/metabonding.abi.service';
 import { PaginationArgs } from 'src/modules/dex.model';
 import { UserMetaEsdtService } from '../user.metaEsdt.service';
+import { StakingComputeService } from 'src/modules/staking/services/staking.compute.service';
 
 @Injectable()
 export class UserEnergyComputeService {
@@ -51,6 +51,7 @@ export class UserEnergyComputeService {
         private readonly stakeProxyService: StakingProxyService,
         private readonly stakeProxyAbi: StakingProxyAbiService,
         private readonly stakingService: StakingService,
+        private readonly stakingCompute: StakingComputeService,
         private readonly energyAbi: EnergyAbiService,
         private readonly lockedAssetGetter: LockedAssetGetterService,
         private readonly proxyService: ProxyService,
@@ -167,6 +168,14 @@ export class UserEnergyComputeService {
         userAddress: string,
         contractAddress: string,
     ): Promise<OutdatedContract> {
+        const isProducingRewards = await this.stakingCompute.isProducingRewards(
+            contractAddress,
+        );
+
+        if (!isProducingRewards) {
+            return new OutdatedContract();
+        }
+
         const [currentClaimProgress, currentWeek, farmToken, userEnergy] =
             await Promise.all([
                 this.weeklyRewardsSplittingAbi.currentClaimProgress(

--- a/src/modules/user/specs/user.energy.compute.service.spec.ts
+++ b/src/modules/user/specs/user.energy.compute.service.spec.ts
@@ -69,6 +69,7 @@ import { MetabondingAbiServiceMockProvider } from 'src/modules/metabonding/mocks
 import { AnalyticsQueryServiceProvider } from 'src/services/analytics/mocks/analytics.query.service.mock';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
 import { StakingProxyFilteringService } from 'src/modules/staking-proxy/services/staking.proxy.filtering.service';
+import { StakingComputeService } from 'src/modules/staking/services/staking.compute.service';
 
 describe('UserEnergyComputeService', () => {
     let module: TestingModule;
@@ -119,6 +120,7 @@ describe('UserEnergyComputeService', () => {
                 SimpleLockService,
                 StakingAbiServiceProvider,
                 StakingServiceProvider,
+                StakingComputeService,
                 PriceDiscoveryServiceProvider,
                 PriceDiscoveryAbiServiceProvider,
                 PriceDiscoveryComputeServiceProvider,


### PR DESCRIPTION
## Reasoning
- the `userOutdatedContracts` query always returns a result for positions in staking farms where the rewards have stopped
  
## Proposed Changes
- add early exit if the contract is not producing rewards in the compute method for outdated staking contracts 
- fix `isProducingRewards` method and usage in staking compute  
- add caching to `isProducingRewards` method

## How to test
- the query should not return a result if the user has a position in a staking farm that is no longer producing rewards
```
query {
  userOutdatedContracts {
    address
    type
    claimProgressOutdated
    farmToken 
  }
}
```
