### PR TITLE
[MEX-719] Limit depth when computing all possible swap routes

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -611,6 +611,7 @@
         "USER_MAX_CLAIM_WEEKS": 4,
         "STAKING_UNBOND_ATTRIBUTES_LEN": 12,
         "MAX_USER_NFTS": 10000,
+        "MAX_SWAP_ROUTE_DEPTH": 8,
         "endpoints": [
             "wrapEgld",
             "unwrapEgld",

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -611,7 +611,7 @@
         "USER_MAX_CLAIM_WEEKS": 4,
         "STAKING_UNBOND_ATTRIBUTES_LEN": 12,
         "MAX_USER_NFTS": 10000,
-        "MAX_SWAP_ROUTE_DEPTH": 8,
+        "MAX_SWAP_ROUTE_DEPTH": 4,
         "endpoints": [
             "wrapEgld",
             "unwrapEgld",

--- a/src/modules/auto-router/services/graph.service.ts
+++ b/src/modules/auto-router/services/graph.service.ts
@@ -1,3 +1,4 @@
+import { constantsConfig } from 'src/config';
 import { PairModel } from 'src/modules/pair/models/pair.model';
 
 export class GraphService {
@@ -48,9 +49,14 @@ export class GraphService {
         isVisited: Map<string, boolean>,
         localPathList: Array<string>,
         paths: Array<string[]>,
+        maxDepth: number,
     ) {
         if (node === destination) {
             paths.push([...localPathList]);
+            return;
+        }
+
+        if (localPathList.length >= maxDepth) {
             return;
         }
 
@@ -70,6 +76,7 @@ export class GraphService {
                     isVisited,
                     localPathList,
                     paths,
+                    maxDepth,
                 );
                 localPathList.splice(localPathList.indexOf(adjNode), 1);
             }
@@ -77,7 +84,11 @@ export class GraphService {
         isVisited.set(node, false);
     }
 
-    getAllPaths(source: string, destination: string) {
+    getAllPaths(
+        source: string,
+        destination: string,
+        maxDepth: number = constantsConfig.MAX_SWAP_ROUTE_DEPTH,
+    ) {
         const isVisited = new Map<string, boolean>();
         const nodes = this.adjList.keys();
         const paths = new Array<string[]>();
@@ -89,7 +100,14 @@ export class GraphService {
         const pathList = new Array<string>();
         pathList.push(source);
 
-        this.getAllPathsUtil(source, destination, isVisited, pathList, paths);
+        this.getAllPathsUtil(
+            source,
+            destination,
+            isVisited,
+            pathList,
+            paths,
+            maxDepth,
+        );
 
         return paths;
     }

--- a/src/modules/auto-router/services/graph.service.ts
+++ b/src/modules/auto-router/services/graph.service.ts
@@ -49,14 +49,13 @@ export class GraphService {
         isVisited: Map<string, boolean>,
         localPathList: Array<string>,
         paths: Array<string[]>,
-        maxDepth: number,
     ) {
         if (node === destination) {
             paths.push([...localPathList]);
             return;
         }
 
-        if (localPathList.length >= maxDepth) {
+        if (localPathList.length >= constantsConfig.MAX_SWAP_ROUTE_DEPTH) {
             return;
         }
 
@@ -76,7 +75,6 @@ export class GraphService {
                     isVisited,
                     localPathList,
                     paths,
-                    maxDepth,
                 );
                 localPathList.splice(localPathList.indexOf(adjNode), 1);
             }
@@ -84,11 +82,7 @@ export class GraphService {
         isVisited.set(node, false);
     }
 
-    getAllPaths(
-        source: string,
-        destination: string,
-        maxDepth: number = constantsConfig.MAX_SWAP_ROUTE_DEPTH,
-    ) {
+    getAllPaths(source: string, destination: string) {
         const isVisited = new Map<string, boolean>();
         const nodes = this.adjList.keys();
         const paths = new Array<string[]>();
@@ -100,14 +94,7 @@ export class GraphService {
         const pathList = new Array<string>();
         pathList.push(source);
 
-        this.getAllPathsUtil(
-            source,
-            destination,
-            isVisited,
-            pathList,
-            paths,
-            maxDepth,
-        );
+        this.getAllPathsUtil(source, destination, isVisited, pathList, paths);
 
         return paths;
     }

--- a/src/modules/auto-router/services/graph.service.ts
+++ b/src/modules/auto-router/services/graph.service.ts
@@ -55,7 +55,7 @@ export class GraphService {
             return;
         }
 
-        if (localPathList.length >= constantsConfig.MAX_SWAP_ROUTE_DEPTH) {
+        if (localPathList.length > constantsConfig.MAX_SWAP_ROUTE_DEPTH) {
             return;
         }
 


### PR DESCRIPTION
## Reasoning
- due to the increasing number of pairs, computing all possible swap paths results in an array containing over 25k entries, which leads to performance degradation when iterating over it
  
## Proposed Changes
- introduce a max depth limitation when computing possible paths

## How to test
- N/A

