### PR TITLE
[MEX-663] Fix tokens liquidity

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -653,7 +653,7 @@
           "VOLUME_WEIGHT": 0.25,
           "TRADES_COUNT_WEIGHT": 0.25
         },
-        "AWS_QUERY_CACHE_WARMER_DELAY": 100
+        "AWS_QUERY_CACHE_WARMER_DELAY": 50
     },
     "dataApi": {
         "tableName": "XEXCHANGE_ANALYTICS"

--- a/src/modules/pair/services/pair.compute.loader.ts
+++ b/src/modules/pair/services/pair.compute.loader.ts
@@ -86,14 +86,8 @@ export class PairComputeLoader {
         string
     >(
         async (addresses: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
+            return await this.pairCompute.getAllFirstTokensLockedValueUSD(
                 addresses,
-                'pair.firstTokenLockedValueUSD',
-                this.pairCompute.firstTokenLockedValueUSD.bind(
-                    this.pairCompute,
-                ),
-                CacheTtlInfo.ContractInfo,
             );
         },
         {
@@ -106,14 +100,8 @@ export class PairComputeLoader {
         string
     >(
         async (addresses: string[]) => {
-            return await getAllKeys(
-                this.cacheService,
+            return await this.pairCompute.getAllSecondTokensLockedValueUSD(
                 addresses,
-                'pair.secondTokenLockedValueUSD',
-                this.pairCompute.secondTokenLockedValueUSD.bind(
-                    this.pairCompute,
-                ),
-                CacheTtlInfo.ContractInfo,
             );
         },
         {

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -313,6 +313,18 @@ export class PairComputeService implements IPairComputeService {
             .multipliedBy(firstTokenPriceUSD);
     }
 
+    async getAllFirstTokensLockedValueUSD(
+        pairAddresses: string[],
+    ): Promise<string[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.firstTokenLockedValueUSD',
+            this.firstTokenLockedValueUSD.bind(this),
+            CacheTtlInfo.ContractInfo,
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })
@@ -341,6 +353,18 @@ export class PairComputeService implements IPairComputeService {
         return new BigNumber(secondTokenReserve)
             .multipliedBy(`1e-${secondToken.decimals}`)
             .multipliedBy(secondTokenPriceUSD);
+    }
+
+    async getAllSecondTokensLockedValueUSD(
+        pairAddresses: string[],
+    ): Promise<string[]> {
+        return await getAllKeys(
+            this.cachingService,
+            pairAddresses,
+            'pair.secondTokenLockedValueUSD',
+            this.secondTokenLockedValueUSD.bind(this),
+            CacheTtlInfo.ContractInfo,
+        );
     }
 
     @ErrorLoggerAsync({

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -363,6 +363,18 @@ export class PairComputeService implements IPairComputeService {
                 this.computeSecondTokenLockedValueUSD(pairAddress),
             ]);
 
+        if (
+            new BigNumber(firstTokenLockedValueUSD)
+                .minus(secondTokenLockedValueUSD)
+                .abs()
+                .gt(1000000)
+        ) {
+            return BigNumber.min(
+                firstTokenLockedValueUSD,
+                secondTokenLockedValueUSD,
+            );
+        }
+
         return new BigNumber(firstTokenLockedValueUSD).plus(
             secondTokenLockedValueUSD,
         );

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -554,8 +554,9 @@ export class TokenComputeService implements ITokenComputeService {
             this.routerAbi.commonTokensForUserPairs(),
         ]);
 
-        const relevantPairs = pairs.filter((pair) =>
-            [pair.firstTokenID, pair.secondTokenID].includes(tokenID),
+        const relevantPairs = pairs.filter(
+            (pair) =>
+                tokenID === pair.firstTokenID || pair.secondTokenID === tokenID,
         );
 
         const [
@@ -596,10 +597,8 @@ export class TokenComputeService implements ITokenComputeService {
             }
 
             if (
-                commonTokenIDs.includesNone([
-                    pair.firstTokenID,
-                    pair.secondTokenID,
-                ])
+                !commonTokenIDs.includes(pair.firstTokenID) &&
+                !commonTokenIDs.includes(pair.secondTokenID)
             ) {
                 continue;
             }

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -26,7 +26,6 @@ import moment from 'moment';
 import { PendingExecutor } from 'src/utils/pending.executor';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { TokenService } from './token.service';
-import { computeValueUSD } from 'src/utils/token.converters';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import { ElasticSearchEventsService } from 'src/services/elastic-search/services/es.events.service';
 
@@ -551,32 +550,51 @@ export class TokenComputeService implements ITokenComputeService {
 
     async computeTokenLiquidityUSD(tokenID: string): Promise<string> {
         const pairs = await this.routerAbi.pairsMetadata();
-        const priceUSD = await this.tokenPriceDerivedUSD(tokenID);
-        const tokenMetadata = await this.tokenService.tokenMetadata(tokenID);
-        const promises = [];
-        for (const pair of pairs) {
-            switch (tokenID) {
-                case pair.firstTokenID:
-                    promises.push(this.pairAbi.firstTokenReserve(pair.address));
-                    break;
-                case pair.secondTokenID:
-                    promises.push(
-                        this.pairAbi.secondTokenReserve(pair.address),
-                    );
-                    break;
-            }
-        }
-        const allLockedValues = await Promise.all(promises);
-        let newLockedValue = new BigNumber(0);
-        allLockedValues.forEach((value) => {
-            newLockedValue = newLockedValue.plus(value);
-        });
 
-        return computeValueUSD(
-            newLockedValue.toFixed(),
-            tokenMetadata.decimals,
-            priceUSD,
-        ).toFixed();
+        const relevantPairs = pairs.filter((pair) =>
+            [pair.firstTokenID, pair.secondTokenID].includes(tokenID),
+        );
+
+        const [allFirstTokensLockedValueUSD, allSecondTokensLockedValueUSD] =
+            await Promise.all([
+                this.pairCompute.getAllFirstTokensLockedValueUSD(
+                    relevantPairs.map((pair) => pair.address),
+                ),
+                this.pairCompute.getAllSecondTokensLockedValueUSD(
+                    relevantPairs.map((pair) => pair.address),
+                ),
+            ]);
+
+        let newLockedValue = new BigNumber(0);
+        for (const [index, pair] of relevantPairs.entries()) {
+            const firstTokenLockedValueUSD =
+                allFirstTokensLockedValueUSD[index];
+            const secondTokenLockedValueUSD =
+                allSecondTokensLockedValueUSD[index];
+
+            if (
+                new BigNumber(firstTokenLockedValueUSD)
+                    .minus(secondTokenLockedValueUSD)
+                    .abs()
+                    .gt(1000000)
+            ) {
+                newLockedValue = newLockedValue.plus(
+                    BigNumber.min(
+                        firstTokenLockedValueUSD,
+                        secondTokenLockedValueUSD,
+                    ),
+                );
+                continue;
+            }
+
+            const tokenLockedValueUSD =
+                tokenID === pair.firstTokenID
+                    ? firstTokenLockedValueUSD
+                    : secondTokenLockedValueUSD;
+            newLockedValue = newLockedValue.plus(tokenLockedValueUSD);
+        }
+
+        return newLockedValue.toFixed();
     }
 
     async getAllTokensLiquidityUSD(tokenIDs: string[]): Promise<string[]> {

--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -115,7 +115,7 @@ export class AWSQueryCacheWarmerService {
         );
     }
 
-    @Cron(CronExpression.EVERY_5_MINUTES)
+    @Cron(CronExpression.EVERY_10_MINUTES)
     @Lock({ name: 'updateHistoricPairsData', verbose: true })
     async updateHistoricPairsData(): Promise<void> {
         if (!this.apiConfig.isAWSTimestreamRead()) {


### PR DESCRIPTION
## Reasoning

1.  Skewed TVL and ranking for tokens and pairs (due to pairs containing tokens with a high supply and low liquidity)
2.  Displayed Total locked value on analytics is sometimes wrong (too small) at the beginning of each hour. This happens because the `start` and `end` dates used in the queries will differ at the benning of an hour

  
## Proposed Changes
- (1) fix compute methods for pairs and tokens locked value by comparing the difference between the 2 tokens. If the difference exceeds a threshold of `1000000` only use the smallest value
- (1) add bulk get methods for pair first and second tocken locked values + update pair dataloader
- (2) increase cron time for `updateHistoricPairsData` and decrease query cache warmer delay value

## How to test
- N/A
