### PR TITLE
[MEX-699] In-memory cache service with true ttl cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@datastructures-js/priority-queue": "^6.1.0",
                 "@elastic/elasticsearch": "7.12.0",
                 "@golevelup/nestjs-rabbitmq": "^4.0.0",
+                "@isaacs/ttlcache": "^1.4.1",
                 "@multiversx/sdk-core": "^13.6.3",
                 "@multiversx/sdk-exchange": "^0.2.21",
                 "@multiversx/sdk-native-auth-server": "1.0.19",
@@ -2355,6 +2356,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/ttlcache": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+            "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@datastructures-js/priority-queue": "^6.1.0",
         "@elastic/elasticsearch": "7.12.0",
         "@golevelup/nestjs-rabbitmq": "^4.0.0",
+        "@isaacs/ttlcache": "^1.4.1",
         "@multiversx/sdk-core": "^13.6.3",
         "@multiversx/sdk-exchange": "^0.2.21",
         "@multiversx/sdk-native-auth-server": "1.0.19",

--- a/src/endpoints/cache/cache.controller.ts
+++ b/src/endpoints/cache/cache.controller.ts
@@ -13,8 +13,6 @@ export class CacheController {
 
     @EventPattern('deleteCacheKeys')
     async deleteCacheKey(keys: string[]) {
-        for (const key of keys) {
-            await this.cachingService.deleteLocal(key);
-        }
+        this.cachingService.deleteManyLocal(keys);
     }
 }

--- a/src/endpoints/cache/cache.controller.ts
+++ b/src/endpoints/cache/cache.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Inject } from '@nestjs/common';
 import { EventPattern } from '@nestjs/microservices';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Logger } from 'winston';
 
 @Controller()

--- a/src/helpers/decorators/caching.decorator.ts
+++ b/src/helpers/decorators/caching.decorator.ts
@@ -1,5 +1,5 @@
 import { Inject } from '@nestjs/common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 import { ContextTracker } from '@multiversx/sdk-nestjs-common';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';

--- a/src/helpers/decorators/caching.decorator.ts
+++ b/src/helpers/decorators/caching.decorator.ts
@@ -46,7 +46,7 @@ export function GetOrSetCache(cachingOptions: ICachingOptions) {
 
             const cachingService: CacheService = this.cachingService;
 
-            const locallyCachedValue = await cachingService.getLocal(cacheKey);
+            const locallyCachedValue = cachingService.getLocal(cacheKey);
             if (locallyCachedValue !== undefined) {
                 MetricsCollector.incrementLocalCacheHit(genericCacheKey);
 
@@ -60,7 +60,8 @@ export function GetOrSetCache(cachingOptions: ICachingOptions) {
                 cachingService.setLocal(
                     cacheKey,
                     cachedValue,
-                    cachingOptions.localTtl,
+                    cachingOptions.localTtl ??
+                        Math.floor(cachingOptions.remoteTtl / 2),
                 );
                 return parseCachedNullOrUndefined(cachedValue);
             }

--- a/src/modules/analytics/services/analytics.aws.getter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.getter.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { generateCacheKeyFromParams } from '../../../utils/generate-cache-key';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { HistoricDataModel } from '../models/analytics.model';
 import moment from 'moment';
 import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';

--- a/src/modules/analytics/services/analytics.aws.setter.service.ts
+++ b/src/modules/analytics/services/analytics.aws.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Logger } from 'winston';
 import { HistoricDataModel } from '../models/analytics.model';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';

--- a/src/modules/analytics/services/analytics.setter.service.ts
+++ b/src/modules/analytics/services/analytics.setter.service.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
 import { TradingActivityModel } from '../models/trading.activity.model';

--- a/src/modules/auth/jwt.or.native.admin.guard.ts
+++ b/src/modules/auth/jwt.or.native.admin.guard.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ApiConfigService } from 'src/helpers/api.config.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { GqlAdminGuard } from './gql.admin.guard';
 import { NativeAdminGuard } from './native.admin.guard';
 

--- a/src/modules/auth/jwt.or.native.auth.guard.ts
+++ b/src/modules/auth/jwt.or.native.auth.guard.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { ApiConfigService } from 'src/helpers/api.config.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Logger } from 'winston';
 import { GqlAuthGuard } from './gql.auth.guard';
 import { NativeAuthGuard } from './native.auth.guard';

--- a/src/modules/auth/native.admin.guard.ts
+++ b/src/modules/auth/native.admin.guard.ts
@@ -10,7 +10,7 @@ import {
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ApiConfigService } from 'src/helpers/api.config.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { UrlUtils } from '@multiversx/sdk-nestjs-common';
 
 @Injectable()

