### PR TITLE
[MEX-532] deprecated farm type

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -544,7 +544,8 @@
             },
             "v2": {
                 "unlockedRewards": "./src/abis/farms/v2/farm.abi.json",
-                "lockedRewards": "src/abis/farms/v2/farm-with-locked-rewards.abi.json"
+                "lockedRewards": "src/abis/farms/v2/farm-with-locked-rewards.abi.json",
+                "deprecated": "src/abis/farms/v2/farm-with-locked-rewards.abi.json"
             }
         },
         "staking": "./src/abis/farm-staking.abi.json",

--- a/src/config/devnet.json
+++ b/src/config/devnet.json
@@ -63,12 +63,14 @@
                 "unlockedRewards": [
                 ],
                 "lockedRewards": [
-                    "erd1qqqqqqqqqqqqqpgqqjpfmappkpzq6kdju3mkqepk3d2kcymu0n4srd45sa",
                     "erd1qqqqqqqqqqqqqpgqmye3xq9p8x0g3hqawz22txsyw07nnv9e0n4swdrvqc",
                     "erd1qqqqqqqqqqqqqpgqtukp628k04vg93peq8k3ngrh0k2rs3nm0n4sjkcz95",
                     "erd1qqqqqqqqqqqqqpgql7rysqgxxzhykg3j6vccnx4003z2mcl80n4ste3jh8",
                     "erd1qqqqqqqqqqqqqpgqrrghrmzzq3vczqpx2quaza4yyke5fudh0n4sxdhv67",
                     "erd1qqqqqqqqqqqqqpgqjxazy2gwxv4m8tat6vsen56hhpsdff2f0n4srjdw3h"
+                ],
+                "deprecated": [
+                    "erd1qqqqqqqqqqqqqpgqqjpfmappkpzq6kdju3mkqepk3d2kcymu0n4srd45sa"
                 ]
         }
     },

