### PR TITLE
[MEX-662] fix undefined timestamp in case of no events

### DIFF
--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -414,10 +414,10 @@ export class AnalyticsComputeService {
                     }, [] as RawElasticEventType[])
                     .slice(0, 10),
             );
-            latestTimestamp = filteredEvents[0].timestamp;
             if (events.length < size) {
                 break;
             }
+            latestTimestamp = filteredEvents[0].timestamp;
         }
 
         return filteredEvents.map((event) => {


### PR DESCRIPTION
## Reasoning
- If there are no events generated for a token, filteredEvents array will be empty
  
## Proposed Changes
- early exit from while loop if no more iterations are needed

## How to test
- on the cache warmer instance it should not be any `undefined timestamp` errors from this compute method