--- a/src/modules/auth/native.auth.guard.ts
+++ b/src/modules/auth/native.auth.guard.ts
@@ -9,7 +9,7 @@ import {
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { ApiConfigService } from 'src/helpers/api.config.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { UrlUtils } from '@multiversx/sdk-nestjs-common';
 import { Logger } from 'winston';
 

--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -17,7 +17,7 @@ import { PairTransactionService } from 'src/modules/pair/services/pair.transacti
 import { computeValueUSD, denominateAmount } from 'src/utils/token.converters';
 import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
 import { GraphService } from './graph.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { WrapAbiService } from 'src/modules/wrapping/services/wrap.abi.service';

--- a/src/modules/currency-converter/services/currency.converter.setter.service.ts
+++ b/src/modules/currency-converter/services/currency.converter.setter.service.ts
@@ -1,4 +1,4 @@
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';

--- a/src/modules/energy/services/energy.setter.service.ts
+++ b/src/modules/energy/services/energy.setter.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/escrow/services/escrow.abi.service.ts
+++ b/src/modules/escrow/services/escrow.abi.service.ts
@@ -17,7 +17,7 @@ import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { EscrowSetterService } from './escrow.setter.service';
 import { EscrowAbiServiceInterface } from './interfaces';
 

--- a/src/modules/escrow/services/escrow.setter.service.ts
+++ b/src/modules/escrow/services/escrow.setter.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
 import { ScheduledTransferModel } from '../models/escrow.model';

--- a/src/modules/escrow/specs/escrow.abi.service.spec.ts
+++ b/src/modules/escrow/specs/escrow.abi.service.spec.ts
@@ -11,7 +11,7 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
 import winston from 'winston';
 import { EscrowSetterService } from '../services/escrow.setter.service';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 describe('EscrowAbiService', () => {
     let service: EscrowAbiService;

--- a/src/modules/farm/base-module/services/farm.abi.loader.ts
+++ b/src/modules/farm/base-module/services/farm.abi.loader.ts
@@ -4,7 +4,7 @@ import DataLoader from 'dataloader';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { FarmAbiService } from './farm.abi.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 

--- a/src/modules/farm/base-module/services/farm.abi.service.ts
+++ b/src/modules/farm/base-module/services/farm.abi.service.ts
@@ -14,7 +14,7 @@ import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { IFarmAbiService } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 
 export class FarmAbiService

--- a/src/modules/farm/base-module/services/farm.base.service.ts
+++ b/src/modules/farm/base-module/services/farm.base.service.ts
@@ -11,7 +11,7 @@ import {
     FarmTokenAttributesModelV1_3,
     FarmTokenAttributesModelV2,
 } from '../../models/farmTokenAttributes.model';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
 import { Inject, forwardRef } from '@nestjs/common';

--- a/src/modules/farm/base-module/services/farm.compute.loader.ts
+++ b/src/modules/farm/base-module/services/farm.compute.loader.ts
@@ -1,7 +1,7 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { FarmComputeService } from './farm.compute.service';
 import DataLoader from 'dataloader';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 

--- a/src/modules/farm/base-module/services/farm.compute.service.ts
+++ b/src/modules/farm/base-module/services/farm.compute.service.ts
@@ -13,7 +13,7 @@ import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { FarmServiceBase } from './farm.base.service';
 import { Inject, forwardRef } from '@nestjs/common';
 import { IFarmComputeService } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 export abstract class FarmComputeService implements IFarmComputeService {
     constructor(

--- a/src/modules/farm/base-module/services/farm.setter.service.ts
+++ b/src/modules/farm/base-module/services/farm.setter.service.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/farm/custom/services/farm.custom.abi.loader.ts
+++ b/src/modules/farm/custom/services/farm.custom.abi.loader.ts
@@ -2,7 +2,7 @@ import { Injectable, Scope } from '@nestjs/common';
 import { FarmAbiLoader } from '../../base-module/services/farm.abi.loader';
 import { FarmCustomService } from './farm.custom.service';
 import { FarmCustomAbiService } from './farm.custom.abi.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/custom/services/farm.custom.compute.loader.ts
+++ b/src/modules/farm/custom/services/farm.custom.compute.loader.ts
@@ -1,7 +1,7 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { FarmComputeLoader } from '../../base-module/services/farm.compute.loader';
 import { FarmCustomComputeService } from './farm.custom.compute.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/custom/services/farm.custom.compute.service.ts
+++ b/src/modules/farm/custom/services/farm.custom.compute.service.ts
@@ -6,7 +6,7 @@ import { PairComputeService } from 'src/modules/pair/services/pair.compute.servi
 import { ContextGetterService } from 'src/services/context/context.getter.service';
 import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
 import { FarmCustomService } from './farm.custom.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class FarmCustomComputeService extends FarmComputeService {

--- a/src/modules/farm/custom/services/farm.custom.service.ts
+++ b/src/modules/farm/custom/services/farm.custom.service.ts
@@ -6,7 +6,7 @@ import { FarmTokenAttributesModel } from '../../models/farmTokenAttributes.model
 import { FarmCustomAbiService } from './farm.custom.abi.service';
 import { FarmCustomComputeService } from './farm.custom.compute.service';
 import { ContextGetterService } from 'src/services/context/context.getter.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 
 @Injectable()

--- a/src/modules/farm/farm.abi.factory.ts
+++ b/src/modules/farm/farm.abi.factory.ts
@@ -5,7 +5,7 @@ import { FarmVersion } from './models/farm.model';
 import { FarmAbiServiceV1_2 } from './v1.2/services/farm.v1.2.abi.service';
 import { FarmAbiServiceV1_3 } from './v1.3/services/farm.v1.3.abi.service';
 import { FarmAbiServiceV2 } from './v2/services/farm.v2.abi.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 
 @Injectable()

--- a/src/modules/farm/v1.2/services/farm.v1.2.abi.loader.ts
+++ b/src/modules/farm/v1.2/services/farm.v1.2.abi.loader.ts
@@ -2,7 +2,7 @@ import { Injectable, Scope } from '@nestjs/common';
 import { FarmAbiLoader } from '../../base-module/services/farm.abi.loader';
 import { FarmServiceV1_2 } from './farm.v1.2.service';
 import { FarmAbiServiceV1_2 } from './farm.v1.2.abi.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/v1.2/services/farm.v1.2.abi.service.ts
+++ b/src/modules/farm/v1.2/services/farm.v1.2.abi.service.ts
@@ -10,7 +10,7 @@ import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { IFarmAbiServiceV1_2 } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class FarmAbiServiceV1_2

--- a/src/modules/farm/v1.2/services/farm.v1.2.compute.loader.ts
+++ b/src/modules/farm/v1.2/services/farm.v1.2.compute.loader.ts
@@ -1,7 +1,7 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { FarmComputeLoader } from '../../base-module/services/farm.compute.loader';
 import { FarmComputeServiceV1_2 } from './farm.v1.2.compute.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/v1.2/services/farm.v1.2.compute.service.ts
+++ b/src/modules/farm/v1.2/services/farm.v1.2.compute.service.ts
@@ -13,7 +13,7 @@ import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { IFarmComputeServiceV1_2 } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class FarmComputeServiceV1_2

--- a/src/modules/farm/v1.2/services/farm.v1.2.service.ts
+++ b/src/modules/farm/v1.2/services/farm.v1.2.service.ts
@@ -3,7 +3,7 @@ import { RewardsModel } from '../../models/farm.model';
 import { CalculateRewardsArgs } from '../../models/farm.args';
 import BigNumber from 'bignumber.js';
 import { ContextGetterService } from 'src/services/context/context.getter.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { FarmAbiServiceV1_2 } from './farm.v1.2.abi.service';
 import { FarmComputeServiceV1_2 } from './farm.v1.2.compute.service';
 import { FarmTokenAttributesV1_2 } from '@multiversx/sdk-exchange';

--- a/src/modules/farm/v1.3/services/farm.v1.3.abi.loader.ts
+++ b/src/modules/farm/v1.3/services/farm.v1.3.abi.loader.ts
@@ -2,7 +2,7 @@ import { Injectable, Scope } from '@nestjs/common';
 import { FarmAbiLoader } from '../../base-module/services/farm.abi.loader';
 import { FarmServiceV1_3 } from './farm.v1.3.service';
 import { FarmAbiServiceV1_3 } from './farm.v1.3.abi.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/v1.3/services/farm.v1.3.abi.service.ts
+++ b/src/modules/farm/v1.3/services/farm.v1.3.abi.service.ts
@@ -10,7 +10,7 @@ import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { IFarmAbiServiceV1_3 } from './interfaces';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class FarmAbiServiceV1_3

--- a/src/modules/farm/v1.3/services/farm.v1.3.compute.loader.ts
+++ b/src/modules/farm/v1.3/services/farm.v1.3.compute.loader.ts
@@ -1,7 +1,7 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { FarmComputeLoader } from '../../base-module/services/farm.compute.loader';
 import { FarmComputeServiceV1_3 } from './farm.v1.3.compute.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/v1.3/services/farm.v1.3.compute.service.ts
+++ b/src/modules/farm/v1.3/services/farm.v1.3.compute.service.ts
@@ -13,7 +13,7 @@ import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { IFarmComputeServiceV1_3 } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class FarmComputeServiceV1_3

--- a/src/modules/farm/v1.3/services/farm.v1.3.service.ts
+++ b/src/modules/farm/v1.3/services/farm.v1.3.service.ts
@@ -3,7 +3,7 @@ import { RewardsModel } from '../../models/farm.model';
 import { CalculateRewardsArgs } from '../../models/farm.args';
 import BigNumber from 'bignumber.js';
 import { ContextGetterService } from 'src/services/context/context.getter.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { FarmAbiServiceV1_3 } from './farm.v1.3.abi.service';
 import { FarmComputeServiceV1_3 } from './farm.v1.3.compute.service';
 import { FarmTokenAttributesV1_3 } from '@multiversx/sdk-exchange';

--- a/src/modules/farm/v2/services/farm.v2.abi.loader.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.loader.ts
@@ -2,7 +2,7 @@ import { Injectable, Scope } from '@nestjs/common';
 import { FarmAbiLoader } from '../../base-module/services/farm.abi.loader';
 import { FarmServiceV2 } from './farm.v2.service';
 import { FarmAbiServiceV2 } from './farm.v2.abi.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/v2/services/farm.v2.abi.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.service.ts
@@ -29,7 +29,7 @@ import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { IFarmAbiServiceV2 } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class FarmAbiServiceV2

--- a/src/modules/farm/v2/services/farm.v2.compute.loader.ts
+++ b/src/modules/farm/v2/services/farm.v2.compute.loader.ts
@@ -1,7 +1,7 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { FarmComputeLoader } from '../../base-module/services/farm.compute.loader';
 import { FarmComputeServiceV2 } from './farm.v2.compute.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable({
     scope: Scope.REQUEST,

--- a/src/modules/farm/v2/services/farm.v2.compute.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.compute.service.ts
@@ -15,7 +15,7 @@ import { FarmServiceV2 } from './farm.v2.service';
 import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { TokenDistributionModel } from 'src/submodules/weekly-rewards-splitting/models/weekly-rewards-splitting.model';
 import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
 import { IFarmComputeServiceV2 } from './interfaces';

--- a/src/modules/farm/v2/services/farm.v2.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, forwardRef } from '@nestjs/common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { ContextGetterService } from 'src/services/context/context.getter.service';
 import { FarmServiceBase } from '../../base-module/services/farm.base.service';
 import { FarmAbiServiceV2 } from './farm.v2.abi.service';

--- a/src/modules/farm/v2/services/farm.v2.setter.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.setter.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { EsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { Logger } from 'winston';
 import { FarmSetterService } from '../../base-module/services/farm.setter.service';

--- a/src/modules/fees-collector/services/fees-collector.setter.service.ts
+++ b/src/modules/fees-collector/services/fees-collector.setter.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { EsdtTokenPayment } from '../../../models/esdtTokenPayment.model';

--- a/src/modules/governance/services/governance.setter.service.ts
+++ b/src/modules/governance/services/governance.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/locked-asset-factory/services/locked.asset.getter.service.ts
+++ b/src/modules/locked-asset-factory/services/locked.asset.getter.service.ts
@@ -3,7 +3,7 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { NftCollection } from 'src/modules/tokens/models/nftCollection.model';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericGetterService } from 'src/services/generics/generic.getter.service';
 import { Logger } from 'winston';

--- a/src/modules/locked-asset-factory/services/locked.asset.setter.service.ts
+++ b/src/modules/locked-asset-factory/services/locked.asset.setter.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 
 @Injectable()

--- a/src/modules/metabonding/services/metabonding.setter.service.ts
+++ b/src/modules/metabonding/services/metabonding.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/pair/services/pair.abi.loader.ts
+++ b/src/modules/pair/services/pair.abi.loader.ts
@@ -1,7 +1,7 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { PairAbiService } from './pair.abi.service';
 import DataLoader from 'dataloader';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { PairService } from './pair.service';
 import { PairInfoModel } from '../models/pair-info.model';

--- a/src/modules/pair/services/pair.abi.service.ts
+++ b/src/modules/pair/services/pair.abi.service.ts
@@ -27,7 +27,7 @@ import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { IPairAbiService } from '../interfaces';
 import { getAllKeys } from 'src/utils/get.many.utils';
 

--- a/src/modules/pair/services/pair.abi.service.ts
+++ b/src/modules/pair/services/pair.abi.service.ts
@@ -90,8 +90,8 @@ export class PairAbiService
     })
     @GetOrSetCache({
         baseKey: 'pair',
-        remoteTtl: CacheTtlInfo.Token.remoteTtl,
-        localTtl: CacheTtlInfo.Token.localTtl,
+        remoteTtl: CacheTtlInfo.TokenID.remoteTtl,
+        localTtl: CacheTtlInfo.TokenID.localTtl,
     })
     async lpTokenID(pairAddress: string): Promise<string> {
         return await this.getLpTokenIDRaw(pairAddress);

--- a/src/modules/pair/services/pair.compute.loader.ts
+++ b/src/modules/pair/services/pair.compute.loader.ts
@@ -1,6 +1,6 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { PairComputeService } from './pair.compute.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import DataLoader from 'dataloader';
 import { PairService } from './pair.service';

--- a/src/modules/pair/services/pair.compute.service.ts
+++ b/src/modules/pair/services/pair.compute.service.ts
@@ -25,7 +25,7 @@ import {
 import { FarmAbiServiceV2 } from 'src/modules/farm/v2/services/farm.v2.abi.service';
 import { FarmComputeServiceV2 } from 'src/modules/farm/v2/services/farm.v2.compute.service';
 import { StakingComputeService } from 'src/modules/staking/services/staking.compute.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import moment from 'moment';
 import { ElasticSearchEventsService } from 'src/services/elastic-search/services/es.events.service';

--- a/src/modules/pair/services/pair.service.ts
+++ b/src/modules/pair/services/pair.service.ts
@@ -48,7 +48,7 @@ export class PairService {
             pairAddresses,
             'pair.firstTokenID',
             this.pairAbi.firstTokenID.bind(this.pairAbi),
-            CacheTtlInfo.Token,
+            CacheTtlInfo.TokenID,
         );
 
         return this.tokenService.getAllTokensMetadata(tokenIDs);
@@ -65,7 +65,7 @@ export class PairService {
             pairAddresses,
             'pair.secondTokenID',
             this.pairAbi.secondTokenID.bind(this.pairAbi),
-            CacheTtlInfo.Token,
+            CacheTtlInfo.TokenID,
         );
 
         return this.tokenService.getAllTokensMetadata(tokenIDs);
@@ -84,7 +84,7 @@ export class PairService {
             pairAddresses,
             'pair.lpTokenID',
             this.pairAbi.lpTokenID.bind(this.pairAbi),
-            CacheTtlInfo.Token,
+            CacheTtlInfo.TokenID,
         );
     }
 

--- a/src/modules/pair/services/pair.service.ts
+++ b/src/modules/pair/services/pair.service.ts
@@ -9,7 +9,7 @@ import {
     getTokenForGivenPosition,
 } from '../pair.utils';
 import { computeValueUSD } from 'src/utils/token.converters';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { WrapAbiService } from 'src/modules/wrapping/services/wrap.abi.service';
 import { PairAbiService } from './pair.abi.service';

--- a/src/modules/pair/services/pair.setter.service.ts
+++ b/src/modules/pair/services/pair.setter.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { FeeDestination } from '../models/pair.model';
 import { Logger } from 'winston';

--- a/src/modules/price-discovery/services/price.discovery.abi.service.ts
+++ b/src/modules/price-discovery/services/price.discovery.abi.service.ts
@@ -10,7 +10,7 @@ import { ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { IPriceDiscoveryAbiService } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 
 @Injectable()

--- a/src/modules/price-discovery/services/price.discovery.setter.service.ts
+++ b/src/modules/price-discovery/services/price.discovery.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/proxy/services/proxy.service.ts
+++ b/src/modules/proxy/services/proxy.service.ts
@@ -35,7 +35,7 @@ import { LockedAssetService } from 'src/modules/locked-asset-factory/services/lo
 import { LockedAssetAttributesModel } from 'src/modules/locked-asset-factory/models/locked-asset.model';
 import { FarmVersion } from 'src/modules/farm/models/farm.model';
 import { LockedTokenAttributesModel } from 'src/modules/simple-lock/models/simple.lock.model';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { ProxyAbiService } from './proxy.abi.service';

--- a/src/modules/rabbitmq/rabbitmq.esdtToken.handler.service.ts
+++ b/src/modules/rabbitmq/rabbitmq.esdtToken.handler.service.ts
@@ -6,7 +6,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { PUB_SUB } from 'src/services/redis.pubSub.module';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';

--- a/src/modules/remote-config/remote-config.controller.ts
+++ b/src/modules/remote-config/remote-config.controller.ts
@@ -21,7 +21,7 @@ import mongoose from 'mongoose';
 import { PUB_SUB } from 'src/services/redis.pubSub.module';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { CacheKeysArgs } from './args/cacheKeys.args';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { AnalyticsRepositoryService } from 'src/services/database/repositories/analytics.repository';
 import { AnalyticsModel } from './models/analytics.model';
 import { AnalyticsArgs } from './args/analytics.args';

--- a/src/modules/remote-config/remote-config.getter.service.ts
+++ b/src/modules/remote-config/remote-config.getter.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { SCAddressRepositoryService } from 'src/services/database/repositories/scAddress.repository';

--- a/src/modules/remote-config/remote-config.setter.service.ts
+++ b/src/modules/remote-config/remote-config.setter.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { SCAddressRepositoryService } from 'src/services/database/repositories/scAddress.repository';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { PUB_SUB } from 'src/services/redis.pubSub.module';

--- a/src/modules/router/services/router.service.ts
+++ b/src/modules/router/services/router.service.ts
@@ -17,7 +17,7 @@ import { CollectionType } from 'src/modules/common/collection.type';
 import { PairsMetadataBuilder } from 'src/modules/pair/services/pair.metadata.builder';
 import { PairFilteringService } from 'src/modules/pair/services/pair.filtering.service';
 import { SortingOrder } from 'src/modules/common/page.data';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { PairService } from 'src/modules/pair/services/pair.service';
 
 @Injectable()

--- a/src/modules/router/services/router.setter.service.ts
+++ b/src/modules/router/services/router.setter.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
 import { PairMetadata } from '../models/pair.metadata.model';

--- a/src/modules/simple-lock/services/simple.lock.service.ts
+++ b/src/modules/simple-lock/services/simple.lock.service.ts
@@ -23,7 +23,7 @@ import {
     LockedTokenAttributesModel,
     LpProxyTokenAttributesModel,
 } from '../models/simple.lock.model';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { FarmFactoryService } from 'src/modules/farm/farm.factory';
 import { farmVersion } from 'src/utils/farm.utils';

--- a/src/modules/simple-lock/services/simple.lock.setter.service.ts
+++ b/src/modules/simple-lock/services/simple.lock.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/staking-proxy/services/staking.proxy.abi.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.abi.service.ts
@@ -7,7 +7,7 @@ import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { IStakingProxyAbiService } from './interfaces';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 
 @Injectable()

--- a/src/modules/staking-proxy/services/staking.proxy.abi.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.abi.service.ts
@@ -161,7 +161,7 @@ export class StakingProxyAbiService
             stakingProxyAddresses,
             'stakeProxy.dualYieldTokenID',
             this.dualYieldTokenID.bind(this),
-            CacheTtlInfo.Token,
+            CacheTtlInfo.TokenID,
         );
     }
 

--- a/src/modules/staking-proxy/services/staking.proxy.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.service.ts
@@ -9,7 +9,7 @@ import { PairService } from 'src/modules/pair/services/pair.service';
 import { DecodeAttributesArgs } from 'src/modules/proxy/models/proxy.args';
 import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
 import { StakingService } from 'src/modules/staking/services/staking.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { tokenIdentifier } from 'src/utils/token.converters';
 import { Logger } from 'winston';

--- a/src/modules/staking-proxy/services/staking.proxy.setter.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.setter.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -65,7 +65,7 @@ export class StakingAbiService
             stakeAddresses,
             'stake.farmTokenID',
             this.farmTokenID.bind(this),
-            CacheTtlInfo.Token,
+            CacheTtlInfo.TokenID,
         );
     }
 
