### PR TITLE
[MEX-726] Fix VM query metrics

### DIFF
--- a/src/helpers/proxy.network.provider.profiler.ts
+++ b/src/helpers/proxy.network.provider.profiler.ts
@@ -21,7 +21,7 @@ export class ProxyNetworkProviderProfiler extends ProxyNetworkProvider {
     async queryContract(query: IContractQuery): Promise<ContractQueryResponse> {
         const profiler = new PerformanceProfiler();
 
-        const result = super.queryContract(query);
+        const result = await super.queryContract(query);
 
         profiler.stop();
 

--- a/src/utils/metrics.collector.ts
+++ b/src/utils/metrics.collector.ts
@@ -8,6 +8,7 @@ export class MetricsCollector {
     private static queryComplexityHistogram: Histogram<string>;
     private static awsQueryDurationHistogram: Histogram<string>;
     private static dataApiQueryDurationHistogram: Histogram<string>;
+    private static vmQueryDurationHistogram: Histogram<string>;
     private static gasDifferenceHistogram: Histogram<string>;
     private static guestQueriesGauge: Gauge<string>;
     private static currentNonceGauge: Gauge<string>;
@@ -67,6 +68,15 @@ export class MetricsCollector {
             MetricsCollector.dataApiQueryDurationHistogram = new Histogram({
                 name: 'data_api_query',
                 help: 'Data API Queries',
+                labelNames: ['query'],
+                buckets: [],
+            });
+        }
+
+        if (!MetricsCollector.vmQueryDurationHistogram) {
+            MetricsCollector.vmQueryDurationHistogram = new Histogram({
+                name: 'vm_query_duration',
+                help: 'VM Queries',
                 labelNames: ['query'],
                 buckets: [],
             });
@@ -177,6 +187,11 @@ export class MetricsCollector {
 
     static setExternalCall(system: string, func: string, duration: number) {
         MetricsCollector.ensureIsInitialized();
+        if (system === 'vm.query') {
+            MetricsCollector.vmQueryDurationHistogram
+                .labels(func)
+                .observe(duration);
+        }
         MetricsCollector.baseMetrics.setExternalCall(system, duration);
     }
 


### PR DESCRIPTION
## Reasoning
- profiling without awaiting the result returns misleading durations for VM queries duration
- the function name is ignored and a generic metric is collected for all VM queries

## Proposed Changes
- add missing await when querying a smart contract
- add a separate histogram for vm queries duration

## How to test
- N/A
