### PR TITLE
[MEX-691] Weekly rewards and timekeeping cache warmers

### DIFF
--- a/src/modules/fees-collector/services/fees-collector.compute.service.ts
+++ b/src/modules/fees-collector/services/fees-collector.compute.service.ts
@@ -163,7 +163,10 @@ export class FeesCollectorComputeService {
             .multipliedBy(userEnergyForWeek.amount)
             .dividedBy(totalEnergyForWeek);
 
-        return userRewardsForWeekUSD.toFixed();
+        return userRewardsForWeekUSD.isNaN() ||
+            !userRewardsForWeekUSD.isFinite()
+            ? '0'
+            : userRewardsForWeekUSD.toFixed();
     }
 
     async computeUserRewardsAPR(

--- a/src/services/cache.warmer.module.ts
+++ b/src/services/cache.warmer.module.ts
@@ -45,6 +45,7 @@ import { ElasticSearchModule } from './elastic-search/elastic.search.module';
 import { EventsProcessorService } from './crons/events.processor.service';
 import { CurrencyConverterCacheWarmerService } from './crons/currency.converter.cache.warmer.service';
 import { CurrencyConverterModule } from 'src/modules/currency-converter/currency.converter.module';
+import { WeekTimekeepingCacheWarmerService } from './crons/week.timekeeping.cache.warmer.service';
 
 @Module({
     imports: [
@@ -97,6 +98,7 @@ import { CurrencyConverterModule } from 'src/modules/currency-converter/currency
         EscrowCacheWarmerService,
         FeesCollectorCacheWarmerService,
         CurrencyConverterCacheWarmerService,
+        WeekTimekeepingCacheWarmerService,
     ],
 })
 export class CacheWarmerModule {}

--- a/src/services/cache.warmer.module.ts
+++ b/src/services/cache.warmer.module.ts
@@ -46,6 +46,7 @@ import { EventsProcessorService } from './crons/events.processor.service';
 import { CurrencyConverterCacheWarmerService } from './crons/currency.converter.cache.warmer.service';
 import { CurrencyConverterModule } from 'src/modules/currency-converter/currency.converter.module';
 import { WeekTimekeepingCacheWarmerService } from './crons/week.timekeeping.cache.warmer.service';
+import { WeeklyRewardsSplittingCacheWarmerService } from './crons/weekly.rewards.cache.warmer.service';
 
 @Module({
     imports: [
@@ -99,6 +100,7 @@ import { WeekTimekeepingCacheWarmerService } from './crons/week.timekeeping.cach
         FeesCollectorCacheWarmerService,
         CurrencyConverterCacheWarmerService,
         WeekTimekeepingCacheWarmerService,
+        WeeklyRewardsSplittingCacheWarmerService,
     ],
 })
 export class CacheWarmerModule {}

--- a/src/services/crons/week.timekeeping.cache.warmer.service.ts
+++ b/src/services/crons/week.timekeeping.cache.warmer.service.ts
@@ -1,0 +1,99 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { PUB_SUB } from '../redis.pubSub.module';
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { WeekTimekeepingAbiService } from 'src/submodules/week-timekeeping/services/week-timekeeping.abi.service';
+import { WeekTimekeepingComputeService } from 'src/submodules/week-timekeeping/services/week-timekeeping.compute.service';
+import { WeekTimekeepingSetterService } from 'src/submodules/week-timekeeping/services/week-timekeeping.setter.service';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Lock } from '@multiversx/sdk-nestjs-common';
+import { PerformanceProfiler } from '@multiversx/sdk-nestjs-monitoring';
+import { scAddress } from 'src/config';
+import { farmsAddresses } from 'src/utils/farm.utils';
+import { FarmVersion } from 'src/modules/farm/models/farm.model';
+import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
+
+@Injectable()
+export class WeekTimekeepingCacheWarmerService {
+    constructor(
+        @Inject(PUB_SUB) private pubSub: RedisPubSub,
+        @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
+        private readonly remoteConfigGetterService: RemoteConfigGetterService,
+        private readonly weekTimekeepingAbi: WeekTimekeepingAbiService,
+        private readonly weekTimekeepingCompute: WeekTimekeepingComputeService,
+        private readonly weekTimekeepingSetter: WeekTimekeepingSetterService,
+    ) {}
+
+    @Cron(CronExpression.EVERY_MINUTE)
+    @Lock({ name: 'cacheWeekTimekeepingData', verbose: true })
+    async cacheWeekTimekeepingData(): Promise<void> {
+        this.logger.info(
+            'Start refresh week timekeeping data for farms, staking and fees collector',
+            {
+                context: 'WeekTimekeepingCacheWarmer',
+            },
+        );
+
+        const addresses = [
+            scAddress.feesCollector,
+            ...farmsAddresses([FarmVersion.V2]),
+            ...(await this.remoteConfigGetterService.getStakingAddresses()),
+        ];
+
+        const profiler = new PerformanceProfiler();
+
+        for (const address of addresses) {
+            const [currentWeek, firstWeekStartEpoch] = await Promise.all([
+                this.weekTimekeepingAbi.getCurrentWeekRaw(address),
+                this.weekTimekeepingAbi.firstWeekStartEpochRaw(address),
+            ]);
+
+            const abiCacheKeys = await Promise.all([
+                this.weekTimekeepingSetter.currentWeek(address, currentWeek),
+                this.weekTimekeepingSetter.firstWeekStartEpoch(
+                    address,
+                    firstWeekStartEpoch,
+                ),
+            ]);
+
+            const [startEpochForWeek, endEpochForWeek] = await Promise.all([
+                this.weekTimekeepingCompute.computeStartEpochForWeek(
+                    address,
+                    currentWeek,
+                ),
+                this.weekTimekeepingCompute.computeEndEpochForWeek(
+                    address,
+                    currentWeek,
+                ),
+            ]);
+
+            const computeCacheKeys = await Promise.all([
+                this.weekTimekeepingSetter.startEpochForWeek(
+                    address,
+                    currentWeek,
+                    startEpochForWeek,
+                ),
+                this.weekTimekeepingSetter.endEpochForWeek(
+                    address,
+                    currentWeek,
+                    endEpochForWeek,
+                ),
+            ]);
+
+            await this.deleteCacheKeys([...abiCacheKeys, ...computeCacheKeys]);
+        }
+
+        profiler.stop();
+        this.logger.info(
+            `Finish refresh week timekeeping data in ${profiler.duration}`,
+            {
+                context: 'WeekTimekeepingCacheWarmer',
+            },
+        );
+    }
+
+    private async deleteCacheKeys(invalidatedKeys: string[]) {
+        await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
+    }
+}