@@ -97,6 +97,7 @@ export class StakingAbiService
             stakeAddresses,
             'stake.farmingTokenID',
             this.farmingTokenID.bind(this),
+            CacheTtlInfo.TokenID,
         );
     }
 
@@ -196,6 +197,7 @@ export class StakingAbiService
             stakeAddresses,
             'stake.accumulatedRewards',
             this.accumulatedRewards.bind(this),
+            CacheTtlInfo.ContractInfo,
         );
     }
 
@@ -227,6 +229,7 @@ export class StakingAbiService
             stakeAddresses,
             'stake.rewardCapacity',
             this.rewardCapacity.bind(this),
+            CacheTtlInfo.ContractInfo,
         );
     }
 
@@ -368,6 +371,7 @@ export class StakingAbiService
             stakeAddresses,
             'stake.produceRewardsEnabled',
             this.produceRewardsEnabled.bind(this),
+            CacheTtlInfo.ContractState,
         );
     }
 

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -20,7 +20,7 @@ import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { IStakingAbiService } from './interfaces';
 import { BoostedYieldsFactors } from 'src/modules/farm/models/farm.v2.model';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 
 @Injectable()

--- a/src/modules/staking/services/staking.setter.service.ts
+++ b/src/modules/staking/services/staking.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/token-unstake/services/token.unstake.setter.service.ts
+++ b/src/modules/token-unstake/services/token.unstake.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';

