### PR TITLE
[MEX-650] Fix undefined amount in compute outdated contracts

### DIFF
--- a/src/modules/user/services/userEnergy/user.energy.compute.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.compute.service.ts
@@ -167,7 +167,8 @@ export class UserEnergyComputeService {
         if (
             !produceRewardsEnabled &&
             outdatedClaimProgress &&
-            claimProgressTotalRewards[0].amount === '0'
+            (claimProgressTotalRewards.length === 0 ||
+                claimProgressTotalRewards[0].amount === '0')
         ) {
             return new OutdatedContract();
         }
@@ -223,7 +224,8 @@ export class UserEnergyComputeService {
         if (
             !isProducingRewards &&
             outdatedClaimProgress &&
-            claimProgressTotalRewards[0].amount === '0'
+            (claimProgressTotalRewards.length === 0 ||
+                claimProgressTotalRewards[0].amount === '0')
         ) {
             return new OutdatedContract();
         }


### PR DESCRIPTION
## Reasoning
- Cannot read properties of undefined (reading 'amount')
  
## Proposed Changes
- added check for length of `claimProgressTotalRewards` array

## How to test
- N/A
