### PR TITLE
[MEX-662]: Filter by pair address in ES query

### DIFF
--- a/src/modules/analytics/services/analytics.setter.service.ts
+++ b/src/modules/analytics/services/analytics.setter.service.ts
@@ -80,8 +80,8 @@ export class AnalyticsSetterService extends GenericSetterService {
         return await this.setData(
             this.getCacheKey('pairTradingActivity', pairAddress),
             value,
-            Constants.oneMinute() * 2,
-            Constants.oneMinute(),
+            Constants.oneMinute() * 5,
+            Constants.oneMinute() * 3,
         );
     }
 
@@ -92,8 +92,8 @@ export class AnalyticsSetterService extends GenericSetterService {
         return await this.setData(
             this.getCacheKey('tokenTradingActivity', tokenID),
             value,
-            Constants.oneMinute() * 2,
-            Constants.oneMinute(),
+            Constants.oneMinute() * 5,
+            Constants.oneMinute() * 3,
         );
     }
 

--- a/src/services/elastic-search/entities/terms.query.ts
+++ b/src/services/elastic-search/entities/terms.query.ts
@@ -1,0 +1,15 @@
+import { AbstractQuery } from '@multiversx/sdk-nestjs-elastic';
+
+export class CustomTermsQuery extends AbstractQuery {
+    constructor(private readonly key: string, private readonly values: any) {
+        super();
+    }
+
+    getQuery(): any {
+        return {
+            terms: {
+                [this.key]: this.values,
+            },
+        };
+    }
+}

--- a/src/services/elastic-search/services/es.events.service.ts
+++ b/src/services/elastic-search/services/es.events.service.ts
@@ -12,6 +12,7 @@ import { Logger } from 'winston';
 import { RawElasticEventType } from '../entities/raw.elastic.event';
 import { SwapEvent } from '@multiversx/sdk-exchange';
 import { convertEventTopicsAndDataToBase64 } from 'src/utils/elastic.search.utils';
+import { CustomTermsQuery } from '../entities/terms.query';
 
 @Injectable()
 export class ElasticSearchEventsService {
@@ -227,7 +228,7 @@ export class ElasticSearchEventsService {
 
     async getTokenTradingEvents(
         tokenID: string,
-        timestamp: number,
+        pairsAddresses: string[],
         size: number,
     ): Promise<RawElasticEventType[]> {
         const pagination = new ElasticPagination();
@@ -248,11 +249,12 @@ export class ElasticSearchEventsService {
                     SWAP_IDENTIFIER.SWAP_FIXED_OUTPUT,
                 ),
             ]),
-            QueryType.Range('timestamp', {
-                key: 'lte',
-                value: timestamp,
-            }),
         ];
+
+        elasticQueryAdapter.filter = [
+            new CustomTermsQuery('address', pairsAddresses),
+        ];
+
         elasticQueryAdapter.sort = [
             { name: 'timestamp', order: ElasticSortOrder.descending },
         ];


### PR DESCRIPTION
## Reasoning
-  current implementation can suffer from infinite loop inside the compute token trading activity if the token only on other exchanges with the same event identifier
  
## Proposed Changes
- added filtering by a set of pairs addresses for the ES query that retrieves the swap events for a token

## How to test
```
query {
    tradingActivity(
        series: "MUNCHKIN-3865e6"
    ) {
        timestamp
        hash
        action
        inputToken {
            tokenIdentifier
            amount
        }
        outputToken {
            tokenIdentifier
            amount
        }
    }
}
```
- query should return an empty array