--- a/src/modules/tokens/services/token.compute.service.ts
+++ b/src/modules/tokens/services/token.compute.service.ts
@@ -24,7 +24,7 @@ import {
 } from '@multiversx/sdk-nestjs-elastic';
 import moment from 'moment';
 import { PendingExecutor } from 'src/utils/pending.executor';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { TokenService } from './token.service';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import { ElasticSearchEventsService } from 'src/services/elastic-search/services/es.events.service';

--- a/src/modules/tokens/services/token.loader.ts
+++ b/src/modules/tokens/services/token.loader.ts
@@ -1,6 +1,6 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { TokenComputeService } from './token.compute.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import DataLoader from 'dataloader';
 import { getAllKeys } from 'src/utils/get.many.utils';
 import { TokenService } from './token.service';

--- a/src/modules/tokens/services/token.service.ts
+++ b/src/modules/tokens/services/token.service.ts
@@ -14,7 +14,7 @@ import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { NftCollection } from '../models/nftCollection.model';
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CollectionType } from 'src/modules/common/collection.type';
 import { TokenComputeService } from './token.compute.service';
 import BigNumber from 'bignumber.js';

--- a/src/modules/tokens/services/token.setter.service.ts
+++ b/src/modules/tokens/services/token.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';

--- a/src/modules/tokens/specs/token.service.spec.ts
+++ b/src/modules/tokens/specs/token.service.spec.ts
@@ -11,7 +11,7 @@ import { TokenRepositoryServiceProvider } from '../mocks/token.repository.servic
 import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
 import { Tokens } from 'src/modules/pair/mocks/pair.constants';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { TokenComputeServiceProvider } from '../mocks/token.compute.service.mock';
 import { TokenFilteringService } from '../services/token.filtering.service';
 import { PairService } from 'src/modules/pair/services/pair.service';

--- a/src/modules/user/services/metaEsdt.compute.service.ts
+++ b/src/modules/user/services/metaEsdt.compute.service.ts
@@ -52,7 +52,7 @@ import { UnbondFarmToken } from 'src/modules/tokens/models/unbondFarmToken.model
 import { LockedAssetGetterService } from 'src/modules/locked-asset-factory/services/locked.asset.getter.service';
 import { FarmTokenAttributesModelV1_2 } from 'src/modules/farm/models/farmTokenAttributes.model';
 import { LockedTokenWrapperService } from '../../locked-token-wrapper/services/locked-token-wrapper.service';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { PairComputeService } from 'src/modules/pair/services/pair.compute.service';
 import { PriceDiscoveryAbiService } from 'src/modules/price-discovery/services/price.discovery.abi.service';

