### PR TITLE
[MEX-527] Memory Store Apollo plugin

### DIFF
--- a/src/modules/memory-store/entities/global.state.ts
+++ b/src/modules/memory-store/entities/global.state.ts
@@ -1,0 +1,30 @@
+import { PairModel } from 'src/modules/pair/models/pair.model';
+import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
+
+export enum GlobalStateInitStatus {
+    NOT_STARTED = 'NOT_STARTED',
+    IN_PROGRESS = 'IN_PROGRESS',
+    DONE = 'DONE',
+    FAILED = 'FAILED',
+}
+
+export class PairEsdtTokens {
+    firstTokenID: string;
+    secondTokenID: string;
+    lpTokenID: string;
+    dualFarmRewardTokenID: string;
+
+    constructor(init?: Partial<PairEsdtTokens>) {
+        Object.assign(this, init);
+    }
+}
+
+export class GlobalStateSingleton {
+    public pairsState: { [key: string]: PairModel } = {};
+    public pairsEsdtTokens: { [key: string]: PairEsdtTokens } = {};
+    public tokensState: { [key: string]: EsdtToken } = {};
+    public initStatus: GlobalStateInitStatus =
+        GlobalStateInitStatus.NOT_STARTED;
+}
+
+export const GlobalState = new GlobalStateSingleton();

--- a/src/modules/memory-store/entities/query.field.type.ts
+++ b/src/modules/memory-store/entities/query.field.type.ts
@@ -1,0 +1,4 @@
+export type QueryField = {
+    name: string;
+    subfields?: QueryField[];
+};

--- a/src/modules/memory-store/memory.store.module.ts
+++ b/src/modules/memory-store/memory.store.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { MemoryStoreFactoryService } from './services/memory.store.factory.service';
+
+@Module({
+    providers: [MemoryStoreFactoryService],
+    exports: [MemoryStoreFactoryService],
+})
+export class MemoryStoreModule {}

