### PR TITLE
[ MEX-662 ] Changed input and output token type to Esdt and fix action on TokenTradingActivity 

### DIFF
--- a/src/modules/analytics/models/trading.activity.model.ts
+++ b/src/modules/analytics/models/trading.activity.model.ts
@@ -20,10 +20,6 @@ export class TradingActivityModel {
     inputToken: EsdtToken;
     @Field()
     outputToken: EsdtToken;
-    @Field()
-    inputAmount: string;
-    @Field()
-    outputAmount: string;
 
     constructor(init?: Partial<TradingActivityModel>) {
         Object.assign(this, init);

--- a/src/modules/analytics/models/trading.activity.model.ts
+++ b/src/modules/analytics/models/trading.activity.model.ts
@@ -20,6 +20,10 @@ export class TradingActivityModel {
     inputToken: EsdtToken;
     @Field()
     outputToken: EsdtToken;
+    @Field()
+    inputAmount: string;
+    @Field()
+    outputAmount: string;
 
     constructor(init?: Partial<TradingActivityModel>) {
         Object.assign(this, init);

--- a/src/modules/analytics/models/trading.activity.model.ts
+++ b/src/modules/analytics/models/trading.activity.model.ts
@@ -1,5 +1,5 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
-import { EsdtTokenPaymentModel } from 'src/modules/tokens/models/esdt.token.payment.model';
+import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 
 export enum TradingActivityAction {
     'BUY' = 'BUY',
@@ -17,9 +17,9 @@ export class TradingActivityModel {
     @Field()
     action: TradingActivityAction;
     @Field()
-    inputToken: EsdtTokenPaymentModel;
+    inputToken: EsdtToken;
     @Field()
-    outputToken: EsdtTokenPaymentModel;
+    outputToken: EsdtToken;
 
     constructor(init?: Partial<TradingActivityModel>) {
         Object.assign(this, init);

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -43,7 +43,7 @@ export class AnalyticsCacheWarmerService {
         await this.deleteCacheKeys(cachedKeys);
     }
 
-    @Cron(CronExpression.EVERY_30_SECONDS)
+    @Cron(CronExpression.EVERY_30_MINUTES)
     @Lock({ name: 'cacheTradingActivity', verbose: true })
     async cacheTradingActivity(): Promise<void> {
         const pairsMetadata = await this.routerAbi.pairsMetadata();

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -43,7 +43,7 @@ export class AnalyticsCacheWarmerService {
         await this.deleteCacheKeys(cachedKeys);
     }
 
-    @Cron(CronExpression.EVERY_30_MINUTES)
+    @Cron(CronExpression.EVERY_30_SECONDS)
     @Lock({ name: 'cacheTradingActivity', verbose: true })
     async cacheTradingActivity(): Promise<void> {
         const pairsMetadata = await this.routerAbi.pairsMetadata();

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -61,7 +61,7 @@ export class AnalyticsCacheWarmerService {
                     tradingActivity,
                 );
 
-            cachedKeys.push(...pairCachedKeys);
+            cachedKeys.push(pairCachedKeys);
 
             tokenIDs.add(pair.firstTokenID);
             tokenIDs.add(pair.secondTokenID);
@@ -78,7 +78,7 @@ export class AnalyticsCacheWarmerService {
                     tradingActivity,
                 );
 
-            cachedKeys.push(...tokenCachedKeys);
+            cachedKeys.push(tokenCachedKeys);
         }
 
         await this.deleteCacheKeys(cachedKeys);


### PR DESCRIPTION
## Reasoning
- There was a need of multiple Esdt Token attributes on frontend, and we were sending only the token identifier
- Action on TokenTradingActivity was not working properly, ( the quote / base computation was implemented only for pairTradingActivity )
  
## Proposed Changes
- Change the model and the compute functions to return EsdtType for inputToken and OutputToken
- Implement quote / base computation for token Trading Activity

## How to test
```
tradingActivity(series: "erd1qqqqqqqqqqqqqpgq5jnjpsukhl295ry3wjrd3gtff0amrgux2jpsz3reum") {
    hash,
    timestamp,
    action,
    inputToken {
      identifier,
      decimals,
      balance
    },
    outputToken {
      identifier,
      decimals,
      balance
    }
  }
```
