### PR TITLE
[MEX-650] Fix user outdated contracts when no rewards are produced

### DIFF
--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -133,22 +133,44 @@ export class UserEnergyComputeService {
         const farmService = this.farmService.useService(
             contractAddress,
         ) as FarmServiceV2;
-        const [currentClaimProgress, currentWeek, farmToken, userEnergy] =
-            await Promise.all([
-                this.weeklyRewardsSplittingAbi.currentClaimProgress(
-                    contractAddress,
-                    userAddress,
-                ),
-                this.weekTimekeepingAbi.currentWeek(contractAddress),
-                farmService.getFarmToken(contractAddress),
-                this.energyAbi.energyEntryForUser(userAddress),
-            ]);
+        const [
+            currentClaimProgress,
+            currentWeek,
+            farmToken,
+            userEnergy,
+            produceRewardsEnabled,
+        ] = await Promise.all([
+            this.weeklyRewardsSplittingAbi.currentClaimProgress(
+                contractAddress,
+                userAddress,
+            ),
+            this.weekTimekeepingAbi.currentWeek(contractAddress),
+            farmService.getFarmToken(contractAddress),
+            this.energyAbi.energyEntryForUser(userAddress),
+            this.farmAbi
+                .useAbi(contractAddress)
+                .produceRewardsEnabled(contractAddress),
+        ]);
 
         if (currentClaimProgress.week === 0) {
             return new OutdatedContract();
         }
 
+        const claimProgressTotalRewards =
+            await this.weeklyRewardsSplittingAbi.totalRewardsForWeek(
+                contractAddress,
+                currentClaimProgress.week,
+            );
+
         const outdatedClaimProgress = currentClaimProgress.week !== currentWeek;
+
+        if (
+            !produceRewardsEnabled &&
+            outdatedClaimProgress &&
+            claimProgressTotalRewards[0].amount === '0'
+        ) {
+            return new OutdatedContract();
+        }
 
         if (
             this.isEnergyOutdated(userEnergy, currentClaimProgress) ||
@@ -161,6 +183,7 @@ export class UserEnergyComputeService {
                 farmToken: farmToken.collection,
             });
         }
+
         return new OutdatedContract();
     }
 
@@ -189,9 +212,19 @@ export class UserEnergyComputeService {
             return new OutdatedContract();
         }
 
+        const claimProgressTotalRewards =
+            await this.weeklyRewardsSplittingAbi.totalRewardsForWeek(
+                contractAddress,
+                currentClaimProgress.week,
+            );
+
         const outdatedClaimProgress = currentClaimProgress.week !== currentWeek;
 
-        if (!isProducingRewards && !outdatedClaimProgress) {
+        if (
+            !isProducingRewards &&
+            outdatedClaimProgress &&
+            claimProgressTotalRewards[0].amount === '0'
+        ) {
             return new OutdatedContract();
         }
 
@@ -206,6 +239,7 @@ export class UserEnergyComputeService {
                 farmToken: farmToken.collection,
             });
         }
+
         return new OutdatedContract();
     }
 


### PR DESCRIPTION
## Reasoning
- user outdated contracts were added to the list even though the contract was not producing rewards anymore
- it should not be an outdated contract if there are no rewards being produced and the total rewards distributed in the current claim progress week for user is `0`
  
## Proposed Changes
- added a check for the total rewards distributed for the user current claim progress

## How to test
```
query UserOutdatedContracts {
    userOutdatedContracts {
        address
        type
        farmToken
        claimProgressOutdated
    }
}
```
- query should not include contracts with stopped rewards for which user already claimed all the rewards