### PR TITLE
[MEX-622] Reduce filtered queries search arg min length to 1

### DIFF
--- a/src/modules/pair/services/pair.filtering.service.ts
+++ b/src/modules/pair/services/pair.filtering.service.ts
@@ -88,7 +88,7 @@ export class PairFilteringService {
     ): Promise<PairMetadata[]> {
         if (
             !pairFilter.searchToken ||
-            pairFilter.searchToken.trim().length < 3
+            pairFilter.searchToken.trim().length < 1
         ) {
             return pairsMetadata;
         }

--- a/src/modules/tokens/services/token.filtering.service.ts
+++ b/src/modules/tokens/services/token.filtering.service.ts
@@ -53,7 +53,7 @@ export class TokenFilteringService {
     ): Promise<EsdtToken[]> {
         if (
             !tokensFilter.searchToken ||
-            tokensFilter.searchToken.trim().length < 3
+            tokensFilter.searchToken.trim().length < 1
         ) {
             return tokens;
         }


### PR DESCRIPTION
## Reasoning
- filtering only happens if the argument is at least 3 characters long
  
## Proposed Changes
- reduce min length to 1

## How to test
- `filteredPairs` or `filteredTokens` queries using the `searchToken` filter argument should return filtered data if the string is at least 1 character long 
