### PR TITLE
Mex 706 token subsctiptions redis key watcher

### DIFF
--- a/src/modules/rabbitmq/handlers/pair.swap.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/pair.swap.handler.service.ts
@@ -293,7 +293,6 @@ export class SwapEventHandler {
             ...token,
             price: tokenPriceDerivedUSD,
         };
-        console.log(token.identifier, token.price, tokenPriceDerivedUSD);
 
         const cacheKeys = await Promise.all([
             this.tokenSetter.setDerivedEGLD(tokenID, tokenPriceDerivedEGLD),

--- a/src/modules/subscriptions/subscriptions.resolver.ts
+++ b/src/modules/subscriptions/subscriptions.resolver.ts
@@ -23,10 +23,18 @@ import { ExitFarmProxyEventModel } from './models/proxy/exitFarmProxy.event.mode
 import { PairProxyEventModel } from './models/proxy/pairProxy.event.model';
 import { RewardsProxyEventModel } from './models/proxy/rewardsProxy.event.model';
 import { SWAP_IDENTIFIER } from '../rabbitmq/handlers/pair.swap.handler.service';
+import { EsdtToken } from '../tokens/models/esdtToken.model';
 
 @Resolver()
 export class SubscriptionsResolver {
     constructor(@Inject(PUB_SUB) private pubSub: RedisPubSub) {}
+
+    @Subscription(() => EsdtToken, {
+        resolve: (event) => event
+    })
+    tokenMetadataChanged() {
+        return this.pubSub.asyncIterator('REDIS_KEY_CHANGED');
+    }
 
     @Subscription(() => SwapFixedInputEventModel, {
         resolve: (event) =>

--- a/src/services/pub.sub.module.ts
+++ b/src/services/pub.sub.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { CommonAppModule } from 'src/common.app.module';
 import { CacheController } from '../endpoints/cache/cache.controller';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { RedisKeyWatcherService } from './redis.key.watcher.service';
 
 @Module({
     imports: [CommonAppModule, DynamicModuleUtils.getCacheModule()],
     controllers: [CacheController],
-    providers: [],
+    providers: [RedisKeyWatcherService],
 })
 export class PubSubModule {}

--- a/src/services/redis.key.watcher.service.ts
+++ b/src/services/redis.key.watcher.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, OnModuleInit, Inject } from '@nestjs/common';
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { PUB_SUB } from './redis.pubSub.module';
+
+@Injectable()
+export class RedisKeyWatcherService implements OnModuleInit {
+    private isProcessing = false;
+
+    constructor(
+        @Inject(PUB_SUB) private pubSub: RedisPubSub,
+    ) {}
+
+    async onModuleInit() {
+        await this.setupKeyWatching();
+    }
+
+    private async setupKeyWatching() {
+        const publisher = this.pubSub.getPublisher();
+        const subscriber = this.pubSub.getSubscriber();
+
+        await publisher.config('SET', 'notify-keyspace-events', 'KEA');
+        const key = 'token.tokenMetadata.*';
+        const subscriptionPattern = `__keyspace@0__:${key}`;
+
+        subscriber.on('pmessage', async (pattern, channel, event) => {
+            if (this.isProcessing) return;
+
+            try {
+                this.isProcessing = true;
+                if (event === 'set') {
+                    const redisKey = channel.split(':').slice(1).join(':');
+                    const newValue = await publisher.get(redisKey);
+                    if (newValue) {
+                        await this.pubSub.publish('REDIS_KEY_CHANGED', JSON.parse(newValue));
+                    }
+                }
+            } finally {
+                this.isProcessing = false;
+            }
+        });
+
+        await subscriber.psubscribe(subscriptionPattern);
+    }
+}

--- a/src/services/redis.pubSub.module.ts
+++ b/src/services/redis.pubSub.module.ts
@@ -2,7 +2,6 @@ import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { Global, Module } from '@nestjs/common';
 import { ApiConfigService } from '../helpers/api.config.service';
 import { ConfigModule } from '@nestjs/config';
-import { setClient } from '../utils/redisClient';
 import * as Redis from 'ioredis';
 
 export const PUB_SUB = 'PUB_SUB';
@@ -18,18 +17,17 @@ export const PUB_SUB = 'PUB_SUB';
         {
             provide: PUB_SUB,
             useFactory: (configService: ApiConfigService) => {
-                const options: Redis.RedisOptions = {
-                    host: configService.getRedisUrl(),
-                    port: configService.getRedisPort(),
-                    retryStrategy: function () {
-                        return 1000;
-                    },
-                };
-
-                return new RedisPubSub({
-                    publisher: setClient(options),
-                    subscriber: setClient(options),
+                const publisher = new Redis.default({
+                    host: configService.getRedisUrl() || 'localhost',
+                    port: Number(configService.getRedisPort()) || 6379,
                 });
+
+                const subscriber = new Redis.default({
+                    host: configService.getRedisUrl() || 'localhost',
+                    port: Number(configService.getRedisPort()) || 6379,
+                });
+
+                return new RedisPubSub({ publisher, subscriber });
             },
             inject: [ApiConfigService],
         },
@@ -37,4 +35,4 @@ export const PUB_SUB = 'PUB_SUB';
     ],
     exports: [PUB_SUB],
 })
-export class RedisPubSubModule { }
+export class RedisPubSubModule {}


### PR DESCRIPTION
## Reasoning
- Token Metadata Subscription
  
## Proposed Changes
- Create a new subscription endpoint for Token Metadata which will be publish data on Redis key change
- Whenever token.tokenMedata.* keys from Redis will be changed, new data will be published

## How to test
```
subscription {
  tokenMetadataChanged {
    identifier,
    price
  }
}
```
