### PR TITLE
[MEX-682] Use gateway URL in MX proxy service

### DIFF
--- a/src/helpers/api.config.service.ts
+++ b/src/helpers/api.config.service.ts
@@ -132,6 +132,14 @@ export class ApiConfigService {
         return apiUrl;
     }
 
+    getGatewayUrl(): string {
+        const gatewayUrl = this.configService.get<string>('MX_GATEWAY_URL');
+        if (!gatewayUrl) {
+            throw new Error('No gatewayUrl present');
+        }
+        return gatewayUrl;
+    }
+
     getKeepAliveTimeoutDownstream(): number {
         const keepAliveTimeoutDownstream = this.configService.get<string>(
             'KEEPALIVE_TIMEOUT_DOWNSTREAM',

--- a/src/services/multiversx-communication/mx.proxy.service.ts
+++ b/src/services/multiversx-communication/mx.proxy.service.ts
@@ -41,7 +41,7 @@ export class MXProxyService {
 
         this.proxy = new ProxyNetworkProviderProfiler(
             this.apiConfigService,
-            this.apiConfigService.getApiUrl(),
+            this.apiConfigService.getGatewayUrl(),
             {
                 timeout: mxConfig.proxyTimeout,
                 httpAgent: mxConfig.keepAlive ? httpAgent : null,


### PR DESCRIPTION
## Reasoning
- SC queries are currently performed through the API which performs forwarding to gateway
  
## Proposed Changes
- use gateway URL when initializing a Proxy Network Provider

## How to test
- N/A
