### PR TITLE
[SERVICES-2691] Performance improvements and caching fixes

### DIFF
--- a/src/modules/pair/interfaces.ts
+++ b/src/modules/pair/interfaces.ts
@@ -43,7 +43,7 @@ export interface IPairComputeService {
     lockedValueUSD(pairAddress: string): Promise<string>;
     firstTokenVolume(pairAddress: string, time: string): Promise<string>;
     secondTokenVolume(pairAddress: string, time: string): Promise<string>;
-    volumeUSD(pairAddress: string, time: string): Promise<string>;
+    volumeUSD(pairAddress: string): Promise<string>;
     feesUSD(pairAddress: string, time: string): Promise<string>;
     feesAPR(pairAddress: string): Promise<string>;
     type(pairAddress: string): Promise<string>;

--- a/src/modules/pair/mocks/pair.compute.service.mock.ts
+++ b/src/modules/pair/mocks/pair.compute.service.mock.ts
@@ -73,6 +73,9 @@ export class PairComputeServiceMock implements IPairComputeService {
     async volumeUSD(pairAddress: string): Promise<string> {
         return PairsData(pairAddress).volumeUSD;
     }
+    async getAllVolumeUSD(pairAddresses: string[]): Promise<string[]> {
+        return pairAddresses.map((address) => PairsData(address).volumeUSD);
+    }
     feesUSD(pairAddress: string, time: string): Promise<string> {
         throw new Error('Method not implemented.');
     }

--- a/src/modules/pair/mocks/pair.compute.service.mock.ts
+++ b/src/modules/pair/mocks/pair.compute.service.mock.ts
@@ -70,7 +70,7 @@ export class PairComputeServiceMock implements IPairComputeService {
     secondTokenVolume(pairAddress: string, time: string): Promise<string> {
         throw new Error('Method not implemented.');
     }
-    async volumeUSD(pairAddress: string, time: string): Promise<string> {
+    async volumeUSD(pairAddress: string): Promise<string> {
         return PairsData(pairAddress).volumeUSD;
     }
     feesUSD(pairAddress: string, time: string): Promise<string> {

--- a/src/modules/pair/mocks/pair.service.mock.ts
+++ b/src/modules/pair/mocks/pair.service.mock.ts
@@ -1,0 +1,23 @@
+import { PairService } from '../services/pair.service';
+import { PairsData } from './pair.constants';
+
+export class PairServiceMock {
+    async getAllLpTokensIds(pairAddresses: string[]): Promise<string[]> {
+        return pairAddresses.map(
+            (address) => PairsData(address).liquidityPoolToken.identifier,
+        );
+    }
+    async getAllFeeStates(pairAddresses: string[]): Promise<boolean[]> {
+        return pairAddresses.map((address) => PairsData(address).feeState);
+    }
+    async getAllLockedValueUSD(pairAddresses: string[]): Promise<string[]> {
+        return pairAddresses.map(
+            (address) => PairsData(address).lockedValueUSD,
+        );
+    }
+}
+
+export const PairServiceProvider = {
+    provide: PairService,
+    useClass: PairServiceMock,
+};

--- a/src/modules/pair/pair.resolver.ts
+++ b/src/modules/pair/pair.resolver.ts
@@ -273,7 +273,7 @@ export class PairResolver {
 
     @ResolveField()
     async volumeUSD24h(@Parent() parent: PairModel): Promise<string> {
-        return this.pairCompute.volumeUSD(parent.address, '24h');
+        return this.pairComputeLoader.volumeUSD24hLoader.load(parent.address);
     }
 
     @ResolveField()

--- a/src/modules/pair/services/pair.abi.loader.ts
+++ b/src/modules/pair/services/pair.abi.loader.ts
@@ -23,20 +23,31 @@ export class PairAbiLoader {
         async (addresses: string[]) => {
             return this.pairService.getAllFirstTokens(addresses);
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly secondTokenLoader = new DataLoader<string, EsdtToken>(
         async (addresses: string[]) => {
             return this.pairService.getAllSecondTokens(addresses);
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly liquidityPoolTokenLoader = new DataLoader<
         string,
         EsdtToken
-    >(async (addresses: string[]) => {
-        return this.pairService.getAllLpTokens(addresses);
-    });
+    >(
+        async (addresses: string[]) => {
+            return this.pairService.getAllLpTokens(addresses);
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly infoMetadataLoader = new DataLoader<string, PairInfoModel>(
         async (addresses: string[]) => {
@@ -47,6 +58,9 @@ export class PairAbiLoader {
                 this.pairAbi.pairInfoMetadata.bind(this.pairAbi),
                 CacheTtlInfo.ContractBalance,
             );
+        },
+        {
+            cache: false,
         },
     );
 
@@ -60,6 +74,9 @@ export class PairAbiLoader {
                 CacheTtlInfo.ContractState,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly specialFeePercentLoader = new DataLoader<string, number>(
@@ -72,29 +89,40 @@ export class PairAbiLoader {
                 CacheTtlInfo.ContractState,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly feesCollectorCutPercentageLoader = new DataLoader<
         string,
         number
-    >(async (addresses: string[]) => {
-        const percentages = await getAllKeys<number>(
-            this.cacheService,
-            addresses,
-            'pair.feesCollectorCutPercentage',
-            this.pairAbi.feesCollectorCutPercentage.bind(this.pairAbi),
-            CacheTtlInfo.ContractState,
-        );
+    >(
+        async (addresses: string[]) => {
+            const percentages = await getAllKeys<number>(
+                this.cacheService,
+                addresses,
+                'pair.feesCollectorCutPercentage',
+                this.pairAbi.feesCollectorCutPercentage.bind(this.pairAbi),
+                CacheTtlInfo.ContractState,
+            );
 
-        return percentages.map(
-            (percentage) =>
-                percentage / constantsConfig.SWAP_FEE_PERCENT_BASE_POINTS,
-        );
-    });
+            return percentages.map(
+                (percentage) =>
+                    percentage / constantsConfig.SWAP_FEE_PERCENT_BASE_POINTS,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly stateLoader = new DataLoader<string, string>(
         async (addresses: string[]) => {
             return this.pairService.getAllStates(addresses);
+        },
+        {
+            cache: false,
         },
     );
 
@@ -102,18 +130,26 @@ export class PairAbiLoader {
         async (addresses: string[]) => {
             return this.pairService.getAllFeeStates(addresses);
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly initialLiquidityAdderLoader = new DataLoader<
         string,
         string
-    >(async (addresses: string[]) => {
-        return getAllKeys<string>(
-            this.cacheService,
-            addresses,
-            'pair.initialLiquidityAdder',
-            this.pairAbi.initialLiquidityAdder.bind(this.pairAbi),
-            CacheTtlInfo.ContractState,
-        );
-    });
+    >(
+        async (addresses: string[]) => {
+            return getAllKeys<string>(
+                this.cacheService,
+                addresses,
+                'pair.initialLiquidityAdder',
+                this.pairAbi.initialLiquidityAdder.bind(this.pairAbi),
+                CacheTtlInfo.ContractState,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 }

--- a/src/modules/pair/services/pair.compute.loader.ts
+++ b/src/modules/pair/services/pair.compute.loader.ts
@@ -26,6 +26,9 @@ export class PairComputeLoader {
                 CacheTtlInfo.Price,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly secondTokenPriceLoader = new DataLoader<string, string>(
@@ -37,6 +40,9 @@ export class PairComputeLoader {
                 this.pairCompute.secondTokenPrice.bind(this.pairCompute),
                 CacheTtlInfo.Price,
             );
+        },
+        {
+            cache: false,
         },
     );
 
@@ -50,6 +56,9 @@ export class PairComputeLoader {
                 CacheTtlInfo.Price,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly secondTokenPriceUSDLoader = new DataLoader<string, string>(
@@ -61,6 +70,9 @@ export class PairComputeLoader {
                 this.pairCompute.secondTokenPriceUSD.bind(this.pairCompute),
                 CacheTtlInfo.Price,
             );
+        },
+        {
+            cache: false,
         },
     );
 
@@ -74,52 +86,79 @@ export class PairComputeLoader {
                 CacheTtlInfo.Price,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly firstTokenLockedValueUSDLoader = new DataLoader<
         string,
         string
-    >(async (addresses: string[]) => {
-        return await getAllKeys(
-            this.cacheService,
-            addresses,
-            'pair.firstTokenLockedValueUSD',
-            this.pairCompute.firstTokenLockedValueUSD.bind(this.pairCompute),
-            CacheTtlInfo.ContractInfo,
-        );
-    });
+    >(
+        async (addresses: string[]) => {
+            return await getAllKeys(
+                this.cacheService,
+                addresses,
+                'pair.firstTokenLockedValueUSD',
+                this.pairCompute.firstTokenLockedValueUSD.bind(
+                    this.pairCompute,
+                ),
+                CacheTtlInfo.ContractInfo,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly secondTokenLockedValueUSDLoader = new DataLoader<
         string,
         string
-    >(async (addresses: string[]) => {
-        return await getAllKeys(
-            this.cacheService,
-            addresses,
-            'pair.secondTokenLockedValueUSD',
-            this.pairCompute.secondTokenLockedValueUSD.bind(this.pairCompute),
-            CacheTtlInfo.ContractInfo,
-        );
-    });
+    >(
+        async (addresses: string[]) => {
+            return await getAllKeys(
+                this.cacheService,
+                addresses,
+                'pair.secondTokenLockedValueUSD',
+                this.pairCompute.secondTokenLockedValueUSD.bind(
+                    this.pairCompute,
+                ),
+                CacheTtlInfo.ContractInfo,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly lockedValueUSDLoader = new DataLoader<string, string>(
         async (addresses: string[]) => {
             return await this.pairService.getAllLockedValueUSD(addresses);
+        },
+        {
+            cache: false,
         },
     );
 
     public readonly previous24hLockedValueUSDLoader = new DataLoader<
         string,
         string
-    >(async (addresses: string[]) => {
-        return await getAllKeys(
-            this.cacheService,
-            addresses,
-            'pair.previous24hLockedValueUSD',
-            this.pairCompute.previous24hLockedValueUSD.bind(this.pairCompute),
-            CacheTtlInfo.ContractInfo,
-        );
-    });
+    >(
+        async (addresses: string[]) => {
+            return await getAllKeys(
+                this.cacheService,
+                addresses,
+                'pair.previous24hLockedValueUSD',
+                this.pairCompute.previous24hLockedValueUSD.bind(
+                    this.pairCompute,
+                ),
+                CacheTtlInfo.ContractInfo,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly previous24hVolumeUSDLoader = new DataLoader<string, string>(
         async (addresses: string[]) => {
@@ -130,6 +169,9 @@ export class PairComputeLoader {
                 this.pairCompute.previous24hVolumeUSD.bind(this.pairCompute),
                 CacheTtlInfo.Analytics,
             );
+        },
+        {
+            cache: false,
         },
     );
 
@@ -143,6 +185,9 @@ export class PairComputeLoader {
                 CacheTtlInfo.Analytics,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly feesAPRLoader = new DataLoader<string, string>(
@@ -154,6 +199,9 @@ export class PairComputeLoader {
                 this.pairCompute.feesAPR.bind(this.pairCompute),
                 CacheTtlInfo.ContractState,
             );
+        },
+        {
+            cache: false,
         },
     );
 
@@ -167,11 +215,17 @@ export class PairComputeLoader {
                 CacheTtlInfo.ContractState,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly hasFarmsLoader = new DataLoader<string, boolean>(
         async (addresses: string[]) => {
             return await this.pairService.getAllHasFarms(addresses);
+        },
+        {
+            cache: false,
         },
     );
 
@@ -179,11 +233,17 @@ export class PairComputeLoader {
         async (addresses: string[]) => {
             return await this.pairService.getAllHasDualFarms(addresses);
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly tradesCountLoader = new DataLoader<string, number>(
         async (addresses: string[]) => {
             return await this.pairService.getAllTradesCount(addresses);
+        },
+        {
+            cache: false,
         },
     );
 
@@ -191,11 +251,17 @@ export class PairComputeLoader {
         async (addresses: string[]) => {
             return await this.pairCompute.getAllTradesCount24h(addresses);
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly deployedAtLoader = new DataLoader<string, number>(
         async (addresses: string[]) => {
             return await this.pairService.getAllDeployedAt(addresses);
+        },
+        {
+            cache: false,
         },
     );
 }

--- a/src/modules/pair/services/pair.compute.loader.ts
+++ b/src/modules/pair/services/pair.compute.loader.ts
@@ -175,6 +175,15 @@ export class PairComputeLoader {
         },
     );
 
+    public readonly volumeUSD24hLoader = new DataLoader<string, string>(
+        async (addresses: string[]) => {
+            return await this.pairCompute.getAllVolumeUSD(addresses);
+        },
+        {
+            cache: false,
+        },
+    );
+
     public readonly previous24hFeesUSDLoader = new DataLoader<string, string>(
         async (addresses: string[]) => {
             return await getAllKeys(

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -427,8 +427,8 @@ export class PairComputeService implements IPairComputeService {
         remoteTtl: CacheTtlInfo.Analytics.remoteTtl,
         localTtl: CacheTtlInfo.Analytics.localTtl,
     })
-    async volumeUSD(pairAddress: string, time: string): Promise<string> {
-        return await this.computeVolumeUSD(pairAddress, time);
+    async volumeUSD(pairAddress: string): Promise<string> {
+        return await this.computeVolumeUSD(pairAddress, '24h');
     }
 
     async computeVolumeUSD(pairAddress: string, time: string): Promise<string> {
@@ -440,6 +440,16 @@ export class PairComputeService implements IPairComputeService {
             metric: 'volumeUSD',
             time,
         });
+    }
+
+    async getAllVolumeUSD(pairAddresses: string[]): Promise<string[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.volumeUSD',
+            this.volumeUSD.bind(this),
+            CacheTtlInfo.Analytics,
+        );
     }
 
     @ErrorLoggerAsync({
@@ -456,8 +466,8 @@ export class PairComputeService implements IPairComputeService {
 
     async computePrevious24hVolumeUSD(pairAddress: string): Promise<string> {
         const [volume24h, volume48h] = await Promise.all([
-            this.volumeUSD(pairAddress, '24h'),
-            this.volumeUSD(pairAddress, '48h'),
+            this.computeVolumeUSD(pairAddress, '24h'),
+            this.computeVolumeUSD(pairAddress, '48h'),
         ]);
         return new BigNumber(volume48h).minus(volume24h).toFixed();
     }

--- a/src/modules/pair/services/pair.filtering.service.ts
+++ b/src/modules/pair/services/pair.filtering.service.ts
@@ -212,10 +212,8 @@ export class PairFilteringService {
             return pairsMetadata;
         }
 
-        const pairsVolumes = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairCompute.volumeUSD(pairMetadata.address, '24h'),
-            ),
+        const pairsVolumes = await this.pairCompute.getAllVolumeUSD(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter((_, index) => {

--- a/src/modules/pair/services/pair.setter.service.ts
+++ b/src/modules/pair/services/pair.setter.service.ts
@@ -266,13 +266,9 @@ export class PairSetterService extends GenericSetterService {
         );
     }
 
-    async setVolumeUSD(
-        pairAddress: string,
-        value: string,
-        time: string,
-    ): Promise<string> {
+    async setVolumeUSD(pairAddress: string, value: string): Promise<string> {
         return await this.setData(
-            this.getCacheKey('volumeUSD', pairAddress, time),
+            this.getCacheKey('volumeUSD', pairAddress),
             value,
             CacheTtlInfo.Analytics.remoteTtl,
             CacheTtlInfo.Analytics.localTtl,

--- a/src/modules/router/services/router.service.ts
+++ b/src/modules/router/services/router.service.ts
@@ -236,10 +236,8 @@ export class RouterService {
             return pairsMetadata;
         }
 
-        const pairsVolumes = await Promise.all(
-            pairsMetadata.map((pairMetadata) =>
-                this.pairCompute.volumeUSD(pairMetadata.address, '24h'),
-            ),
+        const pairsVolumes = await this.pairCompute.getAllVolumeUSD(
+            pairsMetadata.map((pair) => pair.address),
         );
 
         return pairsMetadata.filter((_, index) => {
@@ -311,10 +309,8 @@ export class RouterService {
                 );
                 break;
             case PairSortableFields.VOLUME_24:
-                sortFieldData = await Promise.all(
-                    pairsMetadata.map((pair) =>
-                        this.pairCompute.volumeUSD(pair.address, '24h'),
-                    ),
+                sortFieldData = await this.pairCompute.getAllVolumeUSD(
+                    pairsMetadata.map((pair) => pair.address),
                 );
                 break;
             case PairSortableFields.APR:

--- a/src/modules/router/specs/router.service.spec.ts
+++ b/src/modules/router/specs/router.service.spec.ts
@@ -12,7 +12,7 @@ import winston from 'winston';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { PairComputeServiceProvider } from 'src/modules/pair/mocks/pair.compute.service.mock';
 import { PairFilteringService } from 'src/modules/pair/services/pair.filtering.service';
-import { PairService } from 'src/modules/pair/services/pair.service';
+import { PairServiceProvider } from 'src/modules/pair/mocks/pair.service.mock';
 import { WrapAbiServiceProvider } from 'src/modules/wrapping/mocks/wrap.abi.service.mock';
 import { TokenServiceProvider } from 'src/modules/tokens/mocks/token.service.mock';
 import { ContextGetterServiceProvider } from 'src/services/context/mocks/context.getter.service.mock';
@@ -37,7 +37,7 @@ describe('RouterService', () => {
                 RouterService,
                 ApiConfigService,
                 PairFilteringService,
-                PairService,
+                PairServiceProvider,
                 WrapAbiServiceProvider,
                 TokenServiceProvider,
                 ContextGetterServiceProvider,

--- a/src/modules/tokens/services/token.loader.ts
+++ b/src/modules/tokens/services/token.loader.ts
@@ -20,14 +20,24 @@ export class TokenLoader {
         async (tokenIDs: string[]) => {
             return await this.tokenService.getAllEsdtTokensType(tokenIDs);
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly tokenPriceDerivedEGLDLoader = new DataLoader<
         string,
         string
-    >(async (tokenIDs: string[]) => {
-        return await this.tokenCompute.getAllTokensPriceDerivedEGLD(tokenIDs);
-    });
+    >(
+        async (tokenIDs: string[]) => {
+            return await this.tokenCompute.getAllTokensPriceDerivedEGLD(
+                tokenIDs,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly tokenPriceDerivedUSDLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
@@ -35,14 +45,24 @@ export class TokenLoader {
                 tokenIDs,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly tokenPrevious24hPriceLoader = new DataLoader<
         string,
         string
-    >(async (tokenIDs: string[]) => {
-        return await this.tokenCompute.getAllTokensPrevious24hPrice(tokenIDs);
-    });
+    >(
+        async (tokenIDs: string[]) => {
+            return await this.tokenCompute.getAllTokensPrevious24hPrice(
+                tokenIDs,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly tokenPrevious7dPriceLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
@@ -50,32 +70,49 @@ export class TokenLoader {
                 tokenIDs,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly tokenVolumeUSD24hLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
             return await this.tokenCompute.getAllTokensVolumeUSD24h(tokenIDs);
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly tokenPrevious24hVolumeUSDLoader = new DataLoader<
         string,
         string
-    >(async (tokenIDs: string[]) => {
-        return await this.tokenCompute.getAllTokensPrevious24hVolumeUSD(
-            tokenIDs,
-        );
-    });
+    >(
+        async (tokenIDs: string[]) => {
+            return await this.tokenCompute.getAllTokensPrevious24hVolumeUSD(
+                tokenIDs,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly tokenLiquidityUSDLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
             return await this.tokenCompute.getAllTokensLiquidityUSD(tokenIDs);
+        },
+        {
+            cache: false,
         },
     );
 
     public readonly tokenCreatedAtLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
             return await this.tokenCompute.getAllTokensCreatedAt(tokenIDs);
+        },
+        {
+            cache: false,
         },
     );
 
@@ -89,24 +126,37 @@ export class TokenLoader {
                 CacheTtlInfo.Token,
             );
         },
+        {
+            cache: false,
+        },
     );
 
     public readonly tokenPrevious24hSwapCountLoader = new DataLoader<
         string,
         number
-    >(async (tokenIDs: string[]) => {
-        return await getAllKeys(
-            this.cacheService,
-            tokenIDs,
-            'token.tokenPrevious24hSwapCount',
-            this.tokenCompute.tokenPrevious24hSwapCount.bind(this.tokenCompute),
-            CacheTtlInfo.Token,
-        );
-    });
+    >(
+        async (tokenIDs: string[]) => {
+            return await getAllKeys(
+                this.cacheService,
+                tokenIDs,
+                'token.tokenPrevious24hSwapCount',
+                this.tokenCompute.tokenPrevious24hSwapCount.bind(
+                    this.tokenCompute,
+                ),
+                CacheTtlInfo.Token,
+            );
+        },
+        {
+            cache: false,
+        },
+    );
 
     public readonly tokenTrendingScoreLoader = new DataLoader<string, string>(
         async (tokenIDs: string[]) => {
             return await this.tokenCompute.getAllTokensTrendingScore(tokenIDs);
+        },
+        {
+            cache: false,
         },
     );
 }

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -122,7 +122,7 @@ export class PairCacheWarmerService {
                     secondTokenVolume24h,
                     time,
                 ),
-                this.pairSetterService.setVolumeUSD(
+                this.pairSetterService.setVolumeUSD(pairAddress, volumeUSD24h),
                     pairAddress,
                     volumeUSD24h,
                     time,

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -17,6 +17,7 @@ import { Logger } from 'winston';
 import { PerformanceProfiler } from 'src/utils/performance.profiler';
 import { TokenSetterService } from 'src/modules/tokens/services/token.setter.service';
 import { EsdtTokenType } from 'src/modules/tokens/models/esdtToken.model';
+import { PairService } from 'src/modules/pair/services/pair.service';
 
 @Injectable()
 export class PairCacheWarmerService {
@@ -24,6 +25,7 @@ export class PairCacheWarmerService {
         private readonly pairSetterService: PairSetterService,
         private readonly pairComputeService: PairComputeService,
         private readonly pairAbi: PairAbiService,
+        private readonly pairService: PairService,
         private readonly routerAbi: RouterAbiService,
         private readonly analyticsQuery: AnalyticsQueryService,
         private readonly tokenSetter: TokenSetterService,
@@ -44,7 +46,12 @@ export class PairCacheWarmerService {
                 pairMetadata.address,
             );
 
-            const cachedKeys = await Promise.all([
+            const lpToken =
+                lpTokenID === undefined
+                    ? undefined
+                    : await this.pairService.getLpToken(pairMetadata.address);
+
+            const cacheSetPromises = [
                 this.pairSetterService.setFirstTokenID(
                     pairMetadata.address,
                     pairMetadata.firstTokenID,
@@ -57,11 +64,21 @@ export class PairCacheWarmerService {
                     pairMetadata.address,
                     lpTokenID,
                 ),
-                this.tokenSetter.setEsdtTokenType(
-                    lpTokenID,
-                    EsdtTokenType.FungibleLpToken,
-                ),
-            ]);
+            ];
+
+            if (lpTokenID !== undefined) {
+                cacheSetPromises.push(
+                    this.tokenSetter.setEsdtTokenType(
+                        lpTokenID,
+                        EsdtTokenType.FungibleLpToken,
+                    ),
+                );
+                cacheSetPromises.push(
+                    this.tokenSetter.setMetadata(lpTokenID, lpToken),
+                );
+            }
+
+            const cachedKeys = await Promise.all(cacheSetPromises);
 
             await this.deleteCacheKeys(cachedKeys);
         }
@@ -123,10 +140,6 @@ export class PairCacheWarmerService {
                     time,
                 ),
                 this.pairSetterService.setVolumeUSD(pairAddress, volumeUSD24h),
-                    pairAddress,
-                    volumeUSD24h,
-                    time,
-                ),
                 this.pairSetterService.setFeesUSD(
                     pairAddress,
                     feesUSD24h,

--- a/src/utils/get.many.utils.ts
+++ b/src/utils/get.many.utils.ts
@@ -60,7 +60,7 @@ export async function getAllKeys<T>(
 
     const missingIndexes: number[] = [];
     values.forEach((value, index) => {
-        if (value === undefined) {
+        if (value === undefined || value === null) {
             missingIndexes.push(index);
         } else {
             values[index] = parseCachedNullOrUndefined(value);

--- a/src/utils/get.many.utils.ts
+++ b/src/utils/get.many.utils.ts
@@ -11,7 +11,7 @@ async function getMany<T>(
 
     const missingIndexes: number[] = [];
     values.forEach((value, index) => {
-        if (!value) {
+        if (value === undefined) {
             missingIndexes.push(index);
         }
     });
@@ -38,10 +38,7 @@ async function getMany<T>(
     }
 
     for (const [index, missingIndex] of missingIndexes.entries()) {
-        const remoteValue = remoteValues[index];
-        values[missingIndex] = remoteValue
-            ? parseCachedNullOrUndefined(remoteValue)
-            : undefined;
+        values[missingIndex] = remoteValues[index];
     }
 
     return values;
@@ -63,8 +60,10 @@ export async function getAllKeys<T>(
 
     const missingIndexes: number[] = [];
     values.forEach((value, index) => {
-        if (!value) {
+        if (value === undefined) {
             missingIndexes.push(index);
+        } else {
+            values[index] = parseCachedNullOrUndefined(value);
         }
     });
 
@@ -72,5 +71,6 @@ export async function getAllKeys<T>(
         const tokenID = await getterMethod(rawKeys[missingIndex]);
         values[missingIndex] = tokenID;
     }
+
     return values;
 }


### PR DESCRIPTION
## Reasoning
- using falsy checks instead of explicit undefined checks inside the cache `getAllKeys` method triggers unnecessary individual redis GET requests for cached booleans / the number 0
- LP tokens metadata is only being cached on request resulting in slow queries for the first user that needs the data
- dataloaders have a default in-memory cache enabled
  
## Proposed Changes
- disable caching for pair (abi + compute) and tokens dataloaders
- add dataloader for pair 24h volume
- cache warm LP tokens metadata
- replace falsy check with explicit undefined check in `getAllKeys` util function

## How to test
- N/A