--- a/src/modules/user/services/userEnergy/user.energy.setter.service.ts
+++ b/src/modules/user/services/userEnergy/user.energy.setter.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { OutdatedContract } from '../../models/user.model';

--- a/src/services/caching/cache.module.ts
+++ b/src/services/caching/cache.module.ts
@@ -17,7 +17,6 @@ export class CacheModule {
             imports: [
                 InMemoryCacheModule,
                 RedisCacheModule.forRootAsync(redisCacheModuleAsyncOptions),
-                // ...(redisCacheModuleAsyncOptions.imports || []),
             ],
             providers: [CacheService],
             exports: [CacheService],

--- a/src/services/caching/cache.module.ts
+++ b/src/services/caching/cache.module.ts
@@ -1,0 +1,29 @@
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import {
+    RedisCacheModule,
+    RedisCacheModuleAsyncOptions,
+} from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from './cache.service';
+import { InMemoryCacheModule } from './in.memory.cache.module';
+import { InMemoryCacheOptions } from '@multiversx/sdk-nestjs-cache/lib/in-memory-cache/entities/in-memory-cache-options.interface';
+
+@Global()
+@Module({})
+export class CacheModule {
+    static forRootAsync(
+        redisCacheModuleAsyncOptions: RedisCacheModuleAsyncOptions,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _inMemoryCacheModuleOptions?: InMemoryCacheOptions,
+    ): DynamicModule {
+        return {
+            module: CacheModule,
+            imports: [
+                InMemoryCacheModule,
+                RedisCacheModule.forRootAsync(redisCacheModuleAsyncOptions),
+                ...(redisCacheModuleAsyncOptions.imports || []),
+            ],
+            providers: [CacheService],
+            exports: [CacheService],
+        };
+    }
+}

--- a/src/services/caching/cache.module.ts
+++ b/src/services/caching/cache.module.ts
@@ -5,22 +5,19 @@ import {
 } from '@multiversx/sdk-nestjs-cache';
 import { CacheService } from './cache.service';
 import { InMemoryCacheModule } from './in.memory.cache.module';
-import { InMemoryCacheOptions } from '@multiversx/sdk-nestjs-cache/lib/in-memory-cache/entities/in-memory-cache-options.interface';
 
 @Global()
 @Module({})
 export class CacheModule {
     static forRootAsync(
         redisCacheModuleAsyncOptions: RedisCacheModuleAsyncOptions,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        _inMemoryCacheModuleOptions?: InMemoryCacheOptions,
     ): DynamicModule {
         return {
             module: CacheModule,
             imports: [
                 InMemoryCacheModule,
                 RedisCacheModule.forRootAsync(redisCacheModuleAsyncOptions),
-                ...(redisCacheModuleAsyncOptions.imports || []),
+                // ...(redisCacheModuleAsyncOptions.imports || []),
             ],
             providers: [CacheService],
             exports: [CacheService],

--- a/src/services/caching/cache.service.ts
+++ b/src/services/caching/cache.service.ts
@@ -1,0 +1,451 @@
+import { Injectable } from '@nestjs/common';
+import {
+    OriginLogger,
+    BatchUtils,
+    PendingExecuter,
+} from '@multiversx/sdk-nestjs-common';
+import '@multiversx/sdk-nestjs-common/lib/utils/extensions/array.extensions';
+import { RedisCacheService } from '@multiversx/sdk-nestjs-cache';
+import { InMemoryCacheService } from './in.memory.cache.service';
+
+@Injectable()
+export class CacheService {
+    private readonly pendingExecuter: PendingExecuter;
+    private readonly logger = new OriginLogger(CacheService.name);
+
+    constructor(
+        private readonly inMemoryCacheService: InMemoryCacheService,
+        private readonly redisCacheService: RedisCacheService,
+    ) {
+        this.pendingExecuter = new PendingExecuter();
+    }
+
+    getLocal<T>(key: string): Promise<T | undefined> {
+        return this.inMemoryCacheService.get<T>(key);
+    }
+
+    getManyLocal<T>(keys: string[]): Promise<(T | undefined)[]> {
+        return this.inMemoryCacheService.getMany<T>(keys);
+    }
+
+    setLocal<T>(
+        key: string,
+        value: T,
+        ttl: number,
+        cacheNullable = true,
+    ): void {
+        return this.inMemoryCacheService.set<T>(key, value, ttl, cacheNullable);
+    }
+
+    setManyLocal<T>(
+        keys: string[],
+        values: T[],
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<void> {
+        return this.inMemoryCacheService.setMany(
+            keys,
+            values,
+            ttl,
+            cacheNullable,
+        );
+    }
+
+    deleteLocal(key: string): Promise<void> {
+        return this.inMemoryCacheService.delete(key);
+    }
+
+    async deleteManyLocal(keys: string[]): Promise<void> {
+        await Promise.all(
+            keys.map((key) => this.inMemoryCacheService.delete(key)),
+        );
+    }
+
+    getOrSetLocal<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<T> {
+        return this.inMemoryCacheService.getOrSet<T>(
+            key,
+            () => {
+                return this.executeWithPendingPromise(key, createValueFunc);
+            },
+            ttl,
+            cacheNullable,
+        );
+    }
+
+    setOrUpdateLocal<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<T> {
+        return this.inMemoryCacheService.setOrUpdate<T>(
+            key,
+            createValueFunc,
+            ttl,
+            cacheNullable,
+        );
+    }
+
+    getRemote<T>(key: string): Promise<T | undefined> {
+        return this.redisCacheService.get<T>(key);
+    }
+
+    getManyRemote<T>(keys: string[]): Promise<(T | undefined | null)[]> {
+        return this.redisCacheService.getMany(keys);
+    }
+
+    setRemote<T>(
+        key: string,
+        value: T,
+        ttl: number | null = null,
+        cacheNullable = true,
+    ): Promise<void> {
+        return this.redisCacheService.set<T>(key, value, ttl, cacheNullable);
+    }
+
+    async setManyRemote<T>(
+        keys: string[],
+        values: T[],
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<void> {
+        await this.redisCacheService.setMany(keys, values, ttl, cacheNullable);
+    }
+
+    setTtlRemote(key: string, ttl: number): Promise<void> {
+        return this.redisCacheService.expire(key, ttl);
+    }
+
+    deleteRemote(key: string): Promise<void> {
+        return this.redisCacheService.delete(key);
+    }
+
+    deleteManyRemote(keys: string[]): Promise<void> {
+        return this.redisCacheService.deleteMany(keys);
+    }
+
+    flushDbRemote(): Promise<void> {
+        return this.redisCacheService.flushDb();
+    }
+
+    getKeys(key: string): Promise<string[]> {
+        return this.redisCacheService.keys(key);
+    }
+
+    getOrSetRemote<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<T> {
+        return this.redisCacheService.getOrSet<T>(
+            key,
+            () => {
+                return this.executeWithPendingPromise(key, createValueFunc);
+            },
+            ttl,
+            cacheNullable,
+        );
+    }
+
+    setOrUpdateRemote<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<T> {
+        return this.redisCacheService.setOrUpdate<T>(
+            key,
+            createValueFunc,
+            ttl,
+            cacheNullable,
+        );
+    }
+
+    incrementRemote(key: string, ttl: number | null = null): Promise<number> {
+        return this.redisCacheService.increment(key, ttl);
+    }
+
+    zIncrementRemote(
+        key: string,
+        increment: number,
+        member: string,
+    ): Promise<string> {
+        return this.redisCacheService.zincrby(key, member, increment);
+    }
+
+    zRangeRemote(key: string, from: number, to: number): Promise<string[]> {
+        return this.redisCacheService.zrange(key, from, to, {
+            withScores: true,
+        });
+    }
+
+    zRangeByScoreRemote(
+        key: string,
+        from: number,
+        to: number,
+    ): Promise<string[]> {
+        return this.redisCacheService.zrangebyscore(key, from, to, {
+            withScores: true,
+        });
+    }
+
+    decrementRemote(key: string, ttl: number | null = null): Promise<number> {
+        return this.redisCacheService.decrement(key, ttl);
+    }
+
+    async get<T>(key: string): Promise<T | undefined> {
+        const inMemoryCacheValue = await this.inMemoryCacheService.get<T>(key);
+        if (inMemoryCacheValue) {
+            return inMemoryCacheValue;
+        }
+
+        return await this.redisCacheService.get<T>(key);
+    }
+
+    async getMany<T>(keys: string[]): Promise<(T | undefined)[]> {
+        const values = await this.getManyLocal<T>(keys);
+
+        const missingIndexes: number[] = [];
+        values.forEach((value, index) => {
+            if (!value) {
+                missingIndexes.push(index);
+            }
+        });
+
+        const missingKeys: string[] = [];
+        for (const missingIndex of missingIndexes) {
+            missingKeys.push(keys[missingIndex]);
+        }
+
+        const remoteValues = await this.getManyRemote<T>(missingKeys);
+
+        for (const [index, missingIndex] of missingIndexes.entries()) {
+            const remoteValue = remoteValues[index];
+            values[missingIndex] = remoteValue ? remoteValue : undefined;
+        }
+
+        return values;
+    }
+
+    async set<T>(
+        key: string,
+        value: T,
+        ttl: number,
+        inMemoryTtl: number = ttl,
+        cacheNullable = true,
+    ): Promise<void> {
+        const setInMemoryCachePromise = this.inMemoryCacheService.set<T>(
+            key,
+            value,
+            inMemoryTtl,
+            cacheNullable,
+        );
+        const setRedisCachePromise = this.redisCacheService.set<T>(
+            key,
+            value,
+            ttl,
+            cacheNullable,
+        );
+
+        await Promise.all([setInMemoryCachePromise, setRedisCachePromise]);
+    }
+
+    async setMany<T>(
+        keys: string[],
+        values: T[],
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<void> {
+        await Promise.all([
+            this.setManyRemote(keys, values, ttl, cacheNullable),
+            this.setManyLocal(keys, values, ttl, cacheNullable),
+        ]);
+    }
+
+    async delete(key: string): Promise<void> {
+        await this.redisCacheService.delete(key);
+        await this.inMemoryCacheService.delete(key);
+    }
+
+    async deleteMany(keys: string[]): Promise<void> {
+        await this.deleteManyRemote(keys);
+        await this.deleteManyLocal(keys);
+    }
+
+    async getOrSet<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+        ttl: number,
+        inMemoryTtl: number = ttl,
+        cacheNullable = true,
+    ): Promise<T> {
+        const internalCreateValueFunc = this.buildInternalCreateValueFunc<T>(
+            key,
+            createValueFunc,
+        );
+        const getOrAddFromRedisFunc = async (): Promise<T> => {
+            return await this.redisCacheService.getOrSet<T>(
+                key,
+                internalCreateValueFunc,
+                ttl,
+                cacheNullable,
+            );
+        };
+
+        return await this.inMemoryCacheService.getOrSet<T>(
+            key,
+            getOrAddFromRedisFunc,
+            inMemoryTtl,
+            cacheNullable,
+        );
+    }
+
+    async refreshLocal<T>(
+        key: string,
+        ttl: number = this.getCacheTtl(),
+    ): Promise<T | undefined> {
+        const value = await this.getRemote<T>(key);
+        if (value) {
+            await this.setLocal<T>(key, value, ttl);
+        } else {
+            this.logger.log(`Deleting local cache key '${key}'`);
+            await this.deleteLocal(key);
+        }
+
+        return value;
+    }
+
+    async batchGetManyRemote<T>(
+        keys: string[],
+    ): Promise<(T | undefined | null)[]> {
+        const chunks = BatchUtils.splitArrayIntoChunks(keys, 100);
+
+        const result = [];
+
+        for (const chunkKeys of chunks) {
+            const chunkValues = await this.redisCacheService.getMany<T>(
+                chunkKeys,
+            );
+            result.push(...chunkValues);
+        }
+
+        return result;
+    }
+
+    async setAddRemote(key: string, ...values: string[]): Promise<void> {
+        await this.redisCacheService.sadd(key, ...values);
+    }
+
+    async setCountRemote(key: string): Promise<number> {
+        return await this.redisCacheService.scard(key);
+    }
+
+    async hashGetRemote<T>(hash: string, field: string): Promise<T | null> {
+        return await this.redisCacheService.hget<T>(hash, field);
+    }
+
+    async hashGetAllRemote(hash: string): Promise<Record<string, any> | null> {
+        return await this.redisCacheService.hgetall(hash);
+    }
+
+    async hashSetRemote<T>(
+        hash: string,
+        field: string,
+        value: T,
+        cacheNullable = true,
+    ): Promise<number> {
+        return await this.redisCacheService.hset<T>(
+            hash,
+            field,
+            value,
+            cacheNullable,
+        );
+    }
+
+    async hashSetManyRemote(
+        hash: string,
+        fieldsValues: [string, any][],
+        cacheNullable = true,
+    ): Promise<number> {
+        return await this.redisCacheService.hsetMany(
+            hash,
+            fieldsValues,
+            cacheNullable,
+        );
+    }
+
+    async hashIncrementRemote(
+        hash: string,
+        field: string,
+        increment: number | string,
+    ): Promise<number> {
+        return await this.redisCacheService.hincrby(hash, field, increment);
+    }
+
+    async hashKeysRemote(hash: string): Promise<string[]> {
+        return await this.redisCacheService.hkeys(hash);
+    }
+
+    private executeWithPendingPromise<T>(
+        key: string,
+        promise: () => Promise<T>,
+    ): Promise<T> {
+        return this.pendingExecuter.execute(key, promise);
+    }
+
+    private buildInternalCreateValueFunc<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+    ): () => Promise<T> {
+        return async () => {
+            try {
+                const data = await this.executeWithPendingPromise(
+                    key,
+                    createValueFunc,
+                );
+                return data;
+            } catch (error) {
+                if (error instanceof Error) {
+                    this.logger.error(
+                        'Caching - An error occurred while trying to load value.',
+                        {
+                            error: error?.toString(),
+                            key,
+                        },
+                    );
+                }
+                throw error;
+            }
+        };
+    }
+
+    async deleteInCache(key: string): Promise<string[]> {
+        const invalidatedKeys = [];
+
+        if (key.includes('*')) {
+            const allKeys = await this.getKeys(key);
+            for (const key of allKeys) {
+                await this.deleteLocal(key);
+                await this.redisCacheService.delete(key);
+
+                invalidatedKeys.push(key);
+            }
+        } else {
+            await this.deleteLocal(key);
+            await this.redisCacheService.delete(key);
+            invalidatedKeys.push(key);
+        }
+
+        return invalidatedKeys;
+    }
+
+    private getCacheTtl(): number {
+        return 6;
+    }
+}

--- a/src/services/caching/in.memory.cache.module.ts
+++ b/src/services/caching/in.memory.cache.module.ts
@@ -6,17 +6,3 @@ import { InMemoryCacheService } from './in.memory.cache.service';
     exports: [InMemoryCacheService],
 })
 export class InMemoryCacheModule {}
-
-// export class InMemoryCacheModule {
-//     public static forRoot(
-//         inMemoryCacheOptions?: InMemoryCacheOptions,
-//     ): DynamicModule {
-//         return {
-//             module: InMemoryCacheModule,
-//             providers: [
-//                 InMemoryCacheService,
-//             ],
-//             exports: [InMemoryCacheService],
-//         };
-//     }
-// }

--- a/src/services/caching/in.memory.cache.module.ts
+++ b/src/services/caching/in.memory.cache.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { InMemoryCacheService } from './in.memory.cache.service';
+
+@Module({
+    providers: [InMemoryCacheService],
+    exports: [InMemoryCacheService],
+})
+export class InMemoryCacheModule {}
+
+// export class InMemoryCacheModule {
+//     public static forRoot(
+//         inMemoryCacheOptions?: InMemoryCacheOptions,
+//     ): DynamicModule {
+//         return {
+//             module: InMemoryCacheModule,
+//             providers: [
+//                 InMemoryCacheService,
+//             ],
+//             exports: [InMemoryCacheService],
+//         };
+//     }
+// }

--- a/src/services/caching/in.memory.cache.service.ts
+++ b/src/services/caching/in.memory.cache.service.ts
@@ -1,0 +1,117 @@
+import LRU from 'lru-cache';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class InMemoryCacheService {
+    private static localCache: LRU<any, any>;
+    constructor() {
+        if (!InMemoryCacheService.localCache) {
+            InMemoryCacheService.localCache = new LRU({
+                max: 10000,
+                allowStale: false,
+                updateAgeOnGet: false,
+                updateAgeOnHas: false,
+            });
+        }
+    }
+
+    get<T>(key: string): Promise<T | undefined> {
+        const data = InMemoryCacheService.localCache.get(key);
+
+        const parsedData = data
+            ? data.serialized === true
+                ? JSON.parse(data.value)
+                : data.value
+            : undefined;
+
+        return parsedData;
+    }
+
+    getMany<T>(keys: string[]): Promise<(T | undefined)[]> {
+        return Promise.all(keys.map((key) => this.get<T>(key)));
+    }
+
+    set<T>(key: string, value: T, ttl: number, cacheNullable = true): void {
+        if (value === undefined) {
+            return;
+        }
+
+        if (!cacheNullable && value == null) {
+            return;
+        }
+
+        const writeValue =
+            typeof value === 'object'
+                ? {
+                      serialized: true,
+                      value: JSON.stringify(value),
+                  }
+                : {
+                      serialized: false,
+                      value,
+                  };
+
+        const ttlToMilliseconds = ttl * 1000; // Convert to milliseconds
+
+        if (ttlToMilliseconds > 0) {
+            // Save only if ttl is greater than 0
+            InMemoryCacheService.localCache.set(key, writeValue, {
+                ttl: ttlToMilliseconds,
+            });
+        }
+    }
+
+    async setMany<T>(
+        keys: string[],
+        values: T[],
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<void> {
+        for (const [index, key] of keys.entries()) {
+            this.set(key, values[index], ttl, cacheNullable);
+        }
+    }
+
+    async delete(key: string): Promise<void> {
+        await InMemoryCacheService.localCache.delete(key);
+    }
+
+    async getOrSet<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<T> {
+        const cachedData = await this.get<any>(key);
+        if (cachedData !== undefined) {
+            return cachedData;
+        }
+
+        const internalCreateValueFunc =
+            this.buildInternalCreateValueFunc<T>(createValueFunc);
+        const value = await internalCreateValueFunc();
+        await this.set<T>(key, value, ttl, cacheNullable);
+        return value;
+    }
+
+    async setOrUpdate<T>(
+        key: string,
+        createValueFunc: () => Promise<T>,
+        ttl: number,
+        cacheNullable = true,
+    ): Promise<T> {
+        const internalCreateValueFunc =
+            this.buildInternalCreateValueFunc(createValueFunc);
+        const value = await internalCreateValueFunc();
+        await this.set<T>(key, value, ttl, cacheNullable);
+        return value;
+    }
+
+    private buildInternalCreateValueFunc<T>(
+        createValueFunc: () => Promise<T>,
+    ): () => Promise<T> {
+        return () => {
+            return createValueFunc();
+        };
+    }
+}

--- a/src/services/caching/in.memory.cache.service.ts
+++ b/src/services/caching/in.memory.cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import TTLCache from '@isaacs/ttlcache';
+import { mxConfig } from 'src/config';
 
 @Injectable()
 export class InMemoryCacheService {
@@ -7,7 +8,7 @@ export class InMemoryCacheService {
     constructor() {
         if (!InMemoryCacheService.localCache) {
             InMemoryCacheService.localCache = new TTLCache({
-                max: 50000,
+                max: mxConfig.localCacheMaxItems,
                 ttl: 6000,
                 updateAgeOnGet: false,
             });

--- a/src/services/context/context.getter.service.ts
+++ b/src/services/context/context.getter.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { Logger } from 'winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { MXApiService } from '../multiversx-communication/mx.api.service';
 import { GenericGetterService } from '../generics/generic.getter.service';
 import { NftToken } from 'src/modules/tokens/models/nftToken.model';

--- a/src/services/context/context.setter.service.ts
+++ b/src/services/context/context.setter.service.ts
@@ -3,7 +3,7 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 import { Logger } from 'winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { GenericSetterService } from '../generics/generic.setter.service';
 
 @Injectable()

--- a/src/services/crons/cache.warmer.service.ts
+++ b/src/services/crons/cache.warmer.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 import { MXApiService } from '../multiversx-communication/mx.api.service';
 import { PUB_SUB } from '../redis.pubSub.module';

--- a/src/services/crons/events.processor.service.ts
+++ b/src/services/crons/events.processor.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { MXApiService } from '../multiversx-communication/mx.api.service';
 import { cacheConfig, constantsConfig } from 'src/config';
 import BigNumber from 'bignumber.js';

--- a/src/services/crons/proxy.cache.warmer.service.ts
+++ b/src/services/crons/proxy.cache.warmer.service.ts
@@ -4,7 +4,7 @@ import { ProxyAbiService } from 'src/modules/proxy/services/proxy.abi.service';
 import { ProxyPairAbiService } from 'src/modules/proxy/services/proxy-pair/proxy.pair.abi.service';
 import { ProxyFarmAbiService } from 'src/modules/proxy/services/proxy-farm/proxy.farm.abi.service';
 import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { cacheConfig, scAddress } from 'src/config';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { PUB_SUB } from '../redis.pubSub.module';

--- a/src/services/crons/transaction.processor.service.ts
+++ b/src/services/crons/transaction.processor.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Address } from '@multiversx/sdk-core';
 import { MXApiService } from '../multiversx-communication/mx.api.service';
 import { cacheConfig, constantsConfig } from 'src/config';

--- a/src/services/generics/generic.getter.service.ts
+++ b/src/services/generics/generic.getter.service.ts
@@ -1,6 +1,6 @@
 import { generateGetLogMessage } from 'src/utils/generate-log-message';
 import { Logger } from 'winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { generateCacheKeyFromParams } from '../../utils/generate-cache-key';
 
 export class GenericGetterService {

--- a/src/services/generics/generic.setter.service.ts
+++ b/src/services/generics/generic.setter.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { generateSetLogMessage } from 'src/utils/generate-log-message';
 import { Logger } from 'winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { generateCacheKeyFromParams } from '../../utils/generate-cache-key';
 import { CacheTtlInfo } from '../caching/cache.ttl.info';
 import { formatNullOrUndefined } from 'src/utils/cache.utils';

--- a/src/services/multiversx-communication/mx.data.api.service.ts
+++ b/src/services/multiversx-communication/mx.data.api.service.ts
@@ -5,7 +5,7 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { PendingExecutor } from 'src/utils/pending.executor';
 import { Logger } from 'winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class MXDataApiService {

--- a/src/submodules/week-timekeeping/services/week-timekeeping.setter.service.ts
+++ b/src/submodules/week-timekeeping/services/week-timekeeping.setter.service.ts
@@ -1,4 +1,4 @@
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';

--- a/src/submodules/weekly-rewards-splitting/services/weekly.rewarrds.splitting.setter.service.ts
+++ b/src/submodules/weekly-rewards-splitting/services/weekly.rewarrds.splitting.setter.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
 import { IWeeklyRewardsSplittingSetterService } from '../interfaces';

--- a/src/utils/dynamic.module.utils.ts
+++ b/src/utils/dynamic.module.utils.ts
@@ -1,7 +1,4 @@
-import {
-    CacheModule,
-    RedisCacheModuleOptions,
-} from '@multiversx/sdk-nestjs-cache';
+import { RedisCacheModuleOptions } from '@multiversx/sdk-nestjs-cache';
 import {
     ElasticModule,
     ElasticModuleOptions,
@@ -11,6 +8,7 @@ import { DynamicModule } from '@nestjs/common';
 import { CommonAppModule } from 'src/common.app.module';
 import { mxConfig } from 'src/config';
 import { ApiConfigService } from 'src/helpers/api.config.service';
+import { CacheModule } from 'src/services/caching/cache.module';
 
 export class DynamicModuleUtils {
     static getCacheModule(): DynamicModule {

--- a/src/utils/dynamic.module.utils.ts
+++ b/src/utils/dynamic.module.utils.ts
@@ -12,22 +12,17 @@ import { CacheModule } from 'src/services/caching/cache.module';
 
 export class DynamicModuleUtils {
     static getCacheModule(): DynamicModule {
-        return CacheModule.forRootAsync(
-            {
-                imports: [CommonAppModule],
-                inject: [ApiConfigService],
-                useFactory: (configService: ApiConfigService) =>
-                    new RedisCacheModuleOptions({
-                        host: configService.getRedisUrl(),
-                        port: configService.getRedisPort(),
-                        password: configService.getRedisPassword(),
-                        enableAutoPipelining: true,
-                    }),
-            },
-            {
-                maxItems: mxConfig.localCacheMaxItems,
-            },
-        );
+        return CacheModule.forRootAsync({
+            imports: [CommonAppModule],
+            inject: [ApiConfigService],
+            useFactory: (configService: ApiConfigService) =>
+                new RedisCacheModuleOptions({
+                    host: configService.getRedisUrl(),
+                    port: configService.getRedisPort(),
+                    password: configService.getRedisPassword(),
+                    enableAutoPipelining: true,
+                }),
+        });
     }
 
     static getElasticModule(): DynamicModule {

--- a/src/utils/get.many.utils.ts
+++ b/src/utils/get.many.utils.ts
@@ -7,7 +7,7 @@ async function getMany<T>(
     keys: string[],
     localTtl: number,
 ): Promise<(T | undefined)[]> {
-    const values = await cacheService.getManyLocal<T>(keys);
+    const values = cacheService.getManyLocal<T>(keys);
 
     const missingIndexes: number[] = [];
     values.forEach((value, index) => {
@@ -28,7 +28,7 @@ async function getMany<T>(
     const remoteValues = await cacheService.getManyRemote<T>(missingKeys);
 
     if (localTtl > 0) {
-        await cacheService.setManyLocal<T>(
+        cacheService.setManyLocal<T>(
             missingKeys,
             remoteValues.map((value) =>
                 value ? parseCachedNullOrUndefined(value) : undefined,

--- a/src/utils/get.many.utils.ts
+++ b/src/utils/get.many.utils.ts
@@ -1,4 +1,4 @@
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { parseCachedNullOrUndefined } from './cache.utils';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 

--- a/src/utils/get.many.utils.ts
+++ b/src/utils/get.many.utils.ts
@@ -2,48 +2,6 @@ import { CacheService } from 'src/services/caching/cache.service';
 import { parseCachedNullOrUndefined } from './cache.utils';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 
-async function getMany<T>(
-    cacheService: CacheService,
-    keys: string[],
-    localTtl: number,
-): Promise<(T | undefined)[]> {
-    const values = cacheService.getManyLocal<T>(keys);
-
-    const missingIndexes: number[] = [];
-    values.forEach((value, index) => {
-        if (value === undefined) {
-            missingIndexes.push(index);
-        }
-    });
-
-    const missingKeys: string[] = [];
-    for (const missingIndex of missingIndexes) {
-        missingKeys.push(keys[missingIndex]);
-    }
-
-    if (missingKeys.length === 0) {
-        return values.map((value) => parseCachedNullOrUndefined(value));
-    }
-
-    const remoteValues = await cacheService.getManyRemote<T>(missingKeys);
-
-    if (localTtl > 0) {
-        cacheService.setManyLocal<T>(
-            missingKeys,
-            remoteValues.map((value) =>
-                value ? parseCachedNullOrUndefined(value) : undefined,
-            ),
-            localTtl,
-        );
-    }
-
-    for (const [index, missingIndex] of missingIndexes.entries()) {
-        values[missingIndex] = remoteValues[index];
-    }
-
-    return values;
-}
-
 export async function getAllKeys<T>(
     cacheService: CacheService,
     rawKeys: string[],
@@ -52,8 +10,7 @@ export async function getAllKeys<T>(
     ttlOptions?: CacheTtlInfo,
 ): Promise<T[]> {
     const keys = rawKeys.map((tokenID) => `${baseKey}.${tokenID}`);
-    const values = await getMany<T>(
-        cacheService,
+    const values = await cacheService.getMany<T>(
         keys,
         ttlOptions?.localTtl ?? 0,
     );

--- a/src/utils/guestCaching.middleware.ts
+++ b/src/utils/guestCaching.middleware.ts
@@ -4,7 +4,7 @@ import {
 } from '@nestjs/common';
 import moment from 'moment';
 import * as crypto from 'crypto';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { CacheService } from 'src/services/caching/cache.service';
 import { NextFunction } from 'express';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 import { MetricsCollector } from '../utils/metrics.collector';


### PR DESCRIPTION
## Reasoning
- the current cache service implementation from sdk-nestjs package uses an LRU cache for in-memory caching. This means local TTL values provided are not enforced and cause extra remote cache requests
  
## Proposed Changes
- install [ttlcache](https://github.com/isaacs/ttlcache) package
- custom cache module using redis cache service from [sdk-nestjs](https://github.com/multiversx/mx-sdk-nestjs) and in-memory cache service using ttlcache
- update imports for cache service
- update missing ttl values

## How to test
- N/A
