### PR TITLE
[MEX-532] Update current MEX/EGLD farm type to deprecated

### DIFF
--- a/src/config/mainnet.json
+++ b/src/config/mainnet.json
@@ -87,7 +87,7 @@
         },
         "v2": {
             "lockedRewards": [
-                "erd1qqqqqqqqqqqqqpgqapxdp9gjxtg60mjwhle3n6h88zch9e7kkp2s8aqhkg",
+                "erd1qqqqqqqqqqqqqpgqtdc0rzjwmp9qs0h0wj9pjwxnp5vjc9hdkp2swd4dxz",
                 "erd1qqqqqqqqqqqqqpgqv0pz5z3fkz54nml6pkzzdruuf020gqzykp2sya7kkv",
                 "erd1qqqqqqqqqqqqqpgqenvn0s3ldc94q2mlkaqx4arj3zfnvnmakp2sxca2h9",
                 "erd1qqqqqqqqqqqqqpgqrdq6zvepdxg36rey8pmluwur43q4hcx3kp2su4yltq",
@@ -106,6 +106,9 @@
                 "erd1qqqqqqqqqqqqqpgq4se997u3eyhjmpwaa57lvdgvmyn23yqpx9rsdzja7j",
                 "erd1qqqqqqqqqqqqqpgqhh8lke0kfch0g20jrmskczwq86d23qhex9rs5hm4uk",
                 "erd1qqqqqqqqqqqqqpgqgjqu7c0mq8a4jd4d43st44gvwhduvqaxkp2s7vsq64"
+            ],
+            "deprecated": [
+                "erd1qqqqqqqqqqqqqpgqapxdp9gjxtg60mjwhle3n6h88zch9e7kkp2s8aqhkg"
             ]
         }
     },


### PR DESCRIPTION
## Reasoning
- new MEX/EGLD farm deployed
  
## Proposed Changes
- move current MEX/EGLD farm to deprecated
- add new MEX/EGLD farm address on mainnet config

## How to test
- N/A