--- a/src/services/crons/weekly.rewards.cache.warmer.service.ts
+++ b/src/services/crons/weekly.rewards.cache.warmer.service.ts
@@ -1,0 +1,122 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { PUB_SUB } from '../redis.pubSub.module';
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Lock } from '@multiversx/sdk-nestjs-common';
+import { constantsConfig, scAddress } from 'src/config';
+import { farmsAddresses } from 'src/utils/farm.utils';
+import { FarmVersion } from 'src/modules/farm/models/farm.model';
+import { PerformanceProfiler } from '@multiversx/sdk-nestjs-monitoring';
+import { WeekTimekeepingAbiService } from 'src/submodules/week-timekeeping/services/week-timekeeping.abi.service';
+import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
+import { WeeklyRewardsSplittingSetterService } from 'src/submodules/weekly-rewards-splitting/services/weekly.rewarrds.splitting.setter.service';
+
+@Injectable()
+export class WeeklyRewardsSplittingCacheWarmerService {
+    constructor(
+        @Inject(PUB_SUB) private pubSub: RedisPubSub,
+        @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
+        private readonly remoteConfigGetterService: RemoteConfigGetterService,
+        private readonly weekTimekeepingAbi: WeekTimekeepingAbiService,
+        private readonly weeklyRewardsSplittingAbi: WeeklyRewardsSplittingAbiService,
+        private readonly weeklyRewardsSplittingSetter: WeeklyRewardsSplittingSetterService,
+    ) {}
+
+    @Cron(CronExpression.EVERY_MINUTE)
+    @Lock({ name: 'cacheWeeklyRewardsData', verbose: true })
+    async cacheWeeklyRewardsData(): Promise<void> {
+        this.logger.info(
+            'Start refresh weekly rewards data for farms, staking and fees collector',
+            {
+                context: 'WeeklyRewardsSplittingCacheWarmer',
+            },
+        );
+
+        const addresses = [
+            scAddress.feesCollector,
+            ...farmsAddresses([FarmVersion.V2]),
+            ...(await this.remoteConfigGetterService.getStakingAddresses()),
+        ];
+        const profiler = new PerformanceProfiler();
+
+        for (const address of addresses) {
+            const currentWeek = await this.weekTimekeepingAbi.currentWeek(
+                address,
+            );
+
+            const cachedKeys = await this.cacheClaimWeeksData(
+                currentWeek,
+                address,
+            );
+
+            await this.deleteCacheKeys(cachedKeys);
+        }
+
+        profiler.stop();
+        this.logger.info(
+            `Finish refresh weekly rewards data in ${profiler.duration}`,
+            {
+                context: 'WeeklyRewardsSplittingCacheWarmer',
+            },
+        );
+    }
+
+    private async cacheClaimWeeksData(
+        currentWeek: number,
+        scAddress: string,
+    ): Promise<string[]> {
+        const cachedKeys = [];
+        const startWeek = currentWeek - constantsConfig.USER_MAX_CLAIM_WEEKS;
+
+        for (let week = startWeek; week <= currentWeek; week++) {
+            if (week < 1) {
+                continue;
+            }
+
+            const totalEnergyForWeek =
+                await this.weeklyRewardsSplittingAbi.totalEnergyForWeekRaw(
+                    scAddress,
+                    week,
+                );
+            const totalRewardsForWeek =
+                await this.weeklyRewardsSplittingAbi.totalRewardsForWeekRaw(
+                    scAddress,
+                    week,
+                );
+            const totalLockedTokensForWeek =
+                await this.weeklyRewardsSplittingAbi.totalLockedTokensForWeekRaw(
+                    scAddress,
+                    week,
+                );
+
+            const keys = await Promise.all([
+                this.weeklyRewardsSplittingSetter.totalEnergyForWeek(
+                    scAddress,
+                    week,
+                    totalEnergyForWeek,
+                ),
+                this.weeklyRewardsSplittingSetter.totalRewardsForWeek(
+                    scAddress,
+                    week,
+                    totalRewardsForWeek,
+                ),
+                this.weeklyRewardsSplittingSetter.totalLockedTokensForWeek(
+                    scAddress,
+                    week,
+                    totalLockedTokensForWeek,
+                ),
+            ]);
+
+            cachedKeys.push(...keys);
+        }
+
+        return cachedKeys;
+    }
+
+    private async deleteCacheKeys(invalidatedKeys: string[]) {
+        await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
+    }
+}

