### PR TITLE
[MEX-532] added gas config for deprecated farm type

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -241,6 +241,17 @@
                     },
                     "claimRewards": 30000000
                 },
+                "deprecated": {
+                    "exitFarm": {
+                        "default": 30300000,
+                        "withPenalty": {
+                            "localBurn": 36000000,
+                            "pairBurn": 33000000,
+                            "buybackAndBurn": 48300000
+                        }
+                    },
+                    "claimRewards": 30000000
+                },
                 "claimBoostedRewards": 30000000
             },
             "admin": {
@@ -377,6 +388,17 @@
                             }
                         },
                         "claimRewards": 20700000
+                    },
+                    "deprecated": {
+                        "exitFarm": {
+                            "default": 30000000,
+                            "withPenalty": {
+                                "localBurn": 32000000,
+                                "pairBurn": 51000000,
+                                "buybackAndBurn": 56000000
+                            }
+                        },
+                        "claimRewards": 41500000
                     },
                     "increaseEnergy": 20000000
                 },


### PR DESCRIPTION
## Reasoning
- missing gas limits configs for deprecated farm type
  
## Proposed Changes
- added missing gas limits config into default config file

## How to test
```
query ExitFarm {
    exitFarm(
        farmAddress: "erd1qqqqqqqqqqqqqpgqqjpfmappkpzq6kdju3mkqepk3d2kcymu0n4srd45sa",
        farmTokenID: "EGLDMEXFL-2ed783",
        farmTokenNonce: 60,
        amount: "2452220725944649483",
        exitAmount: "2452220725944649483"
    ) {
        gasLimit
        data
    }
}
```
- query should return transaction