--- a/src/modules/memory-store/memory.store.plugin.ts
+++ b/src/modules/memory-store/memory.store.plugin.ts
@@ -1,0 +1,264 @@
+import {
+    ApolloServerPlugin,
+    GraphQLRequestListener,
+    GraphQLResponse,
+} from '@apollo/server';
+import { Plugin } from '@nestjs/apollo';
+import { FieldNode, Kind, SelectionNode } from 'graphql';
+import {
+    extractFilteredQueryEdgeNodes,
+    extractQueryFields,
+    parseArguments,
+    updateFilteredQueryEdgeNodes,
+} from './utils/graphql.utils';
+import { QueryField } from './entities/query.field.type';
+import { MemoryStoreFactoryService } from './services/memory.store.factory.service';
+
+@Plugin()
+export class MemoryStoreApolloPlugin implements ApolloServerPlugin {
+    constructor(
+        private readonly memoryStoreFactory: MemoryStoreFactoryService,
+    ) {}
+
+    async requestDidStart(): Promise<GraphQLRequestListener<any>> {
+        const memoryStoreFactory = this.memoryStoreFactory;
+
+        const storeResolvableQueries: Array<{
+            queryName: string;
+            queryAlias?: string;
+            isFiltered: boolean;
+            requestedFields: QueryField[];
+            arguments: Record<string, any>;
+        }> = [];
+
+        return {
+            async responseForOperation(
+                requestContext,
+            ): Promise<GraphQLResponse | null> {
+                if (!memoryStoreFactory.isReady()) {
+                    return null;
+                }
+
+                const targetedQueryNames =
+                    memoryStoreFactory.getTargetedQueryNames();
+
+                const requestSelections =
+                    requestContext.operation.selectionSet.selections;
+
+                // Separate selections into those that can be resolved from the store and those that need normal resolution
+                const normalSelections: SelectionNode[] = [];
+                for (const selection of requestSelections) {
+                    if (selection.kind !== Kind.FIELD) {
+                        normalSelections.push(selection);
+                        continue;
+                    }
+
+                    const queryName = selection.name.value;
+                    if (!targetedQueryNames.includes(queryName)) {
+                        normalSelections.push(selection);
+                        continue;
+                    }
+
+                    const targetedQueries = memoryStoreFactory
+                        .useService(queryName)
+                        .getTargetedQueries();
+
+                    const { missingFields, isFiltered, identifierField } =
+                        targetedQueries[queryName];
+
+                    const actualNodes = isFiltered
+                        ? extractFilteredQueryEdgeNodes(
+                              selection.selectionSet?.selections,
+                          )
+                        : selection.selectionSet?.selections || [];
+
+                    if (!actualNodes) {
+                        normalSelections.push(selection);
+                        continue;
+                    }
+
+                    const { storeNodes, normalNodes, identifierNode } =
+                        partitionSelectionNodes(
+                            actualNodes,
+                            missingFields,
+                            identifierField,
+                        );
+
+                    if (storeNodes.length > 0) {
+                        storeResolvableQueries.push({
+                            queryName,
+                            queryAlias: selection.alias?.value,
+                            requestedFields: extractQueryFields(storeNodes),
+                            arguments: parseArguments(
+                                selection.arguments,
+                                requestContext.request.variables,
+                            ),
+                            isFiltered,
+                        });
+                    }
+
+                    if (normalNodes.length > 0) {
+                        if (!identifierNode) {
+                            // Cannot map store data without the identifier field
+                            storeResolvableQueries.length = 0;
+                            return null;
+                        }
+
+                        // Ensure identifier node is included
+                        normalNodes.push(identifierNode);
+
+                        // Update the selection set accordingly
+                        selection.selectionSet.selections = isFiltered
+                            ? updateFilteredQueryEdgeNodes(
+                                  selection.selectionSet.selections,
+                                  normalNodes,
+                              )
+                            : normalNodes;
+
+                        normalSelections.push(selection);
+                    }
+                }
+
+                // If there are normal selections, proceed with the normal request flow
+                if (normalSelections.length > 0) {
+                    requestContext.operation.selectionSet.selections =
+                        normalSelections;
+                    requestContext.contextValue.storeResolve =
+                        storeResolvableQueries.length > 0
+                            ? 'partial'
+                            : undefined;
+
+                    return null;
+                }
+
+                // If no queries can be resolved from the store, proceed normally
+                if (storeResolvableQueries.length === 0) {
+                    return null;
+                }
+
+                // Fully resolve from store
+                const data = resolveQueriesFromStore(
+                    storeResolvableQueries,
+                    memoryStoreFactory,
+                );
+
+                // Clear the processed queries since we're returning the response here
+                storeResolvableQueries.length = 0;
+
+                requestContext.contextValue.storeResolve = 'full';
+
+                return {
+                    body: {
+                        kind: 'single',
+                        singleResult: {
+                            data: data,
+                        },
+                    },
+                    http: requestContext.response.http,
+                };
+            },
+            async willSendResponse(requestContext): Promise<void> {
+                if (
+                    storeResolvableQueries.length === 0 ||
+                    requestContext.response.body.kind !== 'single'
+                ) {
+                    return;
+                }
+
+                const responseData =
+                    requestContext.response.body.singleResult.data;
+
+                for (const storeQuery of storeResolvableQueries) {
+                    const queryKey =
+                        storeQuery.queryAlias || storeQuery.queryName;
+
+                    if (!responseData[queryKey]) {
+                        // Query was not resolved; resolve entirely from store
+                        responseData[queryKey] = memoryStoreFactory
+                            .useService(storeQuery.queryName)
+                            .getQueryResponse(
+                                storeQuery.queryName,
+                                storeQuery.arguments,
+                                storeQuery.requestedFields,
+                            );
+
+                        continue;
+                    } else {
+                        // Append fields from the store to the partially resolved response
+                        responseData[queryKey] = memoryStoreFactory
+                            .useService(storeQuery.queryName)
+                            .appendFieldsToQueryResponse(
+                                storeQuery.queryName,
+                                responseData[queryKey],
+                                storeQuery.requestedFields,
+                            );
+                    }
+                }
+            },
+        };
+    }
+}
+
+/**
+ * Partitions selection nodes into store-resolvable nodes, normal nodes, and identifies the identifier node.
+ */
+function partitionSelectionNodes(
+    nodes: ReadonlyArray<SelectionNode>,
+    missingFields: QueryField[],
+    identifierField: string,
+) {
+    const storeNodes: SelectionNode[] = [];
+    const normalNodes: SelectionNode[] = [];
+    let identifierNode: FieldNode | undefined;
+
+    for (const node of nodes) {
+        if (node.kind !== Kind.FIELD) {
+            normalNodes.push(node);
+            continue;
+        }
+
+        const isMissingField = missingFields.some(
+            (field) => field.name === node.name.value,
+        );
+
+        if (isMissingField) {
+            normalNodes.push(node);
+        } else if (node.name.value === identifierField) {
+            identifierNode = node;
+            storeNodes.push(node);
+        } else {
+            storeNodes.push(node);
+        }
+    }
+
+    return { storeNodes, normalNodes, identifierNode };
+}
+
+/**
+ * Resolves a list of queries entirely from the memory store.
+ */
+function resolveQueriesFromStore(
+    queries: Array<{
+        queryName: string;
+        queryAlias?: string;
+        requestedFields: QueryField[];
+        arguments: Record<string, any>;
+    }>,
+    memoryStoreFactory: MemoryStoreFactoryService,
+) {
+    const data: Record<string, any> = {};
+
+    for (const query of queries) {
+        const result = memoryStoreFactory
+            .useService(query.queryName)
+            .getQueryResponse(
+                query.queryName,
+                query.arguments,
+                query.requestedFields,
+            );
+        const key = query.queryAlias || query.queryName;
+        data[key] = result;
+    }
+
+    return data;
+}

