### PR TITLE
[SERVICES-2706] Remove hatom farm address from devnet config

### DIFF
--- a/src/config/devnet.json
+++ b/src/config/devnet.json
@@ -67,7 +67,6 @@
                     "erd1qqqqqqqqqqqqqpgqtukp628k04vg93peq8k3ngrh0k2rs3nm0n4sjkcz95",
                     "erd1qqqqqqqqqqqqqpgql7rysqgxxzhykg3j6vccnx4003z2mcl80n4ste3jh8",
                     "erd1qqqqqqqqqqqqqpgqrrghrmzzq3vczqpx2quaza4yyke5fudh0n4sxdhv67",
-                    "erd1qqqqqqqqqqqqqpgqw5lslxqdt47jqty6sp2n73wvwxewqg200n4sz3q9nc",
                     "erd1qqqqqqqqqqqqqpgqjxazy2gwxv4m8tat6vsen56hhpsdff2f0n4srjdw3h"
                 ]
         }


### PR DESCRIPTION
## Reasoning
- necessary for some cleanup related to Hatom's devnet test environment
  
## Proposed Changes
- remove farm SC address from devnet config

## How to test
- N/A
