### PR TITLE
[MEX-658] fix analytics total value locked

### DIFF
--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -136,9 +136,6 @@ export class AWSQueryCacheWarmerService {
         const timestampsSetCompleteValues = new Set<string>();
 
         for (const pairAddress of pairsAddresses) {
-            const index = pairsAddresses.indexOf(pairAddress);
-            console.log(`pair ${index} / ${pairsAddresses.length}`);
-
             const currentLockedValueUSD = await this.pairCompute.lockedValueUSD(
                 pairAddress,
             );


### PR DESCRIPTION
## Reasoning
- current implementation does not provide flexibility to choose which pairs are taken into account for total value locked chart from analytics
  
## Proposed Changes
- compute total value locked in USD value over 24h and complete values using all the data points from each pair
- added logic inside `updateHistoricTokensData` method to store all the pairs data and use them for compute

## How to test
- N/A