--- a/src/submodules/week-timekeeping/services/week-timekeeping.setter.service.ts
+++ b/src/submodules/week-timekeeping/services/week-timekeeping.setter.service.ts
@@ -1,0 +1,65 @@
+import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { Inject, Injectable } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
+import { GenericSetterService } from 'src/services/generics/generic.setter.service';
+import { Logger } from 'winston';
+
+@Injectable()
+export class WeekTimekeepingSetterService extends GenericSetterService {
+    constructor(
+        protected readonly cachingService: CacheService,
+        @Inject(WINSTON_MODULE_NEST_PROVIDER) protected readonly logger: Logger,
+    ) {
+        super(cachingService, logger);
+
+        this.baseKey = 'weekTimekeeping';
+    }
+
+    async currentWeek(scAddress: string, value: number): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('currentWeek', scAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+
+    async firstWeekStartEpoch(
+        scAddress: string,
+        value: number,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('firstWeekStartEpoch', scAddress),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+
+    async startEpochForWeek(
+        scAddress: string,
+        week: number,
+        value: number,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('startEpochForWeek', scAddress, week),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+
+    async endEpochForWeek(
+        scAddress: string,
+        week: number,
+        value: number,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('endEpochForWeek', scAddress, week),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
+}

--- a/src/submodules/week-timekeeping/week-timekeeping.module.ts
+++ b/src/submodules/week-timekeeping/week-timekeeping.module.ts
@@ -8,6 +8,7 @@ import { FarmModuleV2 } from 'src/modules/farm/v2/farm.v2.module';
 import { FeesCollectorModule } from 'src/modules/fees-collector/fees-collector.module';
 import { ContextModule } from 'src/services/context/context.module';
 import { RemoteConfigModule } from 'src/modules/remote-config/remote-config.module';
+import { WeekTimekeepingSetterService } from './services/week-timekeeping.setter.service';
 
 @Module({
     imports: [
@@ -22,7 +23,12 @@ import { RemoteConfigModule } from 'src/modules/remote-config/remote-config.modu
         WeekTimekeepingAbiService,
         WeekTimekeepingComputeService,
         WeekTimekeepingResolver,
+        WeekTimekeepingSetterService,
     ],
-    exports: [WeekTimekeepingAbiService, WeekTimekeepingComputeService],
+    exports: [
+        WeekTimekeepingAbiService,
+        WeekTimekeepingComputeService,
+        WeekTimekeepingSetterService,
+    ],
 })
 export class WeekTimekeepingModule {}

--- a/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
+++ b/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
@@ -92,10 +92,11 @@ export class WeeklyRewardsSplittingComputeService
         const totalRewardsForWeekPriceUSD =
             await this.computeTotalRewardsForWeekUSD(scAddress, week);
 
-        return new BigNumber(totalRewardsForWeekPriceUSD)
+        const weekAPR = new BigNumber(totalRewardsForWeekPriceUSD)
             .times(52)
-            .div(totalLockedTokensForWeekPriceUSD)
-            .toFixed();
+            .div(totalLockedTokensForWeekPriceUSD);
+
+        return weekAPR.isNaN() || !weekAPR.isFinite() ? '0' : weekAPR.toFixed();
     }
 
     @ErrorLoggerAsync({
@@ -141,9 +142,9 @@ export class WeeklyRewardsSplittingComputeService
             .multipliedBy(new BigNumber(userEnergyForWeek.amount))
             .multipliedBy(new BigNumber(totalLockedTokensForWeek))
             .div(new BigNumber(totalEnergyForWeek))
-            .div(new BigNumber(userEnergyForWeek.totalLockedTokens))
-            .toFixed();
-        return apr;
+            .div(new BigNumber(userEnergyForWeek.totalLockedTokens));
+
+        return apr.isNaN() || !apr.isFinite() ? '0' : apr.toFixed();
     }
 
     @ErrorLoggerAsync({


### PR DESCRIPTION
## Reasoning
- week timekeeping data for farms, fees collector and staking contracts is used in various computations for user queries. The current implementation fetches this data on user request only, causing poor performance
  
## Proposed Changes
- added 2 new cache warmers for week timekeeping and weekly rewards splitting data (for farms, staking and fees collector)
- small fix for certain fields returning "NaN" (division by 0)

## How to test
- N/A
