### PR TITLE
[MEX-684] Complexity plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,7 @@ ENABLE_PRIVATE_API=true
 ENABLE_CACHE_WARMER=true
 ENABLE_EVENTS_NOTIFIER=false
 ENABLE_TRACER=false
+ENABLE_COMPLEXITY=true
 
 #Log filename to use for file logging. Optional
 LOG_FILE=

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
                 "dataloader": "^2.2.2",
                 "express": "^4.18.1",
                 "graphql": "^16.5.0",
+                "graphql-query-complexity": "^1.0.0",
                 "graphql-redis-subscriptions": "^2.4.2",
                 "graphql-relay": "^0.10.1",
                 "graphql-subscriptions": "^2.0.0",
@@ -9711,6 +9712,17 @@
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
         },
+        "node_modules/graphql-query-complexity": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/graphql-query-complexity/-/graphql-query-complexity-1.0.0.tgz",
+            "integrity": "sha512-Tj7mRIuKWjGomPaRW5E+ztY8bhYPf1v/7bkDPuzksrR3GqHeIS5jxzX8CfimlV3g9z0lT20RG9JgaUUjhRjtOA==",
+            "dependencies": {
+                "lodash.get": "^4.4.2"
+            },
+            "peerDependencies": {
+                "graphql": "^14.6.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
         "node_modules/graphql-redis-subscriptions": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/graphql-redis-subscriptions/-/graphql-redis-subscriptions-2.6.1.tgz",
@@ -11780,6 +11792,12 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
             "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead."
         },
         "node_modules/lodash.includes": {
             "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "dataloader": "^2.2.2",
         "express": "^4.18.1",
         "graphql": "^16.5.0",
+        "graphql-query-complexity": "^1.0.0",
         "graphql-redis-subscriptions": "^2.4.2",
         "graphql-relay": "^0.10.1",
         "graphql-subscriptions": "^2.0.0",

--- a/src/complexity.module.ts
+++ b/src/complexity.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ComplexityPlugin } from './utils/complexity.plugin';
+import { ApiConfigService } from './helpers/api.config.service';
+
+@Module({
+    providers: [ApiConfigService, ComplexityPlugin],
+})
+export class ComplexityModule {}

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -691,11 +691,13 @@
     "cryptoRatesIdentifiers": ["WBTC-5349b3", "WETH-b4ca29", "WEGLD-bd4d79"],
     "complexity": {
       "maxComplexity": 3000,
+      "defaultComplexity": 1,
       "collectMetrics": true,
       "exposeComplexity": true,
       "rejectQueries": false,
       "costModifiers": {
-        "nested": 1.5
+        "nested": 1.5,
+        "exponentialBase": 5
       }
     }
 }

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -688,5 +688,14 @@
             "minEnergy": "5040000000000000000000000000000"
         }
     ],
-    "cryptoRatesIdentifiers": ["WBTC-5349b3", "WETH-b4ca29", "WEGLD-bd4d79"]
+    "cryptoRatesIdentifiers": ["WBTC-5349b3", "WETH-b4ca29", "WEGLD-bd4d79"],
+    "complexity": {
+      "maxComplexity": 3000,
+      "collectMetrics": true,
+      "exposeComplexity": true,
+      "rejectQueries": false,
+      "costModifiers": {
+        "nested": 1.5
+      }
+    }
 }

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -697,7 +697,7 @@
       "rejectQueries": false,
       "costModifiers": {
         "nested": 1.5,
-        "exponentialBase": 5
+        "exponentialBase": 10
       }
     }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,3 +36,5 @@ export const constantsConfig = config.get('constants');
 export const dataApiConfig = config.get('dataApi');
 
 export const leaguesConfig = config.get('leagues');
+
+export const complexityConfig = config.get('complexity');

--- a/src/helpers/complexity/field.estimators.ts
+++ b/src/helpers/complexity/field.estimators.ts
@@ -1,0 +1,10 @@
+import { ComplexityEstimatorArgs } from 'graphql-query-complexity';
+import { complexityConfig } from 'src/config';
+
+export function nestedFieldComplexity(
+    options: ComplexityEstimatorArgs,
+): number {
+    const cost =
+        options.childComplexity * complexityConfig.costModifiers.nested + 1;
+    return cost;
+}

--- a/src/helpers/complexity/query.estimators.ts
+++ b/src/helpers/complexity/query.estimators.ts
@@ -1,0 +1,16 @@
+import { ComplexityEstimatorArgs } from 'graphql-query-complexity';
+
+export function estimateRelayQueryComplexity(
+    options: ComplexityEstimatorArgs,
+): number {
+    const count =
+        options.args.pagination?.first ?? options.args.pagination?.last ?? 10;
+    return count * options.childComplexity;
+}
+
+export function estimatePaginatedQueryComplexity(
+    options: ComplexityEstimatorArgs,
+): number {
+    const count = options.args.page?.limit ?? 10;
+    return count * options.childComplexity;
+}

--- a/src/helpers/complexity/query.estimators.ts
+++ b/src/helpers/complexity/query.estimators.ts
@@ -1,16 +1,62 @@
-import { ComplexityEstimatorArgs } from 'graphql-query-complexity';
+import {
+    ComplexityEstimator,
+    ComplexityEstimatorArgs,
+    simpleEstimator,
+} from 'graphql-query-complexity';
+import { complexityConfig } from 'src/config';
 
