### PR TITLE
MEX-706 Implement Token Metadata Subscription on Swap Events

### DIFF
--- a/src/modules/rabbitmq/handlers/pair.swap.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/pair.swap.handler.service.ts
@@ -18,6 +18,7 @@ import { PairAbiService } from 'src/modules/pair/services/pair.abi.service';
 import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
 import { TokenSetterService } from 'src/modules/tokens/services/token.setter.service';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
+import { TokenService } from 'src/modules/tokens/services/token.service';
 
 export enum SWAP_IDENTIFIER {
     SWAP_FIXED_INPUT = 'swapTokensFixedInput',
@@ -39,6 +40,7 @@ export class SwapEventHandler {
         private readonly tokenSetter: TokenSetterService,
         private readonly pairHandler: PairHandler,
         private readonly dataApi: MXDataApiService,
+        private readonly tokenService: TokenService,
         @Inject(PUB_SUB) private pubSub: RedisPubSub,
     ) {}
 
@@ -286,9 +288,18 @@ export class SwapEventHandler {
             ],
         );
 
+        const token = await this.tokenService.tokenMetadata(tokenID);
+        const updatedToken = {
+            ...token,
+            price: tokenPriceDerivedUSD,
+        };
+
+        await this.pubSub.publish('TOKEN_METADATA_CHANGED', updatedToken);
+
         const cacheKeys = await Promise.all([
             this.tokenSetter.setDerivedEGLD(tokenID, tokenPriceDerivedEGLD),
             this.tokenSetter.setDerivedUSD(tokenID, tokenPriceDerivedUSD),
+            this.tokenSetter.setMetadata(tokenID, updatedToken),
         ]);
 
         await this.deleteCacheKeys(cacheKeys);

--- a/src/modules/subscriptions/subscriptions.resolver.ts
+++ b/src/modules/subscriptions/subscriptions.resolver.ts
@@ -23,10 +23,18 @@ import { ExitFarmProxyEventModel } from './models/proxy/exitFarmProxy.event.mode
 import { PairProxyEventModel } from './models/proxy/pairProxy.event.model';
 import { RewardsProxyEventModel } from './models/proxy/rewardsProxy.event.model';
 import { SWAP_IDENTIFIER } from '../rabbitmq/handlers/pair.swap.handler.service';
+import { EsdtToken } from '../tokens/models/esdtToken.model';
 
 @Resolver()
 export class SubscriptionsResolver {
     constructor(@Inject(PUB_SUB) private pubSub: RedisPubSub) {}
+
+    @Subscription(() => EsdtToken, {
+        resolve: (event) => event,
+    })
+    tokenMetadataChanged() {
+        return this.pubSub.asyncIterator('TOKEN_METADATA_CHANGED');
+    }
 
     @Subscription(() => SwapFixedInputEventModel, {
         resolve: (event) =>

--- a/src/services/redis.pubSub.module.ts
+++ b/src/services/redis.pubSub.module.ts
@@ -2,7 +2,6 @@ import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { Global, Module } from '@nestjs/common';
 import { ApiConfigService } from '../helpers/api.config.service';
 import { ConfigModule } from '@nestjs/config';
-import { setClient } from '../utils/redisClient';
 import * as Redis from 'ioredis';
 
 export const PUB_SUB = 'PUB_SUB';
@@ -18,18 +17,17 @@ export const PUB_SUB = 'PUB_SUB';
         {
             provide: PUB_SUB,
             useFactory: (configService: ApiConfigService) => {
-                const options: Redis.RedisOptions = {
-                    host: configService.getRedisUrl(),
-                    port: configService.getRedisPort(),
-                    retryStrategy: function () {
-                        return 1000;
-                    },
-                };
-
-                return new RedisPubSub({
-                    publisher: setClient(options),
-                    subscriber: setClient(options),
+                const publisher = new Redis.default({
+                    host: configService.getRedisUrl() || 'localhost',
+                    port: Number(configService.getRedisPort()) || 6379,
                 });
+
+                const subscriber = new Redis.default({
+                    host: configService.getRedisUrl() || 'localhost',
+                    port: Number(configService.getRedisPort()) || 6379,
+                });
+
+                return new RedisPubSub({ publisher, subscriber });
             },
             inject: [ApiConfigService],
         },
@@ -37,4 +35,4 @@ export const PUB_SUB = 'PUB_SUB';
     ],
     exports: [PUB_SUB],
 })
-export class RedisPubSubModule { }
+export class RedisPubSubModule {}


### PR DESCRIPTION
## Reasoning
- Token Metadata Subscription
  
## Proposed Changes
- Create a new subscription endpoint for Token Metadata which will be publish data on SwapEvents

## How to test
```
subscription {
  tokenMetadataChanged {
    identifier,
    price
  }
}
```
