### PR TITLE
[Mex-662] - Trading activity for tokens and pairs

### DIFF
--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -447,14 +447,8 @@ export class AnalyticsComputeService {
             );
             outputToken.balance = tokenOut.amount;
 
-            const { quoteToken } = this.determineBaseAndQuoteTokens(
-                swapEvent.address,
-                pairsMetadata,
-                commonTokens,
-            );
-
             const action =
-                quoteToken === tokenOut.tokenID
+                tokenID === tokenOut.tokenID
                     ? TradingActivityAction.BUY
                     : TradingActivityAction.SELL;
 

--- a/src/modules/analytics/services/analytics.compute.service.ts
+++ b/src/modules/analytics/services/analytics.compute.service.ts
@@ -397,7 +397,6 @@ export class AnalyticsComputeService {
         tokenID: string,
     ): Promise<TradingActivityModel[]> {
         const pairsMetadata = await this.routerAbi.pairsMetadata();
-        const commonTokens = await this.routerAbi.commonTokensForUserPairs();
         const pairsTokens = new Set<string>();
 
         const pairsAddresses = pairsMetadata


### PR DESCRIPTION
## Reasoning
- Trading Action ( SELL / BUY ) for Token Trading Activity was incorrect
  
## Proposed Changes
- For Token Trading Activity, the tokenID provided will always be the quote token

## How to test
```
tradingActivity(series: "WEGLD-bd4d79") {
    hash,
    timestamp,
    action,
    inputToken {
      identifier,
      balance,
      decimals
    },
    outputToken {
      identifier,
      balance,
      decimals
    }
  }
```