--- a/src/modules/memory-store/services/interfaces.ts
+++ b/src/modules/memory-store/services/interfaces.ts
@@ -1,0 +1,25 @@
+import { QueryField } from '../entities/query.field.type';
+
+export abstract class IMemoryStoreService<T, V> {
+    abstract isReady(): boolean;
+    abstract getAllData(): T[] | T;
+    abstract getQueryResponse(
+        queryName: string,
+        queryArguments: Record<string, any>,
+        requestedFields: QueryField[],
+    ): T[] | V;
+    abstract appendFieldsToQueryResponse(
+        queryName: string,
+        response: T[] | V,
+        requestedFields: QueryField[],
+    ): T[] | V;
+    abstract getTargetedQueries(): Record<
+        string,
+        {
+            isFiltered: boolean;
+            missingFields: QueryField[];
+            identifierField: string;
+        }
+    >;
+    abstract getTypenameMapping(): Record<string, Record<string, string>>;
+}

--- a/src/modules/memory-store/services/memory.store.factory.service.ts
+++ b/src/modules/memory-store/services/memory.store.factory.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { IMemoryStoreService } from './interfaces';
+
+@Injectable()
+export class MemoryStoreFactoryService {
+    private queryMapping: Record<string, IMemoryStoreService<any, any>> = {};
+
+    isReady(): boolean {
+        // TODO: replace with actual checks on compatible memory store services
+        return false;
+    }
+
+    getTargetedQueryNames(): string[] {
+        return Object.keys(this.queryMapping);
+    }
+
+    useService(queryName: string): IMemoryStoreService<any, any> {
+        if (!this.queryMapping[queryName]) {
+            throw new Error(`Query ${queryName} cannot be resolved from store`);
+        }
+        return this.queryMapping[queryName];
+    }
+}

