### PR TITLE
[MEX-533] Fix farm user rewards for week

### DIFF
--- a/src/modules/farm/v2/services/farm.v2.compute.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.compute.service.ts
@@ -371,12 +371,6 @@ export class FarmComputeServiceV2
             farmedTokenPriceUSD,
         );
 
-        console.log({
-            rewardsPerWeekUSD: userRewardsPerWeekUSD.toFixed(),
-            totalFarmPositionUSD: userTotalFarmPositionUSD.toFixed(),
-            additionalUserEnergy,
-        });
-
         return new BigNumber(userRewardsPerWeekUSD)
             .multipliedBy(52)
             .dividedBy(userTotalFarmPositionUSD)

--- a/src/modules/farm/v2/services/farm.v2.compute.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.compute.service.ts
@@ -250,6 +250,9 @@ export class FarmComputeServiceV2
                 ? await this.farmAbi.farmTokenSupply(scAddress)
                 : await this.farmAbi.farmSupplyForWeek(scAddress, week);
 
+        userEnergyForWeek.amount = new BigNumber(userEnergyForWeek.amount)
+            .plus(additionalUserEnergyAmount)
+            .toFixed();
         totalEnergyForWeek = new BigNumber(totalEnergyForWeek)
             .plus(additionalUserEnergyAmount)
             .toFixed();
@@ -367,6 +370,12 @@ export class FarmComputeServiceV2
             farmedToken.decimals,
             farmedTokenPriceUSD,
         );
+
+        console.log({
+            rewardsPerWeekUSD: userRewardsPerWeekUSD.toFixed(),
+            totalFarmPositionUSD: userTotalFarmPositionUSD.toFixed(),
+            additionalUserEnergy,
+        });
 
         return new BigNumber(userRewardsPerWeekUSD)
             .multipliedBy(52)


### PR DESCRIPTION
## Reasoning
- `curentBoostedAPR` computation for farm positions is not increasing when `additionalUserEnergy` is provided

  
## Proposed Changes
- add `additionalUserEnergyAmount` to user energy when computing user rewards for week


## How to test
```
query {
  getFarmBoostedRewardsBatch(
    farmsAddresses: [
      "erd1qqqqqqqqqqqqqpgqapxdp9gjxtg60mjwhle3n6h88zch9e7kkp2s8aqhkg",
    ]
  ) {
    farmAddress
    curentBoostedAPR(
      additionalUserEnergy: "1000000000000000000000000000000"
    )
  }
}
```