--- a/src/config/devnet.json
+++ b/src/config/devnet.json
@@ -64,6 +64,7 @@
                 ],
                 "lockedRewards": [
                     "erd1qqqqqqqqqqqqqpgqqjpfmappkpzq6kdju3mkqepk3d2kcymu0n4srd45sa",
+                    "erd1qqqqqqqqqqqqqpgqmye3xq9p8x0g3hqawz22txsyw07nnv9e0n4swdrvqc",
                     "erd1qqqqqqqqqqqqqpgqtukp628k04vg93peq8k3ngrh0k2rs3nm0n4sjkcz95",
                     "erd1qqqqqqqqqqqqqpgql7rysqgxxzhykg3j6vccnx4003z2mcl80n4ste3jh8",
                     "erd1qqqqqqqqqqqqqpgqrrghrmzzq3vczqpx2quaza4yyke5fudh0n4sxdhv67",

--- a/src/config/staging.json
+++ b/src/config/staging.json
@@ -88,6 +88,7 @@
         "v2": {
             "lockedRewards": [
                 "erd1qqqqqqqqqqqqqpgqapxdp9gjxtg60mjwhle3n6h88zch9e7kkp2s8aqhkg",
+                "erd1qqqqqqqqqqqqqpgqtdc0rzjwmp9qs0h0wj9pjwxnp5vjc9hdkp2swd4dxz",
                 "erd1qqqqqqqqqqqqqpgqv0pz5z3fkz54nml6pkzzdruuf020gqzykp2sya7kkv",
                 "erd1qqqqqqqqqqqqqpgqenvn0s3ldc94q2mlkaqx4arj3zfnvnmakp2sxca2h9",
                 "erd1qqqqqqqqqqqqqpgqrdq6zvepdxg36rey8pmluwur43q4hcx3kp2su4yltq",

--- a/src/config/staging.json
+++ b/src/config/staging.json
@@ -87,7 +87,6 @@
         },
         "v2": {
             "lockedRewards": [
-                "erd1qqqqqqqqqqqqqpgqapxdp9gjxtg60mjwhle3n6h88zch9e7kkp2s8aqhkg",
                 "erd1qqqqqqqqqqqqqpgqtdc0rzjwmp9qs0h0wj9pjwxnp5vjc9hdkp2swd4dxz",
                 "erd1qqqqqqqqqqqqqpgqv0pz5z3fkz54nml6pkzzdruuf020gqzykp2sya7kkv",
                 "erd1qqqqqqqqqqqqqpgqenvn0s3ldc94q2mlkaqx4arj3zfnvnmakp2sxca2h9",
@@ -107,6 +106,9 @@
                 "erd1qqqqqqqqqqqqqpgq4se997u3eyhjmpwaa57lvdgvmyn23yqpx9rsdzja7j",
                 "erd1qqqqqqqqqqqqqpgqhh8lke0kfch0g20jrmskczwq86d23qhex9rs5hm4uk",
                 "erd1qqqqqqqqqqqqqpgqgjqu7c0mq8a4jd4d43st44gvwhduvqaxkp2s7vsq64"
+            ],
+            "deprecated": [
+                "erd1qqqqqqqqqqqqqpgqapxdp9gjxtg60mjwhle3n6h88zch9e7kkp2s8aqhkg"
             ]
         }
     },

--- a/src/modules/farm/models/farm.model.ts
+++ b/src/modules/farm/models/farm.model.ts
@@ -18,6 +18,7 @@ export enum FarmRewardType {
     UNLOCKED_REWARDS = 'unlockedRewards',
     LOCKED_REWARDS = 'lockedRewards',
     CUSTOM_REWARDS = 'customRewards',
+    DEPRECATED = 'deprecated',
 }
 
 registerEnumType(FarmVersion, { name: 'FarmVersion' });

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -14,11 +14,14 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
 import { IPairComputeService } from '../interfaces';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { computeValueUSD, denominateAmount } from 'src/utils/token.converters';
-import { farmsAddresses } from 'src/utils/farm.utils';
+import { farmsAddresses, farmType } from 'src/utils/farm.utils';
 import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
 import { StakingProxyAbiService } from 'src/modules/staking-proxy/services/staking.proxy.abi.service';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
-import { FarmVersion } from 'src/modules/farm/models/farm.model';
+import {
+    FarmRewardType,
+    FarmVersion,
+} from 'src/modules/farm/models/farm.model';
 import { FarmAbiServiceV2 } from 'src/modules/farm/v2/services/farm.v2.abi.service';
 import { FarmComputeServiceV2 } from 'src/modules/farm/v2/services/farm.v2.compute.service';
 import { StakingComputeService } from 'src/modules/staking/services/staking.compute.service';
@@ -676,7 +679,9 @@ export class PairComputeService implements IPairComputeService {
     }
 
     async computeHasFarms(pairAddress: string): Promise<boolean> {
-        const addresses: string[] = farmsAddresses([FarmVersion.V2]);
+        const addresses: string[] = farmsAddresses([FarmVersion.V2]).filter(
+            (address) => farmType(address) !== FarmRewardType.DEPRECATED,
+        );
         const lpTokenID = await this.pairAbi.lpTokenID(pairAddress);
 
         const farmingTokenIDs = await Promise.all(
@@ -788,7 +793,10 @@ export class PairComputeService implements IPairComputeService {
             return undefined;
         }
 
-        const addresses: string[] = farmsAddresses([FarmVersion.V2]);
+        const addresses: string[] = farmsAddresses([FarmVersion.V2]).filter(
+            (address) => farmType(address) !== FarmRewardType.DEPRECATED,
+        );
+
         const lpTokenID = await this.pairAbi.lpTokenID(pairAddress);
 
         const farmingTokenIDs = await Promise.all(

--- a/src/utils/farm.utils.ts
+++ b/src/utils/farm.utils.ts
@@ -27,6 +27,8 @@ const toRewardTypeEnum = (rewardType: string): FarmRewardType => {
             return FarmRewardType.LOCKED_REWARDS;
         case 'customRewards':
             return FarmRewardType.CUSTOM_REWARDS;
+        case 'deprecated':
+            return FarmRewardType.DEPRECATED;
     }
 };
 
@@ -83,7 +85,7 @@ export const farmType = (farmAddress: string): FarmRewardType | undefined => {
 export const farmsAddresses = (versions?: string[]): string[] => {
     const addresses = [];
     if (versions === undefined || versions.length === 0) {
-        versions = Object.keys(farmsConfig)
+        versions = Object.keys(farmsConfig);
     }
     for (const version of versions) {
         if (Array.isArray(farmsConfig[version])) {


### PR DESCRIPTION
## Reasoning
- deployed new MEX/EGLD farm
- current MEX/EGLD farm will be deprecated
  
## Proposed Changes
- added `deprecated` farm type for v2 farm models
- updated pair compute methods to use only active v2 farm addresses

## How to test
```
query farmsPageDataQuery {
  farms(
    filters: {
        versions: ["v2"]
    }
  ) {
    ...on FarmModelV2 {
        address
        farmToken {
            collection
        }
        rewardType
    }
  }
}
```
- query should return `deprecated` for current MEX/EGLD farm reward type