### PR TITLE
[MEX-722] Implement caching for the pairCandles query

### DIFF
--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -22,6 +22,7 @@ import { AnalyticsModule as AnalyticsServicesModule } from 'src/services/analyti
 import { WeeklyRewardsSplittingModule } from 'src/submodules/weekly-rewards-splitting/weekly-rewards-splitting.module';
 import { AnalyticsSetterService } from './services/analytics.setter.service';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { AnalyticsPairSetterService } from './services/analytics.pair.setter.service';
 
 @Module({
     imports: [
@@ -50,12 +51,15 @@ import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.
         AnalyticsSetterService,
         AnalyticsPairService,
         PairDayDataResolver,
+        AnalyticsPairSetterService,
     ],
     exports: [
         AnalyticsAWSGetterService,
         AnalyticsAWSSetterService,
         AnalyticsComputeService,
         AnalyticsSetterService,
+        AnalyticsPairSetterService,
+        AnalyticsPairService,
     ],
 })
 export class AnalyticsModule {}

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -198,10 +198,8 @@ export class AnalyticsResolver {
 
         return this.analyticsPairService.priceCandles(
             args.series,
-            args.metric,
             adjustedStart,
             adjustedEnd,
-            args.resolution,
         );
     }
 

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -18,6 +18,7 @@ import { PriceCandlesArgsValidationPipe } from './validators/price.candles.args.
 import { TradingActivityModel } from './models/trading.activity.model';
 import { RouterAbiService } from '../router/services/router.abi.service';
 import { alignTimestampTo4HourInterval } from 'src/utils/analytics.utils';
