### PR TITLE
[MEX-666] - Fix: Return Rates instead of prices for Crypto

### DIFF
--- a/src/modules/currency-converter/services/currency.converter.service.ts
+++ b/src/modules/currency-converter/services/currency.converter.service.ts
@@ -46,11 +46,13 @@ export class CurrencyConverterService {
         const tokenRates: CurrencyRateModel[] = cryptoRatesIdentifiers.map(
             (identifier, index) => {
                 const token = tokens.find((t) => t.identifier === identifier);
-                const rate = tokenPrices[index];
+                const price = tokenPrices[index];
                 const [symbol, name] =
                     identifier === tokenProviderUSD
                         ? [mxConfig.EGLDIdentifier, mxConfig.EGLDIdentifier]
                         : [identifier.split('-')[0], token.name];
+
+                const rate = new BigNumber(1).dividedBy(price).toNumber();
                 return {
                     symbol,
                     rate: new BigNumber(rate).toNumber(),

--- a/src/modules/currency-converter/services/currency.converter.service.ts
+++ b/src/modules/currency-converter/services/currency.converter.service.ts
@@ -55,7 +55,7 @@ export class CurrencyConverterService {
                 const rate = new BigNumber(1).dividedBy(price).toNumber();
                 return {
                     symbol,
-                    rate: new BigNumber(rate).toNumber(),
+                    rate,
                     category: CurrencyRateType.CRYPTO,
                     name,
                 };


### PR DESCRIPTION
## Reasoning
- For Cryptocurrencies The Price was returned instead of the rate
  
## Proposed Changes
- Return The Rate for all Cryptocurrencies

## How to test
```
currencyRates (symbols: ["EGLD", "WBTC", "WETH"]) {
      symbol
      rate
      category
      name
}
```