-export function estimateRelayQueryComplexity(
-    options: ComplexityEstimatorArgs,
-): number {
+export function relayQueryEstimator(options: ComplexityEstimatorArgs): number {
     const count =
         options.args.pagination?.first ?? options.args.pagination?.last ?? 10;
     return count * options.childComplexity;
 }
 
-export function estimatePaginatedQueryComplexity(
+export function paginatedQueryEstimator(
     options: ComplexityEstimatorArgs,
 ): number {
     const count = options.args.page?.limit ?? 10;
     return count * options.childComplexity;
+}
+
+export function rootQueryEstimator(): ComplexityEstimator {
+    return (args: ComplexityEstimatorArgs): number | void => {
+        if (!args.field.extensions || args.type.name !== 'Query') {
+            return;
+        }
+
+        const exponent = args.context.queryCount;
+        const exponentialComplexity = Math.pow(
+            complexityConfig.costModifiers.exponentialBase,
+            exponent,
+        );
+
+        args.context.queryCount = args.context.queryCount + 1;
+
+        if (typeof args.field.extensions.complexity === 'number') {
+            return exponentialComplexity + args.field.extensions.complexity;
+        } else if (typeof args.field.extensions.complexity === 'function') {
+            return (
+                exponentialComplexity + args.field.extensions.complexity(args)
+            );
+        }
+        const baseEstimate = simpleEstimator({
+            defaultComplexity: complexityConfig.defaultComplexity,
+        })(args);
+
+        return typeof baseEstimate === 'number'
+            ? exponentialComplexity + baseEstimate
+            : exponentialComplexity;
+    };
+}
+
+export function enforcedSingleQueryEstimator(
+    options: ComplexityEstimatorArgs,
+): number {
+    const { maxComplexity } = complexityConfig;
+
+    if (options.childComplexity < maxComplexity) {
+        return maxComplexity;
+    }
+
+    return options.childComplexity;
 }

--- a/src/helpers/validators/query.args.validation.pipe.ts
+++ b/src/helpers/validators/query.args.validation.pipe.ts
@@ -1,0 +1,28 @@
+import { ApolloServerErrorCode } from '@apollo/server/errors';
+import { ValidationPipe } from '@nestjs/common';
+import { ValidationError } from 'class-validator';
+import { GraphQLError } from 'graphql';
+
+export class QueryArgsValidationPipe extends ValidationPipe {
+    constructor() {
+        super({
+            skipNullProperties: true,
+            skipMissingProperties: true,
+            skipUndefinedProperties: true,
+            transform: true,
+            exceptionFactory: validationExceptionFactory,
+            stopAtFirstError: true,
+        });
+    }
+}
+
+function validationExceptionFactory(errors: ValidationError[]): any {
+    const result = errors.map(
+        (error) => error.constraints[Object.keys(error.constraints)[0]],
+    );
+    return new GraphQLError(`Validation errors: ${result.join(' | ')}`, {
+        extensions: {
+            code: ApolloServerErrorCode.BAD_USER_INPUT,
+        },
+    });
+}

--- a/src/modules/auto-router/models/auto-route.model.ts
+++ b/src/modules/auto-router/models/auto-route.model.ts
@@ -1,4 +1,5 @@
 import { ObjectType, Field } from '@nestjs/graphql';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 import { TransactionModel } from 'src/models/transaction.model';
 import { PairModel } from 'src/modules/pair/models/pair.model';
 
@@ -55,7 +56,7 @@ export class SwapRouteModel {
     @Field({ nullable: true })
     tokensPriceDeviationPercent: number;
 
-    @Field(() => [PairModel])
+    @Field(() => [PairModel], { complexity: nestedFieldComplexity })
     pairs: PairModel[];
 
     @Field()

--- a/src/modules/common/filters/connection.args.ts
+++ b/src/modules/common/filters/connection.args.ts
@@ -90,12 +90,12 @@ export default class ConnectionArgs implements ConnectionArguments {
     public after?: ConnectionCursor;
 
     @IsOptional()
-    @Max(100)
+    @Max(25)
     @Field(() => Int, { nullable: true, description: 'Paginate first' })
     public first?: number;
 
     @IsOptional()
-    @Max(100)
+    @Max(25)
     @Field(() => Int, { nullable: true, description: 'Paginate last' })
     public last?: number;
 }

--- a/src/modules/common/filters/connection.args.ts
+++ b/src/modules/common/filters/connection.args.ts
@@ -4,7 +4,7 @@ import {
     fromGlobalId,
 } from 'graphql-relay';
 import { Field, Int, InputType } from '@nestjs/graphql';
-import { IsOptional, Max } from 'class-validator';
+import { IsInt, IsOptional, Max } from 'class-validator';
 import { PaginationArgs } from 'src/modules/dex.model';
 
 type PagingMeta =
@@ -90,12 +90,12 @@ export default class ConnectionArgs implements ConnectionArguments {
     public after?: ConnectionCursor;
 
     @IsOptional()
-    @Max(25)
+    @Max(1000)
     @Field(() => Int, { nullable: true, description: 'Paginate first' })
     public first?: number;
 
     @IsOptional()
-    @Max(25)
+    @Max(1000)
     @Field(() => Int, { nullable: true, description: 'Paginate last' })
     public last?: number;
 }

--- a/src/modules/common/page.data.ts
+++ b/src/modules/common/page.data.ts
@@ -2,13 +2,13 @@ import { Field, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
 
 @ObjectType()
 export default class PageData {
-    @Field(() => Int)
+    @Field(() => Int, { complexity: 0 })
     public count: number;
 
-    @Field(() => Int)
+    @Field(() => Int, { complexity: 0 })
     public limit: number;
 
-    @Field(() => Int)
+    @Field(() => Int, { complexity: 0 })
     public offset: number;
 }
 

--- a/src/modules/dex.model.ts
+++ b/src/modules/dex.model.ts
@@ -1,10 +1,12 @@
 import { Field, ArgsType, Int } from '@nestjs/graphql';
+import { Max } from 'class-validator';
 
 @ArgsType()
 export class PaginationArgs {
     @Field(() => Int)
     offset = 0;
 
+    @Max(25)
     @Field(() => Int)
     limit = 10;
 

--- a/src/modules/dex.model.ts
+++ b/src/modules/dex.model.ts
@@ -6,7 +6,7 @@ export class PaginationArgs {
     @Field(() => Int)
     offset = 0;
 
-    @Max(25)
+    @Max(1000)
     @Field(() => Int)
     limit = 10;
 

--- a/src/modules/energy/models/simple.lock.energy.model.ts
+++ b/src/modules/energy/models/simple.lock.energy.model.ts
@@ -1,4 +1,5 @@
 import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 
@@ -18,13 +19,13 @@ export class LockOption {
 export class SimpleLockEnergyModel {
     @Field()
     address: string;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     baseAssetToken: EsdtToken;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     lockedToken: NftCollection;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     legacyLockedToken: NftCollection;
-    @Field(() => [LockOption])
+    @Field(() => [LockOption], { complexity: nestedFieldComplexity })
     lockOptions: LockOption[];
     @Field()
     tokenUnstakeAddress: string;

--- a/src/modules/farm/models/farm.model.ts
+++ b/src/modules/farm/models/farm.model.ts
@@ -6,6 +6,7 @@ import {
     ClaimProgress,
     UserInfoByWeekModel,
 } from '../../../submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 export enum FarmVersion {
     V1_2 = 'v1.2',
@@ -32,9 +33,15 @@ export class RewardsModel {
     rewards: string;
     @Field(() => Int, { nullable: true })
     remainingFarmingEpochs?: number;
-    @Field(() => [UserInfoByWeekModel], { nullable: true })
+    @Field(() => [UserInfoByWeekModel], {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     boostedRewardsWeeklyInfo: UserInfoByWeekModel[];
-    @Field(() => ClaimProgress, { nullable: true })
+    @Field(() => ClaimProgress, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     claimProgress: ClaimProgress;
     @Field({ nullable: true })
     accumulatedRewards: string;
@@ -50,9 +57,15 @@ export class BoostedRewardsModel {
     farmAddress: string;
     @Field()
     userAddress: string;
-    @Field(() => [UserInfoByWeekModel], { nullable: true })
+    @Field(() => [UserInfoByWeekModel], {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     boostedRewardsWeeklyInfo: UserInfoByWeekModel[];
-    @Field(() => ClaimProgress, { nullable: true })
+    @Field(() => ClaimProgress, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     claimProgress: ClaimProgress;
     @Field({ nullable: true })
     accumulatedRewards: string;
@@ -115,19 +128,19 @@ export class BaseFarmModel {
     @Field()
     address: string;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmedToken: EsdtToken;
 
     @Field()
     farmedTokenPriceUSD: string;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmToken: NftCollection;
 
     @Field()
     farmTokenPriceUSD: string;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmingToken: EsdtToken;
 
     @Field()
@@ -175,7 +188,7 @@ export class BaseFarmModel {
     @Field({ nullable: true })
     transferExecGasLimit: string;
 
-    @Field({ nullable: true })
+    @Field({ nullable: true, complexity: nestedFieldComplexity })
     pair: PairModel;
 
     @Field({ nullable: true })

--- a/src/modules/farm/models/farm.v1.2.model.ts
+++ b/src/modules/farm/models/farm.v1.2.model.ts
@@ -1,6 +1,7 @@
 import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { BaseFarmModel, FarmMigrationConfig } from './farm.model';
 import { LockedAssetModel } from 'src/modules/locked-asset-factory/models/locked-asset.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType()
 export class FarmModelV1_2 extends BaseFarmModel {
@@ -16,7 +17,7 @@ export class FarmModelV1_2 extends BaseFarmModel {
     @Field(() => Int)
     aprMultiplier: number;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     lockedAssetFactory: LockedAssetModel;
 
     @Field()

--- a/src/modules/farm/models/farm.v1.3.model.ts
+++ b/src/modules/farm/models/farm.v1.3.model.ts
@@ -5,13 +5,14 @@ import {
     FarmRewardType,
 } from './farm.model';
 import { LockedAssetModel } from 'src/modules/locked-asset-factory/models/locked-asset.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType()
 export class FarmModelV1_3 extends BaseFarmModel {
     @Field()
     apr: string;
 
-    @Field({ nullable: true })
+    @Field({ nullable: true, complexity: nestedFieldComplexity })
     lockedAssetFactory: LockedAssetModel;
 
     @Field()

--- a/src/modules/farm/models/farm.v2.model.ts
+++ b/src/modules/farm/models/farm.v2.model.ts
@@ -2,6 +2,7 @@ import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { BaseFarmModel, FarmRewardType } from './farm.model';
 import { GlobalInfoByWeekModel } from '../../../submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { WeekTimekeepingModel } from '../../../submodules/week-timekeeping/models/week-timekeeping.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType()
 export class BoostedYieldsFactors {
@@ -25,7 +26,7 @@ export class BoostedYieldsFactors {
 export class FarmModelV2 extends BaseFarmModel {
     @Field(() => Int)
     boostedYieldsRewardsPercenatage: number;
-    @Field(() => BoostedYieldsFactors)
+    @Field(() => BoostedYieldsFactors, { complexity: nestedFieldComplexity })
     boostedYieldsFactors: BoostedYieldsFactors;
     @Field({ nullable: true })
     lockingScAddress: string;
@@ -39,11 +40,11 @@ export class FarmModelV2 extends BaseFarmModel {
     energyFactoryAddress: string;
     @Field()
     rewardType: FarmRewardType;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     time: WeekTimekeepingModel;
     @Field()
     accumulatedRewards: string;
-    @Field(() => [GlobalInfoByWeekModel])
+    @Field(() => [GlobalInfoByWeekModel], { complexity: nestedFieldComplexity })
     boosterRewards: [GlobalInfoByWeekModel];
     @Field()
     lastGlobalUpdateWeek: number;

--- a/src/modules/locked-asset-factory/models/locked-asset.model.ts
+++ b/src/modules/locked-asset-factory/models/locked-asset.model.ts
@@ -1,4 +1,5 @@
 import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 
@@ -22,7 +23,7 @@ export class LockedAssetAttributesModel {
     attributes: string;
     @Field()
     identifier: string;
-    @Field(() => [UnlockMileStoneModel])
+    @Field(() => [UnlockMileStoneModel], { complexity: nestedFieldComplexity })
     unlockSchedule: UnlockMileStoneModel[];
     @Field()
     isMerged: boolean;
@@ -37,13 +38,13 @@ export class LockedAssetModel {
     @Field()
     address: string;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     assetToken: EsdtToken;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     lockedToken: NftCollection;
 
-    @Field(() => [UnlockMileStoneModel])
+    @Field(() => [UnlockMileStoneModel], { complexity: nestedFieldComplexity })
     unlockMilestones: UnlockMileStoneModel[];
 
     @Field(() => Int)

--- a/src/modules/pair/models/pair.model.ts
+++ b/src/modules/pair/models/pair.model.ts
@@ -5,6 +5,8 @@ import { PairInfoModel } from './pair-info.model';
 import { SimpleLockModel } from 'src/modules/simple-lock/models/simple.lock.model';
 import { FeesCollectorModel } from 'src/modules/fees-collector/models/fees-collector.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
+import { ComplexityEstimatorArgs } from 'graphql-query-complexity';
 
 @ArgsType()
 export class GetPairsArgs extends PaginationArgs {}
@@ -30,7 +32,7 @@ export class LockedTokensInfo {
             'value can be obtained from lockingSC field',
     })
     lockingScAddress: string;
-    @Field(() => SimpleLockModel)
+    @Field(() => SimpleLockModel, { complexity: nestedFieldComplexity })
     lockingSC: SimpleLockModel;
     @Field(() => Int)
     unlockEpoch: number;
@@ -72,13 +74,17 @@ export class PairRewardTokensModel {
     @Field()
     address: string;
 
-    @Field(() => [EsdtToken])
+    @Field(() => [EsdtToken], {
+        complexity: (options: ComplexityEstimatorArgs) => {
+            return nestedFieldComplexity(options) * 2;
+        },
+    })
     poolRewards: EsdtToken[];
 
-    @Field({ nullable: true })
+    @Field({ nullable: true, complexity: nestedFieldComplexity })
     farmReward: NftCollection;
 
-    @Field({ nullable: true })
+    @Field({ nullable: true, complexity: nestedFieldComplexity })
     dualFarmReward: EsdtToken;
 
     constructor(init?: Partial<PairRewardTokensModel>) {
@@ -91,10 +97,10 @@ export class PairModel {
     @Field()
     address: string;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     firstToken: EsdtToken;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     secondToken: EsdtToken;
 
     @Field()
@@ -109,7 +115,7 @@ export class PairModel {
     @Field()
     secondTokenPriceUSD: string;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     liquidityPoolToken: EsdtToken;
 
     @Field()
@@ -148,7 +154,7 @@ export class PairModel {
     @Field()
     feesAPR: string;
 
-    @Field()
+    @Field(() => PairInfoModel, { complexity: nestedFieldComplexity })
     info: PairInfoModel;
 
     @Field()
@@ -174,7 +180,10 @@ export class PairModel {
     @Field()
     feeState: boolean;
 
-    @Field(() => LockedTokensInfo, { nullable: true })
+    @Field(() => LockedTokensInfo, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     lockedTokensInfo: LockedTokensInfo;
 
     @Field(() => [String])
@@ -183,12 +192,13 @@ export class PairModel {
     @Field()
     initialLiquidityAdder: string;
 
-    @Field(() => [FeeDestination])
+    @Field(() => [FeeDestination], { complexity: nestedFieldComplexity })
     feeDestinations: FeeDestination[];
 
     @Field(() => FeesCollectorModel, {
         nullable: true,
         description: 'Fees collector set for this pair',
+        complexity: nestedFieldComplexity,
     })
     feesCollector: FeesCollectorModel;
 
@@ -207,10 +217,16 @@ export class PairModel {
     @Field(() => Int, { nullable: true })
     deployedAt: number;
 
-    @Field(() => PairCompoundedAPRModel, { nullable: true })
+    @Field(() => PairCompoundedAPRModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     compoundedAPR: PairCompoundedAPRModel;
 
-    @Field(() => PairRewardTokensModel, { nullable: true })
+    @Field(() => PairRewardTokensModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     rewardTokens: PairRewardTokensModel;
 
     @Field({ nullable: true })

--- a/src/modules/proxy/models/proxy.model.ts
+++ b/src/modules/proxy/models/proxy.model.ts
@@ -1,4 +1,5 @@
 import { ObjectType, Field, registerEnumType } from '@nestjs/graphql';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 
@@ -16,16 +17,16 @@ export class ProxyModel {
     @Field()
     address: string;
 
-    @Field(() => [NftCollection])
+    @Field(() => [NftCollection], { complexity: nestedFieldComplexity })
     lockedAssetTokens: NftCollection[];
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     wrappedLpToken: NftCollection;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     wrappedFarmToken: NftCollection;
 
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     assetToken: EsdtToken;
 
     @Field(() => [String])

--- a/src/modules/router/router.resolver.ts
+++ b/src/modules/router/router.resolver.ts
@@ -7,7 +7,7 @@ import {
     Int,
     Float,
 } from '@nestjs/graphql';
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, UsePipes } from '@nestjs/common';
 import { TransactionModel } from '../../models/transaction.model';
 import { GetPairsArgs, PairModel } from '../pair/models/pair.model';
 import { EnableSwapByUserConfig, FactoryModel } from './models/factory.model';
@@ -34,6 +34,11 @@ import ConnectionArgs, {
 import PageResponse from '../common/page.response';
 import { AnalyticsAWSGetterService } from '../analytics/services/analytics.aws.getter.service';
 import BigNumber from 'bignumber.js';
+import { QueryArgsValidationPipe } from 'src/helpers/validators/query.args.validation.pipe';
+import {
+    estimateRelayQueryComplexity,
+    estimatePaginatedQueryComplexity,
+} from 'src/helpers/complexity/query.estimators';
 
 @Resolver(() => FactoryModel)
 export class RouterResolver {
@@ -169,7 +174,9 @@ export class RouterResolver {
     @Query(() => [PairModel], {
         deprecationReason:
             'New query (filteredPairs) following GraphQL "Connection" standard for pagination/sorting/filtering is now available.',
+        complexity: estimatePaginatedQueryComplexity,
     })
+    @UsePipes(new QueryArgsValidationPipe())
     async pairs(
         @Args() page: GetPairsArgs,
         @Args() filter: PairFilterArgs,
@@ -177,7 +184,10 @@ export class RouterResolver {
         return this.routerService.getAllPairs(page.offset, page.limit, filter);
     }
 
-    @Query(() => PairsResponse)
+    @Query(() => PairsResponse, {
+        complexity: estimateRelayQueryComplexity,
+    })
+    @UsePipes(new QueryArgsValidationPipe())
     async filteredPairs(
         @Args({ name: 'filters', type: () => PairsFilter, nullable: true })
         filters: PairsFilter,

--- a/src/modules/router/router.resolver.ts
+++ b/src/modules/router/router.resolver.ts
@@ -36,8 +36,8 @@ import { AnalyticsAWSGetterService } from '../analytics/services/analytics.aws.g
 import BigNumber from 'bignumber.js';
 import { QueryArgsValidationPipe } from 'src/helpers/validators/query.args.validation.pipe';
 import {
-    estimateRelayQueryComplexity,
-    estimatePaginatedQueryComplexity,
+    relayQueryEstimator,
+    paginatedQueryEstimator,
 } from 'src/helpers/complexity/query.estimators';
 
 @Resolver(() => FactoryModel)
@@ -174,7 +174,7 @@ export class RouterResolver {
     @Query(() => [PairModel], {
         deprecationReason:
             'New query (filteredPairs) following GraphQL "Connection" standard for pagination/sorting/filtering is now available.',
-        complexity: estimatePaginatedQueryComplexity,
+        complexity: paginatedQueryEstimator,
     })
     @UsePipes(new QueryArgsValidationPipe())
     async pairs(
@@ -185,7 +185,7 @@ export class RouterResolver {
     }
 
     @Query(() => PairsResponse, {
-        complexity: estimateRelayQueryComplexity,
+        complexity: relayQueryEstimator,
     })
     @UsePipes(new QueryArgsValidationPipe())
     async filteredPairs(

--- a/src/modules/simple-lock/models/simple.lock.model.ts
+++ b/src/modules/simple-lock/models/simple.lock.model.ts
@@ -5,6 +5,7 @@ import {
 import { Field, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { FarmTokenAttributesUnion } from 'src/modules/farm/models/farmTokenAttributes.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 export enum FarmType {
     SIMPLE_FARM,
@@ -113,11 +114,11 @@ export class FarmProxyTokenAttributesModel {
 export class SimpleLockModel {
     @Field()
     address: string;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     lockedToken: NftCollection;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     lpProxyToken: NftCollection;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmProxyToken: NftCollection;
     @Field(() => [String])
     intermediatedPairs: string[];

--- a/src/modules/staking-proxy/models/staking.proxy.model.ts
+++ b/src/modules/staking-proxy/models/staking.proxy.model.ts
@@ -4,6 +4,7 @@ import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { RewardsModel } from 'src/modules/farm/models/farm.model';
 import { LiquidityPosition } from 'src/modules/pair/models/pair.model';
 import { StakingRewardsModel } from 'src/modules/staking/models/staking.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType()
 export class StakingProxyModel {
@@ -17,13 +18,13 @@ export class StakingProxyModel {
     stakingMinUnboundEpochs: number;
     @Field()
     pairAddress: string;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     stakingToken: EsdtToken;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmToken: NftCollection;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     dualYieldToken: NftCollection;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     lpFarmToken: NftCollection;
 
     constructor(init?: Partial<StakingProxyModel>) {
@@ -37,9 +38,9 @@ export class DualYieldRewardsModel {
     identifier?: string;
     @Field({ nullable: true })
     attributes?: string;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     stakingRewards: StakingRewardsModel;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmRewards: RewardsModel;
 
     constructor(init?: Partial<DualYieldRewardsModel>) {
@@ -49,7 +50,7 @@ export class DualYieldRewardsModel {
 
 @ObjectType()
 export class UnstakeFarmTokensReceiveModel {
-    @Field(() => LiquidityPosition)
+    @Field(() => LiquidityPosition, { complexity: nestedFieldComplexity })
     liquidityPosition: LiquidityPosition;
     @Field()
     farmRewards: string;

--- a/src/modules/staking-proxy/staking.proxy.resolver.ts
+++ b/src/modules/staking-proxy/staking.proxy.resolver.ts
@@ -1,4 +1,4 @@
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, UsePipes } from '@nestjs/common';
 import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
@@ -32,6 +32,8 @@ import ConnectionArgs, {
     getPagingParameters,
 } from '../common/filters/connection.args';
 import PageResponse from '../common/page.response';
+import { QueryArgsValidationPipe } from 'src/helpers/validators/query.args.validation.pipe';
+import { relayQueryEstimator } from 'src/helpers/complexity/query.estimators';
 
 @Resolver(() => StakingProxyModel)
 export class StakingProxyResolver {
@@ -108,7 +110,10 @@ export class StakingProxyResolver {
         return this.stakingProxyService.getStakingProxies();
     }
 
-    @Query(() => StakingProxiesResponse)
+    @Query(() => StakingProxiesResponse, {
+        complexity: relayQueryEstimator,
+    })
+    @UsePipes(new QueryArgsValidationPipe())
     async filteredStakingProxies(
         @Args({
             name: 'filters',

--- a/src/modules/staking/models/staking.model.ts
+++ b/src/modules/staking/models/staking.model.ts
@@ -10,16 +10,17 @@ import {
 } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
 import { BoostedRewardsModel } from 'src/modules/farm/models/farm.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType()
 export class StakingModel {
     @Field()
     address: string;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmToken: NftCollection;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     farmingToken: EsdtToken;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     rewardToken: EsdtToken;
     @Field()
     farmTokenSupply: string;
@@ -59,14 +60,19 @@ export class StakingModel {
     boostedYieldsRewardsPercenatage: number;
     @Field(() => BoostedYieldsFactors, {
         description: 'Factors used to compute boosted rewards',
+        complexity: nestedFieldComplexity,
     })
     boostedYieldsFactors: BoostedYieldsFactors;
     @Field({ description: 'Optimal energy for staking position' })
     optimalEnergyPerStaking: string;
-    @Field({ description: 'Timekeeping for boosted rewards' })
+    @Field({
+        description: 'Timekeeping for boosted rewards',
+        complexity: nestedFieldComplexity,
+    })
     time: WeekTimekeepingModel;
     @Field(() => [GlobalInfoByWeekModel], {
         description: 'Global info for boosted rewards',
+        complexity: nestedFieldComplexity,
     })
     boosterRewards: [GlobalInfoByWeekModel];
     @Field()
@@ -96,15 +102,23 @@ export class StakingModel {
 
 @ObjectType()
 export class StakingRewardsModel {
-    @Field(() => StakingTokenAttributesModel)
+    @Field(() => StakingTokenAttributesModel, {
+        complexity: nestedFieldComplexity,
+    })
     decodedAttributes: StakingTokenAttributesModel;
     @Field()
     rewards: string;
     @Field(() => Int, { nullable: true })
     remainingFarmingEpochs?: number;
-    @Field(() => [UserInfoByWeekModel], { nullable: true })
+    @Field(() => [UserInfoByWeekModel], {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     boostedRewardsWeeklyInfo: UserInfoByWeekModel[];
-    @Field(() => ClaimProgress, { nullable: true })
+    @Field(() => ClaimProgress, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     claimProgress: ClaimProgress;
     @Field({ nullable: true })
     accumulatedRewards: string;

--- a/src/modules/staking/staking.resolver.ts
+++ b/src/modules/staking/staking.resolver.ts
@@ -1,4 +1,4 @@
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, UsePipes } from '@nestjs/common';
 import { Args, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthUser } from '../auth/auth.user';
 import { UserAuthResult } from '../auth/user.auth.result';
@@ -41,6 +41,8 @@ import ConnectionArgs, {
     getPagingParameters,
 } from '../common/filters/connection.args';
 import PageResponse from '../common/page.response';
+import { QueryArgsValidationPipe } from 'src/helpers/validators/query.args.validation.pipe';
+import { relayQueryEstimator } from 'src/helpers/complexity/query.estimators';
 
 @Resolver(() => StakingBoostedRewardsModel)
 export class StakingBoostedRewardsResolver {
@@ -459,7 +461,10 @@ export class StakingResolver {
         return this.stakingService.getFarmsStaking();
     }
 
-    @Query(() => StakingFarmsResponse)
+    @Query(() => StakingFarmsResponse, {
+        complexity: relayQueryEstimator,
+    })
+    @UsePipes(new QueryArgsValidationPipe())
     async filteredStakingFarms(
         @Args({
             name: 'filters',

--- a/src/modules/tokens/models/assets.interface.ts
+++ b/src/modules/tokens/models/assets.interface.ts
@@ -2,22 +2,24 @@ import { Field, InterfaceType } from '@nestjs/graphql';
 
 @InterfaceType()
 export abstract class ISocial {
-    @Field({ nullable: true }) email?: string;
-    @Field({ nullable: true }) blog?: string;
-    @Field({ nullable: true }) twitter?: string;
-    @Field({ nullable: true }) coinmarketcap?: string;
-    @Field({ nullable: true }) coingecko?: string;
+    @Field({ nullable: true, complexity: 0 }) email?: string;
+    @Field({ nullable: true, complexity: 0 }) blog?: string;
+    @Field({ nullable: true, complexity: 0 }) twitter?: string;
+    @Field({ nullable: true, complexity: 0 }) coinmarketcap?: string;
+    @Field({ nullable: true, complexity: 0 }) coingecko?: string;
 }
 
 @InterfaceType()
 export abstract class IAssets {
-    @Field({ nullable: true }) website?: string;
-    @Field({ nullable: true }) description?: string;
-    @Field(() => ISocial, { nullable: true }) social?: ISocial;
-    @Field({ nullable: true }) status?: string;
-    @Field({ nullable: true }) pngUrl?: string;
-    @Field({ nullable: true }) svgUrl?: string;
-    @Field(() => [String], { nullable: 'itemsAndList' })
+    @Field({ nullable: true, complexity: 0 }) website?: string;
+    @Field({ nullable: true, complexity: 0 }) description?: string;
+    @Field(() => ISocial, { nullable: true })
+    social?: ISocial;
+    @Field({ nullable: true, complexity: 0 }) status?: string;
+    @Field({ nullable: true, complexity: 0 }) pngUrl?: string;
+    @Field({ nullable: true, complexity: 0 }) svgUrl?: string;
+    @Field(() => [String], { nullable: 'itemsAndList', complexity: 0 })
     lockedAccounts?: string[];
-    @Field(() => [String], { nullable: 'itemsAndList' }) extraTokens?: string[];
+    @Field(() => [String], { nullable: 'itemsAndList', complexity: 0 })
+    extraTokens?: string[];
 }

--- a/src/modules/tokens/models/assets.model.ts
+++ b/src/modules/tokens/models/assets.model.ts
@@ -1,5 +1,6 @@
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { IAssets, ISocial } from './assets.interface';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType({
     implements: () => [ISocial],
@@ -22,6 +23,10 @@ export class SocialModel implements ISocial {
 export class AssetsModel implements IAssets {
     website?: string;
     description?: string;
+    @Field(() => SocialModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     social?: SocialModel;
     status?: string;
     pngUrl?: string;

--- a/src/modules/tokens/models/esdtToken.interface.ts
+++ b/src/modules/tokens/models/esdtToken.interface.ts
@@ -4,29 +4,31 @@ import { IRoles } from './roles.interface';
 
 @InterfaceType()
 export abstract class IEsdtToken {
-    @Field() identifier: string;
-    @Field() name: string;
-    @Field() ticker: string;
-    @Field() owner: string;
-    @Field({ nullable: true }) minted?: string;
-    @Field({ nullable: true }) burnt?: string;
-    @Field({ nullable: true }) initialMinted?: string;
-    @Field() decimals: number;
+    @Field({ complexity: 0 }) identifier: string;
+    @Field({ complexity: 0 }) name: string;
+    @Field({ complexity: 0 }) ticker: string;
+    @Field({ complexity: 0 }) owner: string;
+    @Field({ nullable: true, complexity: 0 }) minted?: string;
+    @Field({ nullable: true, complexity: 0 }) burnt?: string;
+    @Field({ nullable: true, complexity: 0 }) initialMinted?: string;
+    @Field({ complexity: 0 }) decimals: number;
     @Field({ nullable: true }) price?: string;
-    @Field({ nullable: true }) supply?: string;
-    @Field({ nullable: true }) circulatingSupply?: string;
-    @Field(() => IAssets, { nullable: true }) assets?: IAssets;
-    @Field(() => Int) transactions: number;
-    @Field(() => Int, { defaultValue: 0 }) accounts: number;
-    @Field() isPaused: boolean;
-    @Field() canUpgrade: boolean;
-    @Field() canMint: boolean;
-    @Field() canBurn: boolean;
-    @Field() canChangeOwner: boolean;
-    @Field() canPause: boolean;
-    @Field() canFreeze: boolean;
-    @Field() canWipe: boolean;
-    @Field(() => IRoles, { nullable: true }) roles?: IRoles;
+    @Field({ nullable: true, complexity: 0 }) supply?: string;
+    @Field({ nullable: true, complexity: 0 }) circulatingSupply?: string;
+    @Field(() => IAssets, { nullable: true })
+    assets?: IAssets;
+    @Field(() => Int, { complexity: 0 }) transactions: number;
+    @Field(() => Int, { defaultValue: 0, complexity: 0 }) accounts: number;
+    @Field({ complexity: 0 }) isPaused: boolean;
+    @Field({ complexity: 0 }) canUpgrade: boolean;
+    @Field({ complexity: 0 }) canMint: boolean;
+    @Field({ complexity: 0 }) canBurn: boolean;
+    @Field({ complexity: 0 }) canChangeOwner: boolean;
+    @Field({ complexity: 0 }) canPause: boolean;
+    @Field({ complexity: 0 }) canFreeze: boolean;
+    @Field({ complexity: 0 }) canWipe: boolean;
+    @Field(() => IRoles, { nullable: true })
+    roles?: IRoles;
     @Field({ nullable: true }) type?: string;
-    @Field({ nullable: true }) balance?: string;
+    @Field({ nullable: true, complexity: 0 }) balance?: string;
 }

--- a/src/modules/tokens/models/esdtToken.model.ts
+++ b/src/modules/tokens/models/esdtToken.model.ts
@@ -1,7 +1,8 @@
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { AssetsModel } from './assets.model';
 import { IEsdtToken } from './esdtToken.interface';
 import { RolesModel } from './roles.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 export enum EsdtTokenType {
     FungibleToken = 'FungibleESDT',
@@ -32,6 +33,10 @@ export class EsdtToken implements IEsdtToken {
     trendingScore?: string;
     supply?: string;
     circulatingSupply?: string;
+    @Field(() => AssetsModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     assets?: AssetsModel;
     transactions: number;
     accounts: number;
@@ -43,6 +48,10 @@ export class EsdtToken implements IEsdtToken {
     canPause: boolean;
     canFreeze: boolean;
     canWipe: boolean;
+    @Field(() => RolesModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     roles?: RolesModel;
     type?: string;
     balance?: string;

--- a/src/modules/tokens/models/nft.interface.ts
+++ b/src/modules/tokens/models/nft.interface.ts
@@ -4,24 +4,26 @@ import { IRoles } from './roles.interface';
 
 @InterfaceType()
 export abstract class INFTCollection {
-    @Field() collection: string;
-    @Field() name: string;
-    @Field() ticker: string;
-    @Field(() => Int) decimals: number;
-    @Field() issuer: string;
-    @Field() timestamp: number;
-    @Field() canUpgrade: boolean;
-    @Field() canMint: boolean;
-    @Field() canBurn: boolean;
-    @Field() canChangeOwner: boolean;
-    @Field() canPause: boolean;
-    @Field() canFreeze: boolean;
-    @Field() canWipe: boolean;
-    @Field() canAddSpecialRoles: boolean;
-    @Field() canTransferNFTCreateRole: boolean;
-    @Field() NFTCreateStopped: boolean;
-    @Field(() => IAssets, { nullable: true }) assets?: IAssets;
-    @Field(() => IRoles, { nullable: true }) roles?: IRoles;
+    @Field({ complexity: 0 }) collection: string;
+    @Field({ complexity: 0 }) name: string;
+    @Field({ complexity: 0 }) ticker: string;
+    @Field(() => Int, { complexity: 0 }) decimals: number;
+    @Field({ complexity: 0 }) issuer: string;
+    @Field({ complexity: 0 }) timestamp: number;
+    @Field({ complexity: 0 }) canUpgrade: boolean;
+    @Field({ complexity: 0 }) canMint: boolean;
+    @Field({ complexity: 0 }) canBurn: boolean;
+    @Field({ complexity: 0 }) canChangeOwner: boolean;
+    @Field({ complexity: 0 }) canPause: boolean;
+    @Field({ complexity: 0 }) canFreeze: boolean;
+    @Field({ complexity: 0 }) canWipe: boolean;
+    @Field({ complexity: 0 }) canAddSpecialRoles: boolean;
+    @Field({ complexity: 0 }) canTransferNFTCreateRole: boolean;
+    @Field({ complexity: 0 }) NFTCreateStopped: boolean;
+    @Field(() => IAssets, { nullable: true })
+    assets?: IAssets;
+    @Field(() => IRoles, { nullable: true })
+    roles?: IRoles;
 }
 
 @InterfaceType()

--- a/src/modules/tokens/models/nftCollection.model.ts
+++ b/src/modules/tokens/models/nftCollection.model.ts
@@ -1,7 +1,8 @@
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { AssetsModel } from './assets.model';
 import { INFTCollection } from './nft.interface';
 import { RolesModel } from './roles.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType({
     implements: () => [INFTCollection],
@@ -23,7 +24,15 @@ export class NftCollection implements INFTCollection {
     canAddSpecialRoles: boolean;
     canTransferNFTCreateRole: boolean;
     NFTCreateStopped: boolean;
+    @Field(() => AssetsModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     assets?: AssetsModel;
+    @Field(() => RolesModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     roles?: RolesModel;
 
     constructor(init?: Partial<NftCollection>) {

--- a/src/modules/tokens/models/nftToken.model.ts
+++ b/src/modules/tokens/models/nftToken.model.ts
@@ -1,6 +1,7 @@
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { AssetsModel } from './assets.model';
 import { INFTToken } from './nft.interface';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType({
     implements: () => [INFTToken],
@@ -21,6 +22,10 @@ export class NftToken implements INFTToken {
     url?: string;
     tags?: string[];
     balance: string;
+    @Field(() => AssetsModel, {
+        nullable: true,
+        complexity: nestedFieldComplexity,
+    })
     assets?: AssetsModel;
 
     constructor(init?: Partial<NftToken>) {

--- a/src/modules/tokens/models/roles.interface.ts
+++ b/src/modules/tokens/models/roles.interface.ts
@@ -2,8 +2,8 @@ import { Field, InterfaceType } from '@nestjs/graphql';
 
 @InterfaceType()
 export abstract class IRoles {
-    @Field({ nullable: true }) address?: string;
-    @Field({ nullable: true }) canMint?: boolean;
-    @Field({ nullable: true }) canBurn?: boolean;
+    @Field({ nullable: true, complexity: 0 }) address?: string;
+    @Field({ nullable: true, complexity: 0 }) canMint?: boolean;
+    @Field({ nullable: true, complexity: 0 }) canBurn?: boolean;
     @Field(() => [String], { nullable: 'itemsAndList' }) roles?: string[];
 }

--- a/src/modules/wrapping/models/wrapping.model.ts
+++ b/src/modules/wrapping/models/wrapping.model.ts
@@ -1,4 +1,5 @@
 import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 
 @ObjectType()
@@ -7,7 +8,7 @@ export class WrapModel {
     address: string;
     @Field(() => Int)
     shard: number;
-    @Field()
+    @Field({ complexity: nestedFieldComplexity })
     wrappedToken: EsdtToken;
 
     constructor(init?: Partial<WrapModel>) {

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -40,6 +40,8 @@ import { ComposableTasksModule } from './modules/composable-tasks/composable.tas
 import { TradingViewModule } from './modules/trading-view/trading.view.module';
 import { QueryMetricsPlugin } from './utils/query.metrics.plugin';
 import { CurrencyConverterModule } from './modules/currency-converter/currency.converter.module';
+import { ConditionalModule } from '@nestjs/config';
+import { ComplexityModule } from './complexity.module';
 
 @Module({
     imports: [
@@ -50,6 +52,9 @@ import { CurrencyConverterModule } from './modules/currency-converter/currency.c
             useFactory: async (logger: LoggerService) => ({
                 autoSchemaFile: 'schema.gql',
                 installSubscriptionHandlers: true,
+                parseOptions: {
+                    maxTokens: 500,
+                },
                 formatError: (
                     formattedError: GraphQLFormattedError,
                     error: any,
@@ -101,6 +106,10 @@ import { CurrencyConverterModule } from './modules/currency-converter/currency.c
         DynamicModuleUtils.getCacheModule(),
         TradingViewModule,
         CurrencyConverterModule,
+        ConditionalModule.registerWhen(
+            ComplexityModule,
+            (env: NodeJS.ProcessEnv) => env['ENABLE_COMPLEXITY'] === 'true',
+        ),
     ],
     providers: [QueryMetricsPlugin],
 })

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -53,7 +53,7 @@ import { ComplexityModule } from './complexity.module';
                 autoSchemaFile: 'schema.gql',
                 installSubscriptionHandlers: true,
                 parseOptions: {
-                    maxTokens: 500,
+                    maxTokens: 1000,
                 },
                 formatError: (
                     formattedError: GraphQLFormattedError,

--- a/src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model.ts
+++ b/src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model.ts
@@ -1,6 +1,7 @@
 import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { EnergyModel } from '../../../modules/energy/models/energy.model';
 import { EsdtTokenPayment } from '../../../models/esdtTokenPayment.model';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 
 @ObjectType()
 export class TokenDistributionModel {
@@ -25,10 +26,13 @@ export class GlobalInfoByWeekModel {
     @Field()
     apr: string;
 
-    @Field(() => [EsdtTokenPayment])
+    @Field(() => [EsdtTokenPayment], { complexity: nestedFieldComplexity })
     totalRewardsForWeek: [EsdtTokenPayment];
 
-    @Field(() => [TokenDistributionModel])
+    @Field(() => [
+        TokenDistributionModel,
+        { complexity: nestedFieldComplexity },
+    ])
     rewardsDistributionForWeek: TokenDistributionModel[];
 
     @Field()
@@ -59,13 +63,15 @@ export class UserInfoByWeekModel {
     @Field({ nullable: true })
     positionAmount: string;
 
-    @Field(() => EnergyModel)
+    @Field(() => EnergyModel, { complexity: nestedFieldComplexity })
     energyForWeek: EnergyModel;
 
-    @Field(() => [EsdtTokenPayment])
+    @Field(() => [EsdtTokenPayment], { complexity: nestedFieldComplexity })
     rewardsForWeek: [EsdtTokenPayment];
 
-    @Field(() => [TokenDistributionModel])
+    @Field(() => [TokenDistributionModel], {
+        complexity: nestedFieldComplexity,
+    })
     rewardsDistributionForWeek: TokenDistributionModel[];
 
     constructor(init?: Partial<UserInfoByWeekModel>) {
@@ -75,7 +81,7 @@ export class UserInfoByWeekModel {
 
 @ObjectType()
 export class ClaimProgress {
-    @Field(() => EnergyModel)
+    @Field(() => EnergyModel, { complexity: nestedFieldComplexity })
     energy: EnergyModel;
 
     @Field(() => Int)
@@ -88,7 +94,7 @@ export class ClaimProgress {
 
 @ObjectType()
 export class UserInfoByWeekSubModel {
-    @Field(() => ClaimProgress)
+    @Field(() => ClaimProgress, { complexity: nestedFieldComplexity })
     claimProgress: ClaimProgress;
 
     @Field()

--- a/src/utils/complexity.plugin.ts
+++ b/src/utils/complexity.plugin.ts
@@ -14,6 +14,7 @@ import { GraphQLSchema } from 'graphql';
 import { complexityConfig } from 'src/config';
 import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
+import { rootQueryEstimator } from 'src/helpers/complexity/query.estimators';
 
 @Plugin()
 export class ComplexityPlugin implements ApolloServerPlugin {
@@ -45,9 +46,11 @@ export class ComplexityPlugin implements ApolloServerPlugin {
                     query: document,
                     variables: request.variables,
                     estimators: [
+                        rootQueryEstimator(),
                         fieldExtensionsEstimator(),
-                        simpleEstimator({ defaultComplexity: 1 }),
+                        simpleEstimator({ defaultComplexity: complexityConfig.defaultComplexity }),
                     ],
+                    context: { queryCount: 1 },
                 });
 
                 if (exposeComplexity) {

--- a/src/utils/complexity.plugin.ts
+++ b/src/utils/complexity.plugin.ts
@@ -1,0 +1,78 @@
+import { Plugin } from '@nestjs/apollo';
+import {
+    ApolloServerPlugin,
+    BaseContext,
+    GraphQLRequestListener,
+    GraphQLServerContext,
+} from '@apollo/server';
+import {
+    fieldExtensionsEstimator,
+    getComplexity,
+    simpleEstimator,
+} from 'graphql-query-complexity';
+import { GraphQLSchema } from 'graphql';
+import { complexityConfig } from 'src/config';
+import { GraphQLError } from 'graphql';
+import { ApolloServerErrorCode } from '@apollo/server/errors';
+
+@Plugin()
+export class ComplexityPlugin implements ApolloServerPlugin {
+    private schema: GraphQLSchema;
+
+    async serverWillStart(service: GraphQLServerContext) {
+        this.schema = service.schema;
+    }
+
+    async requestDidStart(): Promise<GraphQLRequestListener<BaseContext>> {
+        const {
+            maxComplexity,
+            exposeComplexity,
+            rejectQueries,
+            collectMetrics,
+        } = complexityConfig;
+        const schema = this.schema;
+
+        return {
+            async didResolveOperation({
+                request,
+                document,
+                response,
+                contextValue,
+            }) {
+                const complexity = getComplexity({
+                    schema,
+                    operationName: request.operationName,
+                    query: document,
+                    variables: request.variables,
+                    estimators: [
+                        fieldExtensionsEstimator(),
+                        simpleEstimator({ defaultComplexity: 1 }),
+                    ],
+                });
+
+                if (exposeComplexity) {
+                    response.http.headers.set(
+                        'X-Operation-Complexity',
+                        complexity.toFixed(),
+                    );
+                }
+
+                if (collectMetrics) {
+                    // query metrics plugin will handle collection
+                    contextValue['complexity'] = complexity;
+                }
+
+                if (rejectQueries && complexity > maxComplexity) {
+                    throw new GraphQLError(
+                        `Query is too complex: ${complexity}. Maximum allowed complexity: ${maxComplexity}`,
+                        {
+                            extensions: {
+                                code: ApolloServerErrorCode.BAD_USER_INPUT,
+                            },
+                        },
+                    );
+                }
+            },
+        };
+    }
+}

--- a/src/utils/complexity.plugin.ts
+++ b/src/utils/complexity.plugin.ts
@@ -48,9 +48,12 @@ export class ComplexityPlugin implements ApolloServerPlugin {
                     estimators: [
                         rootQueryEstimator(),
                         fieldExtensionsEstimator(),
-                        simpleEstimator({ defaultComplexity: complexityConfig.defaultComplexity }),
+                        simpleEstimator({
+                            defaultComplexity:
+                                complexityConfig.defaultComplexity,
+                        }),
                     ],
-                    context: { queryCount: 1 },
+                    context: { queryCount: 0 },
                 });
 
                 if (exposeComplexity) {

--- a/src/utils/metrics.collector.ts
+++ b/src/utils/metrics.collector.ts
@@ -5,6 +5,7 @@ export class MetricsCollector {
     private static fieldDurationHistogram: Histogram<string>;
     private static queryDurationHistogram: Histogram<string>;
     private static queryCpuHistogram: Histogram<string>;
+    private static queryComplexityHistogram: Histogram<string>;
     private static awsQueryDurationHistogram: Histogram<string>;
     private static dataApiQueryDurationHistogram: Histogram<string>;
     private static gasDifferenceHistogram: Histogram<string>;
@@ -39,6 +40,15 @@ export class MetricsCollector {
             MetricsCollector.queryCpuHistogram = new Histogram({
                 name: 'query_cpu',
                 help: 'The CPU time it takes to resolve a query',
+                labelNames: ['query', 'origin'],
+                buckets: [],
+            });
+        }
+
+        if (!MetricsCollector.queryComplexityHistogram) {
+            MetricsCollector.queryComplexityHistogram = new Histogram({
+                name: 'query_complexity',
+                help: 'The estimated complexity of a query',
                 labelNames: ['query', 'origin'],
                 buckets: [],
             });
@@ -131,6 +141,17 @@ export class MetricsCollector {
         MetricsCollector.queryCpuHistogram
             .labels(query, origin)
             .observe(duration);
+    }
+
+    static setQueryComplexity(
+        query: string,
+        origin: string,
+        complexity: number,
+    ) {
+        MetricsCollector.ensureIsInitialized();
+        MetricsCollector.queryComplexityHistogram
+            .labels(query, origin)
+            .observe(complexity);
     }
 
     static setRedisDuration(action: string, duration: number) {

--- a/src/utils/query.metrics.plugin.ts
+++ b/src/utils/query.metrics.plugin.ts
@@ -31,7 +31,11 @@ export class QueryMetricsPlugin implements ApolloServerPlugin {
                 cpuProfiler = new CpuProfiler();
                 profiler.start(operationName);
             },
-            async willSendResponse(): Promise<void> {
+            async willSendResponse({ contextValue }): Promise<void> {
+                if (profiler === undefined) {
+                    return;
+                }
+
                 profiler.stop(operationName);
                 const cpuTime = cpuProfiler.stop();
 
@@ -42,6 +46,14 @@ export class QueryMetricsPlugin implements ApolloServerPlugin {
                 );
 
                 MetricsCollector.setQueryCpu(operationName, origin, cpuTime);
+
+                if (contextValue.complexity) {
+                    MetricsCollector.setQueryComplexity(
+                        operationName,
+                        origin,
+                        contextValue.complexity,
+                    );
+                }
             },
         };
     }

--- a/src/utils/relay.types.ts
+++ b/src/utils/relay.types.ts
@@ -12,25 +12,25 @@ export default function relayTypes<T>(type: Type<T>): any {
     class Edge implements Relay.Edge<T> {
         public name = `${name}Edge`;
 
-        @Field({ nullable: true })
+        @Field({ nullable: true, complexity: 0 })
         public cursor!: Relay.ConnectionCursor;
 
-        @Field(() => type, { nullable: true })
+        @Field(() => type, { nullable: true, complexity: 0 })
         public node!: T;
     }
 
     @ObjectType(`${name}PageInfo`, { isAbstract: true })
     class PageInfo implements Relay.PageInfo {
-        @Field({ nullable: true })
+        @Field({ nullable: true, complexity: 0 })
         public startCursor!: Relay.ConnectionCursor;
 
-        @Field({ nullable: true })
+        @Field({ nullable: true, complexity: 0 })
         public endCursor!: Relay.ConnectionCursor;
 
-        @Field(() => Boolean)
+        @Field(() => Boolean, { complexity: 0 })
         public hasPreviousPage!: boolean;
 
-        @Field(() => Boolean)
+        @Field(() => Boolean, { complexity: 0 })
         public hasNextPage!: boolean;
     }
 
@@ -38,22 +38,22 @@ export default function relayTypes<T>(type: Type<T>): any {
     class Connection implements Relay.Connection<T> {
         public name = `${name}Connection`;
 
-        @Field(() => [Edge], { nullable: true })
+        @Field(() => [Edge], { nullable: true, complexity: 0 })
         public edges!: Relay.Edge<T>[];
 
-        @Field(() => PageInfo, { nullable: true })
+        @Field(() => PageInfo, { nullable: true, complexity: 0 })
         public pageInfo!: Relay.PageInfo;
     }
 
     @ObjectType(`${name}Page`, { isAbstract: true })
     abstract class Page {
-        @Field(() => [Edge], { nullable: true })
+        @Field(() => [Edge], { nullable: true, complexity: 0 })
         public edges!: Relay.Edge<T>[];
 
-        @Field(() => PageInfo, { nullable: true })
+        @Field(() => PageInfo, { nullable: true, complexity: 0 })
         public pageInfo!: Relay.PageInfo;
 
-        @Field(() => PageData, { nullable: true })
+        @Field(() => PageData, { nullable: true, complexity: 0 })
         public pageData!: PageData;
     }
 


### PR DESCRIPTION
## Reasoning
- the API currently suffers performance issues due to overly complex GraphQL queries
- there is no mechanism in place to monitor or limit query complexity
- tracking complexity metrics will allow us to gather insights before enabling request rejections in the future
  
## Proposed Changes
- install `graphql-query-complexity` package + create an apollo plugin
- apply exponential cost calculations when multiple sub-queries are present (`rootQueryEstimator`)
- custom estimators for nested fields, paginated queries, relay (filtered) queries
- add custom estimators to the most expensive models (pair, farm, esdt token, nft, staking, staking proxy)

## How to test
- set environment variable `ENABLE_COMPLEXITY=true`
- configure the plugin by changing the settings in `config/default.json`
```
"complexity": {
      "maxComplexity": 3000,
      "defaultComplexity": 1,
      "collectMetrics": true,
      "exposeComplexity": true,
      "rejectQueries": false,
      "costModifiers": {
        "nested": 1.5,
        "exponentialBase": 10
      }
    }
```
- check the response header `X-Operation-Complexity` to validate that complexity metrics are being returned