--- a/src/modules/memory-store/utils/graphql.utils.ts
+++ b/src/modules/memory-store/utils/graphql.utils.ts
@@ -1,0 +1,125 @@
+import {
+    ArgumentNode,
+    FieldNode,
+    Kind,
+    SelectionNode,
+    ValueNode,
+} from 'graphql';
+import { QueryField } from '../entities/query.field.type';
+
+export function extractQueryFields(
+    selectionNodes: readonly SelectionNode[],
+): QueryField[] {
+    const fields: QueryField[] = [];
+
+    selectionNodes
+        .filter((node): node is FieldNode => node.kind === Kind.FIELD)
+        .forEach((node) => {
+            if (node.selectionSet) {
+                const subfields = extractQueryFields(
+                    node.selectionSet.selections,
+                );
+
+                fields.push({
+                    name: node.name.value,
+                    subfields: subfields,
+                });
+            } else {
+                fields.push({
+                    name: node.name.value,
+                });
+            }
+        });
+
+    return fields;
+}
+
+export function extractFilteredQueryEdgeNodes(
+    selectionNodes: readonly SelectionNode[],
+): readonly SelectionNode[] {
+    for (const node of selectionNodes) {
+        if (node.kind !== Kind.FIELD || node.name.value !== 'edges') {
+            continue;
+        }
+
+        const edgesNode = node.selectionSet?.selections.find(
+            (selection) =>
+                selection.kind === Kind.FIELD &&
+                selection.name.value === 'node',
+        );
+
+        if (edgesNode) {
+            return (edgesNode as FieldNode).selectionSet.selections;
+        }
+    }
+
+    return undefined;
+}
+
+export function updateFilteredQueryEdgeNodes(
+    existingNodes: readonly SelectionNode[],
+    newNodes: readonly SelectionNode[],
+): readonly SelectionNode[] {
+    for (const node of existingNodes) {
+        if (node.kind !== Kind.FIELD || node.name.value !== 'edges') {
+            continue;
+        }
+
+        const edgesNode = node.selectionSet?.selections.find(
+            (selection) =>
+                selection.kind === Kind.FIELD &&
+                selection.name.value === 'node',
+        );
+
+        if (edgesNode) {
+            (edgesNode as FieldNode).selectionSet.selections = newNodes;
+        }
+    }
+    return existingNodes;
+}
+
+export function parseArguments(
+    argumentsArray: ReadonlyArray<ArgumentNode>,
+    variables: Record<string, any>,
+): Record<string, any> {
+    const args: Record<string, any> = {};
+    for (const argNode of argumentsArray) {
+        const argName = argNode.name.value;
+        const argValue = resolveValueNode(argNode.value, variables);
+        args[argName] = argValue;
+    }
+    return args;
+}
+
+function resolveValueNode(
+    valueNode: ValueNode,
+    variables: Record<string, any>,
+): any {
+    switch (valueNode.kind) {
+        case Kind.INT:
+            return parseInt(valueNode.value, 10);
+        case Kind.FLOAT:
+            return parseFloat(valueNode.value);
+        case Kind.STRING:
+        case Kind.BOOLEAN:
+        case Kind.ENUM:
+            return valueNode.value;
+        case Kind.LIST:
+            return valueNode.values.map((value) =>
+                resolveValueNode(value, variables),
+            );
+        case Kind.OBJECT:
+            const obj: Record<string, any> = {};
+            for (const field of valueNode.fields) {
+                obj[field.name.value] = resolveValueNode(
+                    field.value,
+                    variables,
+                );
+            }
+            return obj;
+        case Kind.VARIABLE:
+            return variables[valueNode.name.value];
+        case Kind.NULL:
+            return null;
+    }
+}

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -40,6 +40,8 @@ import { PositionCreatorModule } from './modules/position-creator/position.creat
 import { ComposableTasksModule } from './modules/composable-tasks/composable.tasks.module';
 import { TradingViewModule } from './modules/trading-view/trading.view.module';
 import { QueryMetricsPlugin } from './utils/query.metrics.plugin';
+import { MemoryStoreApolloPlugin } from './modules/memory-store/memory.store.plugin';
+import { MemoryStoreModule } from './modules/memory-store/memory.store.module';
 
 @Module({
     imports: [
@@ -73,6 +75,7 @@ import { QueryMetricsPlugin } from './utils/query.metrics.plugin';
                     };
                 },
                 fieldResolverEnhancers: ['guards'],
+                documentStore: null,
             }),
             inject: [WINSTON_MODULE_NEST_PROVIDER],
         }),
@@ -103,8 +106,9 @@ import { QueryMetricsPlugin } from './utils/query.metrics.plugin';
         ComposableTasksModule,
         DynamicModuleUtils.getCacheModule(),
         TradingViewModule,
+        MemoryStoreModule,
     ],
-    providers: [QueryMetricsPlugin],
+    providers: [MemoryStoreApolloPlugin, QueryMetricsPlugin],
 })
 export class PublicAppModule {
     configure(consumer: MiddlewareConsumer) {


### PR DESCRIPTION
## Reasoning
- the API sufferes from performance degradation in high concurrent requests scenarios. This happens due to the high number of fields with resolver functions and the highly nested nature of certain models. 
- the method propsed below, is meant to reduce load with the following strategy :
1. maintain certain complex models in a singleton (memory store)
2. hook into the graphQL lifecycle (bypass the regular resolve route) and return the data directly from the memory store
- this PR tackles point 2
  
## Proposed Changes
- add singleton that will hold all pairs, all esdt tokens and the mapping pair<>esdt_tokens in memory
- add interface (actually abstract class) that describes the behaviour of a service capable of returning response from the memory store based on a graphQL query
- add a memory store factory service that abstracts away the underlying memory store services
- add Apollo server plugin that attempts to resolve queries (partially or completely) from the memory store using the memory store factory
- append `-store_partial` or `-store_full` to the metrics key of queries resolved from the memory store

## How to test
- N/A