+import { QueryArgsValidationPipe } from 'src/helpers/validators/query.args.validation.pipe';
 
 @Resolver()
 export class AnalyticsResolver {
@@ -209,13 +210,7 @@ export class AnalyticsResolver {
     }
 
     @Query(() => [CandleDataModel])
-    @UsePipes(
-        new ValidationPipe({
-            skipNullProperties: true,
-            skipMissingProperties: true,
-            skipUndefinedProperties: true,
-        }),
-    )
+    @UsePipes(new QueryArgsValidationPipe())
     async tokenMiniChartPriceCandles(
         @Args(PriceCandlesArgsValidationPipe)
         args: TokenMiniChartPriceCandlesQueryArgs,

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -201,7 +201,7 @@ export class AnalyticsResolver {
         const adjustedStart = alignTimestampTo4HourInterval(args.start);
         const adjustedEnd = alignTimestampTo4HourInterval(args.end);
 
-        return this.analyticsPairService.priceCandles(
+        return this.analyticsPairService.tokenMiniChartPriceCandles(
             args.series,
             adjustedStart,
             adjustedEnd,
@@ -223,7 +223,7 @@ export class AnalyticsResolver {
         const adjustedStart = alignTimestampTo4HourInterval(args.start);
         const adjustedEnd = alignTimestampTo4HourInterval(args.end);
 
-        return this.analyticsPairService.priceCandles(
+        return this.analyticsPairService.tokenMiniChartPriceCandles(
             args.series,
             adjustedStart,
             adjustedEnd,

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -14,6 +14,7 @@ import { AnalyticsPairService } from './services/analytics.pair.service';
 import { PriceCandlesArgsValidationPipe } from './validators/price.candles.args.validator';
 import { TradingActivityModel } from './models/trading.activity.model';
 import { RouterAbiService } from '../router/services/router.abi.service';
+import { alignTimestampTo4HourInterval } from 'src/utils/analytics.utils';
 
 @Resolver()
 export class AnalyticsResolver {
@@ -192,11 +193,14 @@ export class AnalyticsResolver {
         @Args(PriceCandlesArgsValidationPipe)
         args: PriceCandlesQueryArgs,
     ): Promise<CandleDataModel[]> {
-        return this.analyticsPairService.getPriceCandles(
+        const adjustedStart = alignTimestampTo4HourInterval(args.start);
+        const adjustedEnd = alignTimestampTo4HourInterval(args.end);
+
+        return this.analyticsPairService.priceCandles(
             args.series,
             args.metric,
-            args.start,
-            args.end,
+            adjustedStart,
+            adjustedEnd,
             args.resolution,
         );
     }

--- a/src/modules/analytics/models/query.args.ts
+++ b/src/modules/analytics/models/query.args.ts
@@ -53,3 +53,16 @@ export class PriceCandlesQueryArgs {
     @Field(() => PriceCandlesResolutions)
     resolution: PriceCandlesResolutions;
 }
+
+@ArgsType()
+export class TokenMiniChartPriceCandlesQueryArgs {
+    @Field()
+    @IsValidSeries()
+    series: string;
+    @Field()
+    @IsNotEmpty()
+    start: string;
+    @Field()
+    @IsNotEmpty()
+    end: string;
+}

--- a/src/modules/analytics/services/analytics.pair.service.ts
+++ b/src/modules/analytics/services/analytics.pair.service.ts
@@ -148,8 +148,8 @@ export class AnalyticsPairService {
 
     @GetOrSetCache({
         baseKey: 'analytics',
-        remoteTtl: Constants.oneHour() * 3,
-        localTtl: Constants.oneHour(),
+        remoteTtl: Constants.oneHour() * 4,
+        localTtl: Constants.oneHour() * 3,
     })
     async priceCandles(
         series: string,

--- a/src/modules/analytics/services/analytics.pair.service.ts
+++ b/src/modules/analytics/services/analytics.pair.service.ts
@@ -130,7 +130,7 @@ export class AnalyticsPairService {
         return pairsDayDatas;
     }
 
-    async gueryPriceCandles(
+    async queryPriceCandles(
         series: string,
         metric: string,
         start: string,
@@ -158,7 +158,7 @@ export class AnalyticsPairService {
         end: string,
         resolution: PriceCandlesResolutions,
     ): Promise<CandleDataModel[]> {
-        return await this.gueryPriceCandles(
+        return await this.queryPriceCandles(
             series,
             metric,
             start,

--- a/src/modules/analytics/services/analytics.pair.service.ts
+++ b/src/modules/analytics/services/analytics.pair.service.ts
@@ -135,12 +135,12 @@ export class AnalyticsPairService {
         remoteTtl: Constants.oneHour() * 4,
         localTtl: Constants.oneHour() * 3,
     })
-    async priceCandles(
+    async tokenMiniChartPriceCandles(
         series: string,
         start: string,
         end: string,
     ): Promise<CandleDataModel[]> {
-        return await this.analyticsQueryService.getPriceCandles({
+        return await this.analyticsQueryService.getTokenMiniChartPriceCandles({
             series,
             start,
             end,

--- a/src/modules/analytics/services/analytics.pair.service.ts
+++ b/src/modules/analytics/services/analytics.pair.service.ts
@@ -10,6 +10,8 @@ import { PairAbiService } from 'src/modules/pair/services/pair.abi.service';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 import { AnalyticsQueryService } from 'src/services/analytics/services/analytics.query.service';
 import { PriceCandlesResolutions } from '../models/query.args';
+import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
+import { Constants } from '@multiversx/sdk-nestjs-common';
 
 @Injectable()
 export class AnalyticsPairService {
@@ -128,7 +130,7 @@ export class AnalyticsPairService {
         return pairsDayDatas;
     }
 
-    async getPriceCandles(
+    async gueryPriceCandles(
         series: string,
         metric: string,
         start: string,
@@ -142,5 +144,26 @@ export class AnalyticsPairService {
             start,
             end,
         });
+    }
+
+    @GetOrSetCache({
+        baseKey: 'analytics',
+        remoteTtl: Constants.oneHour() * 3,
+        localTtl: Constants.oneHour(),
+    })
+    async priceCandles(
+        series: string,
+        metric: string,
+        start: string,
+        end: string,
+        resolution: PriceCandlesResolutions,
+    ): Promise<CandleDataModel[]> {
+        return await this.gueryPriceCandles(
+            series,
+            metric,
+            start,
+            end,
+            resolution,
+        );
     }
 }

--- a/src/modules/analytics/services/analytics.pair.service.ts
+++ b/src/modules/analytics/services/analytics.pair.service.ts
@@ -130,22 +130,6 @@ export class AnalyticsPairService {
         return pairsDayDatas;
     }
 
-    async queryPriceCandles(
-        series: string,
-        metric: string,
-        start: string,
-        end: string,
-        resolution: PriceCandlesResolutions,
-    ): Promise<CandleDataModel[]> {
-        return await this.analyticsQueryService.getPriceCandles({
-            series,
-            metric,
-            resolution,
-            start,
-            end,
-        });
-    }
-
     @GetOrSetCache({
         baseKey: 'analytics',
         remoteTtl: Constants.oneHour() * 4,
@@ -153,17 +137,13 @@ export class AnalyticsPairService {
     })
     async priceCandles(
         series: string,
-        metric: string,
         start: string,
         end: string,
-        resolution: PriceCandlesResolutions,
     ): Promise<CandleDataModel[]> {
-        return await this.queryPriceCandles(
+        return await this.analyticsQueryService.getPriceCandles({
             series,
-            metric,
             start,
             end,
-            resolution,
-        );
+        });
     }
 }

--- a/src/modules/analytics/services/analytics.pair.setter.service.ts
+++ b/src/modules/analytics/services/analytics.pair.setter.service.ts
@@ -4,8 +4,6 @@ import { Logger } from 'winston';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { CandleDataModel } from '../models/analytics.model';
-import { PriceCandlesResolutions } from '../models/query.args';
-import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { Constants } from '@multiversx/sdk-nestjs-common';
 
 @Injectable()
@@ -20,17 +18,15 @@ export class AnalyticsPairSetterService extends GenericSetterService {
 
     async setPriceCandles(
         series: string,
-        metric: string,
         start: string,
         end: string,
-        resolution: PriceCandlesResolutions,
         candles: CandleDataModel[],
     ): Promise<string> {
         return await this.setData(
-            this.getCacheKey('priceCandles', series, metric, start, end, resolution),
+            this.getCacheKey('priceCandles', series, start, end),
             candles,
+            Constants.oneHour() * 4,
             Constants.oneHour() * 3,
-            Constants.oneHour(),
         );
     }
-} 
+}

--- a/src/modules/analytics/services/analytics.pair.setter.service.ts
+++ b/src/modules/analytics/services/analytics.pair.setter.service.ts
@@ -1,0 +1,36 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { GenericSetterService } from 'src/services/generics/generic.setter.service';
+import { CandleDataModel } from '../models/analytics.model';
+import { PriceCandlesResolutions } from '../models/query.args';
+import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
+import { Constants } from '@multiversx/sdk-nestjs-common';
+
+@Injectable()
+export class AnalyticsPairSetterService extends GenericSetterService {
+    constructor(
+        protected readonly cachingService: CacheService,
+        @Inject(WINSTON_MODULE_PROVIDER) protected readonly logger: Logger,
+    ) {
+        super(cachingService, logger);
+        this.baseKey = 'analytics';
+    }
+
+    async setPriceCandles(
+        series: string,
+        metric: string,
+        start: string,
+        end: string,
+        resolution: PriceCandlesResolutions,
+        candles: CandleDataModel[],
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('priceCandles', series, metric, start, end, resolution),
+            candles,
+            Constants.oneHour() * 3,
+            Constants.oneHour(),
+        );
+    }
+} 

--- a/src/modules/analytics/services/analytics.pair.setter.service.ts
+++ b/src/modules/analytics/services/analytics.pair.setter.service.ts
@@ -1,10 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
-import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { CandleDataModel } from '../models/analytics.model';
 import { Constants } from '@multiversx/sdk-nestjs-common';
+import { CacheService } from 'src/services/caching/cache.service';
 
 @Injectable()
 export class AnalyticsPairSetterService extends GenericSetterService {

--- a/src/modules/analytics/services/analytics.pair.setter.service.ts
+++ b/src/modules/analytics/services/analytics.pair.setter.service.ts
@@ -16,14 +16,14 @@ export class AnalyticsPairSetterService extends GenericSetterService {
         this.baseKey = 'analytics';
     }
 
-    async setPriceCandles(
+    async setTokenMiniChartPriceCandles(
         series: string,
         start: string,
         end: string,
         candles: CandleDataModel[],
     ): Promise<string> {
         return await this.setData(
-            this.getCacheKey('priceCandles', series, start, end),
+            this.getCacheKey('tokenMiniChartPriceCandles', series, start, end),
             candles,
             Constants.oneHour() * 4,
             Constants.oneHour() * 3,

--- a/src/services/analytics/interfaces/analytics.query.interface.ts
+++ b/src/services/analytics/interfaces/analytics.query.interface.ts
@@ -30,7 +30,7 @@ export interface AnalyticsQueryInterface {
         endDate,
     }): Promise<HistoricDataModel[]>;
 
-    getPriceCandles({
+    getTokenMiniChartPriceCandles({
         series,
         start,
         end,

--- a/src/services/analytics/interfaces/analytics.query.interface.ts
+++ b/src/services/analytics/interfaces/analytics.query.interface.ts
@@ -32,8 +32,6 @@ export interface AnalyticsQueryInterface {
 
     getPriceCandles({
         series,
-        metric,
-        resolution,
         start,
         end,
     }): Promise<CandleDataModel[]>;

--- a/src/services/analytics/mocks/analytics.query.service.mock.ts
+++ b/src/services/analytics/mocks/analytics.query.service.mock.ts
@@ -41,7 +41,7 @@ export class AnalyticsQueryServiceMock implements AnalyticsQueryInterface {
     getHourlySumValues(args: AnalyticsQueryArgs): Promise<HistoricDataModel[]> {
         throw new Error('Method not implemented.');
     }
-    getPriceCandles({
+    getTokenMiniChartPriceCandles({
         series,
         start,
         end,

--- a/src/services/analytics/mocks/analytics.query.service.mock.ts
+++ b/src/services/analytics/mocks/analytics.query.service.mock.ts
@@ -43,7 +43,6 @@ export class AnalyticsQueryServiceMock implements AnalyticsQueryInterface {
     }
     getPriceCandles({
         series,
-        metric,
         start,
         end,
     }): Promise<CandleDataModel[]> {

--- a/src/services/analytics/services/analytics.query.service.ts
+++ b/src/services/analytics/services/analytics.query.service.ts
@@ -6,7 +6,6 @@ import {
 } from 'src/modules/analytics/models/analytics.model';
 import { TimescaleDBQueryService } from '../timescaledb/timescaledb.query.service';
 import { AnalyticsQueryInterface } from '../interfaces/analytics.query.interface';
-import { AnalyticsQueryArgs } from '../entities/analytics.query.args';
 
 @Injectable()
 export class AnalyticsQueryService implements AnalyticsQueryInterface {
@@ -84,16 +83,12 @@ export class AnalyticsQueryService implements AnalyticsQueryInterface {
 
     async getPriceCandles({
         series,
-        metric,
-        resolution,
         start,
         end,
     }): Promise<CandleDataModel[]> {
         const service = await this.getService();
         return await service.getPriceCandles({
             series,
-            metric,
-            resolution,
             start,
             end,
         });

--- a/src/services/analytics/services/analytics.query.service.ts
+++ b/src/services/analytics/services/analytics.query.service.ts
@@ -81,13 +81,13 @@ export class AnalyticsQueryService implements AnalyticsQueryInterface {
         });
     }
 
-    async getPriceCandles({
+    async getTokenMiniChartPriceCandles({
         series,
         start,
         end,
     }): Promise<CandleDataModel[]> {
         const service = await this.getService();
-        return await service.getPriceCandles({
+        return await service.getTokenMiniChartPriceCandles({
             series,
             start,
             end,

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -507,7 +507,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
                 .map(
                     (row) =>
                         new CandleDataModel({
-                            time: moment(row.bucket).valueOf().toString(),
+                            time: row.bucket,
                             ohlc: [row.open, row.high, row.low, row.close],
                         }),
                 );
@@ -516,7 +516,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
         return query.map(
             (row) =>
                 new CandleDataModel({
-                    time: moment(row.bucket).valueOf().toString(),
+                    time: row.bucket,
                     ohlc: [
                         row.open ?? previousCandle.open,
                         row.high ?? previousCandle.high,

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -454,16 +454,11 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     }
 
     @TimescaleDBQuery()
-    async getPriceCandles({
-        series,
-        metric,
-        resolution,
-        start,
-        end,
-    }): Promise<CandleDataModel[]> {
+    async getPriceCandles({ series, start, end }): Promise<CandleDataModel[]> {
+        const resolution = PriceCandlesResolutions.HOUR_4;
         const candleRepository = this.getCandleRepositoryByResolutionAndMetric(
             resolution,
-            metric,
+            'priceUSD',
         );
 
         const startDate = moment.unix(start).utc().toString();
@@ -596,20 +591,6 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
                     ],
                 }),
         );
-    }
-
-    private getCandleModelByResolution(
-        resolution: PriceCandlesResolutions,
-    ): Repository<PriceCandleMinute | PriceCandleHourly | PriceCandleDaily> {
-        if (resolution.includes('minute')) {
-            return this.priceCandleMinute;
-        }
-
-        if (resolution.includes('hour')) {
-            return this.priceCandleHourly;
-        }
-
-        return this.priceCandleDaily;
     }
 
     private getCandleRepositoryByResolutionAndMetric(

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -456,9 +456,11 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     @TimescaleDBQuery()
     async getPriceCandles({ series, start, end }): Promise<CandleDataModel[]> {
         const resolution = PriceCandlesResolutions.HOUR_4;
+        const metric = 'priceUSD';
+
         const candleRepository = this.getCandleRepositoryByResolutionAndMetric(
             resolution,
-            'priceUSD',
+            metric,
         );
 
         const startDate = moment.unix(start).utc().toString();
@@ -489,7 +491,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
             return query.map(
                 (row) =>
                     new CandleDataModel({
-                        time: row.bucket,
+                        time: moment(row.bucket).valueOf().toString(),
                         ohlc: [row.open, row.high, row.low, row.close],
                     }),
             );
@@ -510,7 +512,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
                 .map(
                     (row) =>
                         new CandleDataModel({
-                            time: row.bucket,
+                            time: moment(row.bucket).valueOf().toString(),
                             ohlc: [row.open, row.high, row.low, row.close],
                         }),
                 );
@@ -519,7 +521,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
         return query.map(
             (row) =>
                 new CandleDataModel({
-                    time: row.bucket,
+                    time: moment(row.bucket).valueOf().toString(),
                     ohlc: [
                         row.open ?? previousCandle.open,
                         row.high ?? previousCandle.high,

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -12,9 +12,6 @@ import {
     CloseDaily,
     CloseHourly,
     PDCloseMinute,
-    PriceCandleHourly,
-    PriceCandleMinute,
-    PriceCandleDaily,
     SumDaily,
     SumHourly,
     TokenBurnedWeekly,
@@ -55,12 +52,6 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
         private readonly tokenBurnedWeekly: Repository<TokenBurnedWeekly>,
         @InjectRepository(PDCloseMinute)
         private readonly pdCloseMinute: Repository<PDCloseMinute>,
-        @InjectRepository(PriceCandleMinute)
-        private readonly priceCandleMinute: Repository<PriceCandleMinute>,
-        @InjectRepository(PriceCandleHourly)
-        private readonly priceCandleHourly: Repository<PriceCandleHourly>,
-        @InjectRepository(PriceCandleDaily)
-        private readonly priceCandleDaily: Repository<PriceCandleDaily>,
         @InjectRepository(TokenCandlesMinute)
         private readonly tokenCandlesMinute: Repository<TokenCandlesMinute>,
         @InjectRepository(TokenCandlesHourly)
@@ -454,7 +445,11 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     }
 
     @TimescaleDBQuery()
-    async getTokenMiniChartPriceCandles({ series, start, end }): Promise<CandleDataModel[]> {
+    async getTokenMiniChartPriceCandles({
+        series,
+        start,
+        end,
+    }): Promise<CandleDataModel[]> {
         const resolution = PriceCandlesResolutions.HOUR_4;
         const metric = 'priceUSD';
 

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -486,7 +486,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
             return query.map(
                 (row) =>
                     new CandleDataModel({
-                        time: moment(row.bucket).valueOf().toString(),
+                        time: row.bucket,
                         ohlc: [row.open, row.high, row.low, row.close],
                     }),
             );

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -454,7 +454,7 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     }
 
     @TimescaleDBQuery()
-    async getPriceCandles({ series, start, end }): Promise<CandleDataModel[]> {
+    async getTokenMiniChartPriceCandles({ series, start, end }): Promise<CandleDataModel[]> {
         const resolution = PriceCandlesResolutions.HOUR_4;
         const metric = 'priceUSD';
 

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -461,7 +461,10 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
         start,
         end,
     }): Promise<CandleDataModel[]> {
-        const candleRepository = this.getCandleModelByResolution(resolution);
+        const candleRepository = this.getCandleRepositoryByResolutionAndMetric(
+            resolution,
+            metric,
+        );
 
         const startDate = moment.unix(start).utc().toString();
         const endDate = moment.unix(end).utc().toString();
@@ -474,7 +477,6 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
             .addSelect('locf(min(low)) as low')
             .addSelect('locf(max(high)) as high')
             .where('series = :series', { series })
-            .andWhere('key = :metric', { metric })
             .andWhere('time between :startDate and :endDate', {
                 startDate,
                 endDate,
@@ -502,7 +504,6 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
             .createQueryBuilder()
             .select('open, close, high, low')
             .where('series = :series', { series })
-            .andWhere('key = :metric', { metric })
             .andWhere('time < :startDate', { startDate })
             .orderBy('time', 'DESC')
             .limit(1)

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -124,8 +124,8 @@ export class AnalyticsCacheWarmerService {
     }
 
     @Cron(CronExpression.EVERY_2_HOURS)
-    @Lock({ name: 'cachePriceCandles', verbose: true })
-    async cachePriceCandles(): Promise<void> {
+    @Lock({ name: 'cacheTokenMiniChartPriceCandles', verbose: true })
+    async cacheTokenMiniChartPriceCandles(): Promise<void> {
         const pairsMetadata = await this.routerAbi.pairsMetadata();
 
         const endTimestamp = moment().unix().toString();
@@ -141,13 +141,13 @@ export class AnalyticsCacheWarmerService {
         }
 
         for (const tokenID of tokenIDs) {
-            const candles = await this.analyticsQueryService.getPriceCandles({
+            const candles = await this.analyticsQueryService.getTokenMiniChartPriceCandles({
                 series: tokenID,
                 start: alignedStart,
                 end: alignedEnd,
             });
 
-            const cacheKey = await this.analyticsPairSetter.setPriceCandles(
+            const cacheKey = await this.analyticsPairSetter.setTokenMiniChartPriceCandles(
                 tokenID,
                 alignedStart,
                 alignedEnd,

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -162,33 +162,6 @@ export class AnalyticsCacheWarmerService {
                 await this.deleteCacheKeys([cacheKey]);
             }
         }
-
-        const tokenIDs = new Set<string>();
-        for (const pair of pairsMetadata) {
-            tokenIDs.add(pair.firstTokenID);
-            tokenIDs.add(pair.secondTokenID);
-        }
-
-        for (const tokenID of tokenIDs) {
-            const candles = await this.analyticsPairService.priceCandles(
-                tokenID,
-                'priceUSD',
-                alignedStart,
-                alignedEnd,
-                resolution,
-            );
-
-            const cacheKey = await this.analyticsPairSetter.setPriceCandles(
-                tokenID,
-                'priceUSD',
-                alignedStart,
-                alignedEnd,
-                resolution,
-                candles,
-            );
-
-            await this.deleteCacheKeys([cacheKey]);
-        }
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {

--- a/src/utils/analytics.utils.ts
+++ b/src/utils/analytics.utils.ts
@@ -48,3 +48,13 @@ export const computeIntervalValues = (keys, values) => {
     }
     return intervalValues;
 };
+
+export const alignTimestampTo4HourInterval = (timestamp: string): string => {
+    const momentTimestamp = moment.unix(parseInt(timestamp));
+
+    return momentTimestamp
+        .subtract(momentTimestamp.minutes() % (4 * 60), 'minutes')
+        .subtract(momentTimestamp.hours() % 4, 'hours')
+        .unix()
+        .toString();
+};

--- a/src/utils/analytics.utils.ts
+++ b/src/utils/analytics.utils.ts
@@ -53,7 +53,7 @@ export const alignTimestampTo4HourInterval = (timestamp: string): string => {
     const momentTimestamp = moment.unix(parseInt(timestamp));
 
     return momentTimestamp
-        .subtract(momentTimestamp.minutes() % (4 * 60), 'minutes')
+        .startOf('hour')
         .subtract(momentTimestamp.hours() % 4, 'hours')
         .unix()
         .toString();


### PR DESCRIPTION
## Reasoning
- priceCandles query didn't have any caching
  
## Proposed Changes
- Implement caching for the priceCandles query

## How to test
```
query {
  priceCandles (series: "HTM-f51d55", metric: "priceUSD", start: "1740644706", end:"1741249506", resolution: HOUR_4) {
    time,
    ohlc
  }
}
```
