### PR TITLE
[MEX-715] Swap query cache optimization

### DIFF
--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -26,7 +26,6 @@ import { PairComputeService } from 'src/modules/pair/services/pair.compute.servi
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { TransactionModel } from 'src/models/transaction.model';
-import { PairMetadata } from 'src/modules/router/models/pair.metadata.model';
 
 @Injectable()
 export class AutoRouterService {

--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -26,6 +26,7 @@ import { PairComputeService } from 'src/modules/pair/services/pair.compute.servi
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { TransactionModel } from 'src/models/transaction.model';
+import { PairMetadata } from 'src/modules/router/models/pair.metadata.model';
 
 @Injectable()
 export class AutoRouterService {
@@ -334,38 +335,42 @@ export class AutoRouterService {
     }
 
     private async getAllActivePairs() {
-        const pairAddresses = await this.routerAbi.pairsAddress();
-        const statesPromises = pairAddresses.map((address) =>
-            this.pairAbi.state(address),
+        const pairMetadata = await this.routerAbi.pairsMetadata();
+
+        const states = await this.pairService.getAllStates(
+            pairMetadata.map((pair) => pair.address),
         );
-        const states = await Promise.all(statesPromises);
-        const activePairs: string[] = [];
-        states.forEach((value, index) => {
-            if (value === 'Active') activePairs.push(pairAddresses[index]);
+
+        const activePairs = pairMetadata.filter(
+            (_pair, index) => states[index] === 'Active',
+        );
+
+        const pairAddresses: string[] = [];
+        let tokenIDs: string[] = [];
+        activePairs.forEach((pair) => {
+            pairAddresses.push(pair.address);
+            tokenIDs.push(...[pair.firstTokenID, pair.secondTokenID]);
         });
+        tokenIDs = [...new Set(tokenIDs)];
 
-        const pairsPromises = activePairs.map((address) =>
-            this.getPair(address),
+        const [allInfo, allTotalFeePercent, allTokens] = await Promise.all([
+            this.pairAbi.getAllPairsInfoMetadata(pairAddresses),
+            this.pairAbi.getAllPairsTotalFeePercent(pairAddresses),
+            this.tokenService.getAllTokensMetadata(tokenIDs),
+        ]);
+
+        const tokenMap = new Map(
+            allTokens.map((token) => [token.identifier, token]),
         );
 
-        return await Promise.all(pairsPromises);
-    }
-
-    private async getPair(pairAddress: string): Promise<PairModel> {
-        const [info, totalFeePercent, firstToken, secondToken] =
-            await Promise.all([
-                this.pairAbi.pairInfoMetadata(pairAddress),
-                this.pairAbi.totalFeePercent(pairAddress),
-                this.pairService.getFirstToken(pairAddress),
-                this.pairService.getSecondToken(pairAddress),
-            ]);
-
-        return new PairModel({
-            address: pairAddress,
-            firstToken,
-            secondToken,
-            info,
-            totalFeePercent,
+        return activePairs.map((pair, index) => {
+            return new PairModel({
+                address: pair.address,
+                firstToken: tokenMap.get(pair.firstTokenID),
+                secondToken: tokenMap.get(pair.secondTokenID),
+                info: allInfo[index],
+                totalFeePercent: allTotalFeePercent[index],
+            });
         });
     }
 

--- a/src/modules/pair/mocks/pair.abi.service.mock.ts
+++ b/src/modules/pair/mocks/pair.abi.service.mock.ts
@@ -40,6 +40,13 @@ export class PairAbiServiceMock implements IPairAbiService {
     async totalFeePercent(pairAddress: string): Promise<number> {
         return PairsData(pairAddress).totalFeePercent;
     }
+    async getAllPairsTotalFeePercent(
+        pairAddresses: string[],
+    ): Promise<number[]> {
+        return pairAddresses.map(
+            (pairAddress) => PairsData(pairAddress).totalFeePercent,
+        );
+    }
     specialFeePercent(pairAddress: string): Promise<number> {
         throw new Error('Method not implemented.');
     }

--- a/src/modules/pair/services/pair.abi.loader.ts
+++ b/src/modules/pair/services/pair.abi.loader.ts
@@ -60,13 +60,7 @@ export class PairAbiLoader {
 
     public readonly totalFeePercentLoader = new DataLoader<string, number>(
         async (addresses: string[]) => {
-            return getAllKeys<number>(
-                this.cacheService,
-                addresses,
-                'pair.totalFeePercent',
-                this.pairAbi.totalFeePercent.bind(this.pairAbi),
-                CacheTtlInfo.ContractState,
-            );
+            return this.pairAbi.getAllPairsTotalFeePercent(addresses);
         },
         {
             cache: false,

--- a/src/modules/pair/services/pair.abi.service.ts
+++ b/src/modules/pair/services/pair.abi.service.ts
@@ -241,6 +241,18 @@ export class PairAbiService
         return response.firstValue.valueOf().toNumber();
     }
 
+    async getAllPairsTotalFeePercent(
+        pairAddresses: string[],
+    ): Promise<number[]> {
+        return getAllKeys<number>(
+            this.cachingService,
+            pairAddresses,
+            'pair.totalFeePercent',
+            this.totalFeePercent.bind(this),
+            CacheTtlInfo.ContractState,
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })


### PR DESCRIPTION
## Reasoning
- the `getAllActivePairs` method used in the `swap` query performs multiple single GET requests from cache for fetching pairs state, reserves, fee percentage and token metadata
  
## Proposed Changes
- use bulk get methods in `getAllActivePairs`
- fetch token metadata for unique token IDs 

## How to test
- N/A
