### PR TITLE
[ MEX-662 ] Trading activity for Tokens and Pairs

### DIFF
--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -21,6 +21,7 @@ import { RemoteConfigModule } from '../remote-config/remote-config.module';
 import { AnalyticsModule as AnalyticsServicesModule } from 'src/services/analytics/analytics.module';
 import { WeeklyRewardsSplittingModule } from 'src/submodules/weekly-rewards-splitting/weekly-rewards-splitting.module';
 import { AnalyticsSetterService } from './services/analytics.setter.service';
+import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
 
 @Module({
     imports: [
@@ -39,6 +40,7 @@ import { AnalyticsSetterService } from './services/analytics.setter.service';
         RemoteConfigModule,
         WeekTimekeepingModule,
         WeeklyRewardsSplittingModule,
+        ElasticSearchModule,
     ],
     providers: [
         AnalyticsResolver,

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -12,6 +12,7 @@ import { PairComputeService } from '../pair/services/pair.compute.service';
 import { TokenService } from '../tokens/services/token.service';
 import { AnalyticsPairService } from './services/analytics.pair.service';
 import { PriceCandlesArgsValidationPipe } from './validators/price.candles.args.validator';
+import { TradingActivityModel } from './models/trading.activity.model';
 
 @Resolver()
 export class AnalyticsResolver {
@@ -196,5 +197,21 @@ export class AnalyticsResolver {
             args.end,
             args.resolution,
         );
+    }
+
+    @Query(() => [TradingActivityModel])
+    async tradingActivity(
+        @Args('tokenID', { nullable: true }) tokenID?: string,
+        @Args('pairAddress', { nullable: true }) pairAddress?: string,
+    ): Promise<TradingActivityModel[]> {
+        if (pairAddress && pairAddress.trim().length > 0) {
+            return this.analyticsCompute.pairTradingActivity(pairAddress);
+        }
+
+        if (tokenID && tokenID.trim().length > 0) {
+            return this.analyticsCompute.tokenTradingActivity(tokenID);
+        }
+
+        throw new Error('Invalid parameters');
     }
 }

--- a/src/modules/analytics/models/trading.activity.model.ts
+++ b/src/modules/analytics/models/trading.activity.model.ts
@@ -1,0 +1,27 @@
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
+import { EsdtTokenPaymentModel } from 'src/modules/tokens/models/esdt.token.payment.model';
+
+export enum TradingActivityAction {
+    'BUY' = 'BUY',
+    'SELL' = 'SELL',
+}
+
+registerEnumType(TradingActivityAction, { name: 'TradingActivityAction' });
+
+@ObjectType()
+export class TradingActivityModel {
+    @Field()
+    hash: string;
+    @Field()
+    timestamp: string;
+    @Field()
+    action: TradingActivityAction;
+    @Field()
+    input: EsdtTokenPaymentModel;
+    @Field()
+    output: EsdtTokenPaymentModel;
+
+    constructor(init?: Partial<TradingActivityModel>) {
+        Object.assign(this, init);
+    }
+}

--- a/src/modules/analytics/models/trading.activity.model.ts
+++ b/src/modules/analytics/models/trading.activity.model.ts
@@ -17,9 +17,9 @@ export class TradingActivityModel {
     @Field()
     action: TradingActivityAction;
     @Field()
-    input: EsdtTokenPaymentModel;
+    inputToken: EsdtTokenPaymentModel;
     @Field()
-    output: EsdtTokenPaymentModel;
+    outputToken: EsdtTokenPaymentModel;
 
     constructor(init?: Partial<TradingActivityModel>) {
         Object.assign(this, init);

--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -25,10 +25,8 @@ import {
     TradingActivityAction,
     TradingActivityModel,
 } from '../models/trading.activity.model';
-import { SWAP_IDENTIFIER } from 'src/modules/rabbitmq/handlers/pair.swap.handler.service';
 import { SwapEvent } from '@multiversx/sdk-exchange';
 import { convertEventTopicsAndDataToBase64 } from 'src/utils/elastic.search.utils';
-import { PairService } from 'src/modules/pair/services/pair.service';
 import { ElasticSearchEventsService } from 'src/services/elastic-search/services/es.events.service';
 import { RawElasticEventType } from 'src/services/elastic-search/entities/raw.elastic.event';
 
@@ -39,7 +37,6 @@ export class AnalyticsComputeService {
         private readonly farmAbi: FarmAbiFactory,
         private readonly farmCompute: FarmComputeFactory,
         private readonly pairAbi: PairAbiService,
-        private readonly pairService: PairService,
         private readonly pairCompute: PairComputeService,
         private readonly stakingCompute: StakingComputeService,
         private readonly tokenCompute: TokenComputeService,

--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -415,7 +415,7 @@ export class AnalyticsComputeService {
                     .slice(0, 10),
             );
             latestTimestamp = filteredEvents[0].timestamp;
-            if (filteredEvents.length < size) {
+            if (events.length < size) {
                 break;
             }
         }

--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -310,7 +310,7 @@ export class AnalyticsComputeService {
         const pairsMetadata = await this.routerAbi.pairsMetadata();
         const commonTokens = await this.routerAbi.commonTokensForUserPairs();
         const sortedCommonTokens = commonTokens.sort((a, b) => {
-            const order = ['USDC', 'EGLD'];
+            const order = ['USD', 'EGLD'];
             const indexA = order.findIndex((token) => a.includes(token));
             const indexB = order.findIndex((token) => b.includes(token));
             if (indexA === -1 && indexB === -1) return 0;

--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -388,6 +388,7 @@ export class AnalyticsComputeService {
         const filteredEvents: RawElasticEventType[] = [];
         const pairsAddresses = await this.routerAbi.pairsAddress();
         let latestTimestamp = Math.floor(Date.now() / 1000);
+        const size = 50;
 
         const createUniqueIdentifier = (event: RawElasticEventType) => {
             return `${event.txHash}-${event.shardID}-${event.order}`;
@@ -398,6 +399,7 @@ export class AnalyticsComputeService {
                 await this.elasticEventsService.getTokenTradingEvents(
                     tokenID,
                     latestTimestamp,
+                    size,
                 );
             filteredEvents.push(
                 ...events
@@ -413,6 +415,9 @@ export class AnalyticsComputeService {
                     .slice(0, 10),
             );
             latestTimestamp = filteredEvents[0].timestamp;
+            if (filteredEvents.length < size) {
+                break;
+            }
         }
 
         return filteredEvents.map((event) => {

--- a/src/modules/analytics/services/analytics.setter.service.ts
+++ b/src/modules/analytics/services/analytics.setter.service.ts
@@ -4,6 +4,7 @@ import { Constants } from '@multiversx/sdk-nestjs-common';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
+import { TradingActivityModel } from '../models/trading.activity.model';
 
 export class AnalyticsSetterService extends GenericSetterService {
     constructor(
@@ -69,6 +70,30 @@ export class AnalyticsSetterService extends GenericSetterService {
             value,
             Constants.oneMinute() * 10,
             Constants.oneMinute() * 5,
+        );
+    }
+
+    async pairTradingActivity(
+        pairAddress: string,
+        value: TradingActivityModel[],
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('pairTradingActivity', pairAddress),
+            value,
+            Constants.oneMinute() * 2,
+            Constants.oneMinute(),
+        );
+    }
+
+    async tokenTradingActivity(
+        tokenID: string,
+        value: TradingActivityModel[],
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('tokenTradingActivity', tokenID),
+            value,
+            Constants.oneMinute() * 2,
+            Constants.oneMinute(),
         );
     }
 

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -52,9 +52,9 @@ export class AnalyticsCacheWarmerService {
 
         for (const pair of pairsMetadata) {
             const tradingActivity =
-                await this.analyticsCompute.computeTradingActivity({
-                    pairAddress: pair.address,
-                });
+                await this.analyticsCompute.computePairTradingActivity(
+                    pair.address,
+                );
             const pairCachedKeys =
                 await this.analyticsSetter.pairTradingActivity(
                     pair.address,
@@ -69,7 +69,9 @@ export class AnalyticsCacheWarmerService {
 
         for (const tokenID of tokenIDs.values()) {
             const tradingActivity =
-                await this.analyticsCompute.computeTradingActivity({ tokenID });
+                await this.analyticsCompute.computeTokenTradingActivity(
+                    tokenID,
+                );
             const tokenCachedKeys =
                 await this.analyticsSetter.tokenTradingActivity(
                     tokenID,

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -71,7 +71,7 @@ export class AnalyticsCacheWarmerService {
             const tradingActivity =
                 await this.analyticsCompute.computeTradingActivity({ tokenID });
             const tokenCachedKeys =
-                await this.analyticsSetter.pairTradingActivity(
+                await this.analyticsSetter.tokenTradingActivity(
                     tokenID,
                     tradingActivity,
                 );

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -7,6 +7,8 @@ import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { PUB_SUB } from '../redis.pubSub.module';
 import { ApiConfigService } from 'src/helpers/api.config.service';
 import { AnalyticsSetterService } from 'src/modules/analytics/services/analytics.setter.service';
+import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
+import { Lock } from '@multiversx/sdk-nestjs-common';
 
 @Injectable()
 export class AnalyticsCacheWarmerService {
@@ -14,6 +16,7 @@ export class AnalyticsCacheWarmerService {
         private readonly analyticsCompute: AnalyticsComputeService,
         private readonly analyticsSetter: AnalyticsSetterService,
         private readonly apiConfig: ApiConfigService,
+        private readonly routerAbi: RouterAbiService,
         @Inject(PUB_SUB) private pubSub: RedisPubSub,
     ) {}
 
@@ -36,6 +39,45 @@ export class AnalyticsCacheWarmerService {
             ),
             this.analyticsSetter.lockedValueUSDFarms(totalValueLockedUSDFarms),
         ]);
+
+        await this.deleteCacheKeys(cachedKeys);
+    }
+
+    @Cron(CronExpression.EVERY_30_SECONDS)
+    @Lock({ name: 'cacheTradingActivity', verbose: true })
+    async cacheTradingActivity(): Promise<void> {
+        const pairsMetadata = await this.routerAbi.pairsMetadata();
+        const tokenIDs = new Set<string>();
+        const cachedKeys = [];
+
+        for (const pair of pairsMetadata) {
+            const tradingActivity =
+                await this.analyticsCompute.computeTradingActivity({
+                    pairAddress: pair.address,
+                });
+            const pairCachedKeys =
+                await this.analyticsSetter.pairTradingActivity(
+                    pair.address,
+                    tradingActivity,
+                );
+
+            cachedKeys.push(...pairCachedKeys);
+
+            tokenIDs.add(pair.firstTokenID);
+            tokenIDs.add(pair.secondTokenID);
+        }
+
+        for (const tokenID of tokenIDs.values()) {
+            const tradingActivity =
+                await this.analyticsCompute.computeTradingActivity({ tokenID });
+            const tokenCachedKeys =
+                await this.analyticsSetter.pairTradingActivity(
+                    tokenID,
+                    tradingActivity,
+                );
+
+            cachedKeys.push(...tokenCachedKeys);
+        }
 
         await this.deleteCacheKeys(cachedKeys);
     }

--- a/src/services/elastic-search/services/es.events.service.ts
+++ b/src/services/elastic-search/services/es.events.service.ts
@@ -228,9 +228,10 @@ export class ElasticSearchEventsService {
     async getTokenTradingEvents(
         tokenID: string,
         timestamp: number,
+        size: number,
     ): Promise<RawElasticEventType[]> {
         const pagination = new ElasticPagination();
-        pagination.size = 50;
+        pagination.size = size;
 
         const elasticQueryAdapter: ElasticQuery =
             new ElasticQuery().withPagination(pagination);


### PR DESCRIPTION
## Reasoning
- Fetching Swap Transactions from the REST API didn't catch all required transactions correctly

  
## Proposed Changes
- New Endpoint for retrieving Trading Activity for both Tokens and Pairs
- Using Events Index to catch all transactions

## How to test
Replace "erd1qqqqqqqqqqqqqpgq5jnjpsukhl295ry3wjrd3gtff0amrgux2jpsz3reum" with any other pair address or token Identifier
```
tradingActivity(series: "erd1qqqqqqqqqqqqqpgq5jnjpsukhl295ry3wjrd3gtff0amrgux2jpsz3reum") {
    hash,
    timestamp,
    action,
    inputToken {
      amount,
      tokenIdentifier,
      tokenNonce
    },
    outputToken {
      amount,
      tokenIdentifier,
      tokenNonce
    }
  }
```
