### PR TITLE
[MEX-725] Optimize weekly rewards computations

### DIFF
--- a/src/services/crons/week.timekeeping.cache.warmer.service.ts
+++ b/src/services/crons/week.timekeeping.cache.warmer.service.ts
@@ -9,7 +9,7 @@ import { WeekTimekeepingSetterService } from 'src/submodules/week-timekeeping/se
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Lock } from '@multiversx/sdk-nestjs-common';
 import { PerformanceProfiler } from '@multiversx/sdk-nestjs-monitoring';
-import { scAddress } from 'src/config';
+import { constantsConfig, scAddress } from 'src/config';
 import { farmsAddresses } from 'src/utils/farm.utils';
 import { FarmVersion } from 'src/modules/farm/models/farm.model';
 import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
@@ -56,32 +56,9 @@ export class WeekTimekeepingCacheWarmerService {
                     firstWeekStartEpoch,
                 ),
             ]);
+            await this.deleteCacheKeys(abiCacheKeys);
 
-            const [startEpochForWeek, endEpochForWeek] = await Promise.all([
-                this.weekTimekeepingCompute.computeStartEpochForWeek(
-                    address,
-                    currentWeek,
-                ),
-                this.weekTimekeepingCompute.computeEndEpochForWeek(
-                    address,
-                    currentWeek,
-                ),
-            ]);
-
-            const computeCacheKeys = await Promise.all([
-                this.weekTimekeepingSetter.startEpochForWeek(
-                    address,
-                    currentWeek,
-                    startEpochForWeek,
-                ),
-                this.weekTimekeepingSetter.endEpochForWeek(
-                    address,
-                    currentWeek,
-                    endEpochForWeek,
-                ),
-            ]);
-
-            await this.deleteCacheKeys([...abiCacheKeys, ...computeCacheKeys]);
+            await this.cacheWeekTimekeepingWeeklyEpochs(address, currentWeek);
         }
 
         profiler.stop();
@@ -91,6 +68,45 @@ export class WeekTimekeepingCacheWarmerService {
                 context: 'WeekTimekeepingCacheWarmer',
             },
         );
+    }
+
+    private async cacheWeekTimekeepingWeeklyEpochs(
+        address: string,
+        currentWeek: number,
+    ): Promise<void> {
+        const startWeek = currentWeek - constantsConfig.USER_MAX_CLAIM_WEEKS;
+
+        for (let week = startWeek; week <= currentWeek; week++) {
+            if (week < 1) {
+                continue;
+            }
+
+            const [startEpochForWeek, endEpochForWeek] = await Promise.all([
+                this.weekTimekeepingCompute.computeStartEpochForWeek(
+                    address,
+                    week,
+                ),
+                this.weekTimekeepingCompute.computeEndEpochForWeek(
+                    address,
+                    week,
+                ),
+            ]);
+
+            const computeCacheKeys = await Promise.all([
+                this.weekTimekeepingSetter.startEpochForWeek(
+                    address,
+                    week,
+                    startEpochForWeek,
+                ),
+                this.weekTimekeepingSetter.endEpochForWeek(
+                    address,
+                    week,
+                    endEpochForWeek,
+                ),
+            ]);
+
+            await this.deleteCacheKeys(computeCacheKeys);
+        }
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {

--- a/src/services/crons/week.timekeeping.cache.warmer.service.ts
+++ b/src/services/crons/week.timekeeping.cache.warmer.service.ts
@@ -81,16 +81,16 @@ export class WeekTimekeepingCacheWarmerService {
                 continue;
             }
 
-            const [startEpochForWeek, endEpochForWeek] = await Promise.all([
-                this.weekTimekeepingCompute.computeStartEpochForWeek(
+            const startEpochForWeek =
+                await this.weekTimekeepingCompute.computeStartEpochForWeek(
                     address,
                     week,
-                ),
-                this.weekTimekeepingCompute.computeEndEpochForWeek(
-                    address,
-                    week,
-                ),
-            ]);
+                );
+
+            const endEpochForWeek =
+                startEpochForWeek +
+                this.weekTimekeepingCompute.epochsInWeek -
+                1;
 
             const computeCacheKeys = await Promise.all([
                 this.weekTimekeepingSetter.startEpochForWeek(

--- a/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
+++ b/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
@@ -81,10 +81,8 @@ export class WeeklyRewardsSplittingComputeService
             await this.computeTotalLockedTokensForWeekPriceUSD(
                 totalLockedTokensForWeek,
             );
-        const totalRewardsForWeekPriceUSD = await this.totalRewardsForWeekUSD(
-            scAddress,
-            week,
-        );
+        const totalRewardsForWeekPriceUSD =
+            await this.computeTotalRewardsForWeekUSD(scAddress, week);
 
         const weekAPR = new BigNumber(totalRewardsForWeekPriceUSD)
             .times(52)

--- a/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
+++ b/src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service.ts
@@ -29,40 +29,32 @@ export class WeeklyRewardsSplittingComputeService
     async computeDistribution(
         payments: EsdtTokenPayment[],
     ): Promise<TokenDistributionModel[]> {
-        let totalPriceUSD = new BigNumber('0');
-        const tokenDistributionModels = [];
-
-        const tokenDistributions = await Promise.all(
-            payments.map(async (token) => {
-                const tokenPriceUSD =
-                    await this.tokenCompute.tokenPriceDerivedUSD(token.tokenID);
-                const rewardsPriceUSD = new BigNumber(
-                    tokenPriceUSD,
-                ).multipliedBy(new BigNumber(token.amount));
-
-                return {
-                    tokenID: token.tokenID,
-                    rewardsPriceUSD: rewardsPriceUSD,
-                };
-            }),
-        );
-
-        tokenDistributions.forEach((token) => {
-            tokenDistributionModels.push(
-                new TokenDistributionModel({
-                    tokenId: token.tokenID,
-                    percentage: token.rewardsPriceUSD.toFixed(),
-                }),
+        const tokensPriceUSD =
+            await this.tokenCompute.getAllTokensPriceDerivedUSD(
+                payments.map((payment) => payment.tokenID),
             );
-            totalPriceUSD = totalPriceUSD.plus(token.rewardsPriceUSD);
+
+        let totalPriceUSD = new BigNumber(0);
+        const paymentsValueUSD = payments.map((payment, index) => {
+            const reward = new BigNumber(tokensPriceUSD[index]).multipliedBy(
+                payment.amount,
+            );
+            totalPriceUSD = totalPriceUSD.plus(reward);
+            return reward;
         });
 
-        return tokenDistributionModels.map((model: TokenDistributionModel) => {
-            model.percentage = new BigNumber(model.percentage)
-                .dividedBy(totalPriceUSD)
-                .multipliedBy(100)
-                .toFixed(4);
-            return model;
+        return payments.map((payment, index) => {
+            const valueUSD = paymentsValueUSD[index];
+            const percentage = totalPriceUSD.isZero()
+                ? '0.0000'
+                : valueUSD
+                      .dividedBy(totalPriceUSD)
+                      .multipliedBy(100)
+                      .toFixed(4);
+            return new TokenDistributionModel({
+                tokenId: payment.tokenID,
+                percentage,
+            });
         });
     }
 
@@ -89,8 +81,10 @@ export class WeeklyRewardsSplittingComputeService
             await this.computeTotalLockedTokensForWeekPriceUSD(
                 totalLockedTokensForWeek,
             );
-        const totalRewardsForWeekPriceUSD =
-            await this.computeTotalRewardsForWeekUSD(scAddress, week);
+        const totalRewardsForWeekPriceUSD = await this.totalRewardsForWeekUSD(
+            scAddress,
+            week,
+        );
 
         const weekAPR = new BigNumber(totalRewardsForWeekPriceUSD)
             .times(52)
@@ -124,6 +118,7 @@ export class WeeklyRewardsSplittingComputeService
             totalLockedTokensForWeek,
             totalEnergyForWeek,
             userEnergyForWeek,
+            globalApr,
         ] = await Promise.all([
             this.weeklyRewardsSplittingAbi.totalLockedTokensForWeek(
                 scAddress,
@@ -135,8 +130,8 @@ export class WeeklyRewardsSplittingComputeService
                 userAddress,
                 week,
             ),
+            this.weekAPR(scAddress, week),
         ]);
-        const globalApr = await this.computeWeekAPR(scAddress, week);
 
         const apr = new BigNumber(globalApr)
             .multipliedBy(new BigNumber(userEnergyForWeek.amount))
@@ -175,30 +170,28 @@ export class WeeklyRewardsSplittingComputeService
                     week,
                 ),
             ]);
-        let totalPriceUSD = new BigNumber(0);
 
-        const totalRewardsArray = await Promise.all(
-            totalRewardsForWeek.map(async (reward) => {
-                const tokenID =
-                    reward.tokenID === lockedTokenID
-                        ? baseAssetTokenID
-                        : reward.tokenID;
-                const [token, rewardsPriceUSD] = await Promise.all([
-                    this.tokenService.tokenMetadata(tokenID),
-                    this.tokenCompute.computeTokenPriceDerivedUSD(tokenID),
-                ]);
-                return computeValueUSD(
+        const tokenIDs = totalRewardsForWeek.map((reward) =>
+            reward.tokenID === lockedTokenID
+                ? baseAssetTokenID
+                : reward.tokenID,
+        );
+
+        const [tokensMetadata, tokensPriceUSD] = await Promise.all([
+            this.tokenService.getAllTokensMetadata(tokenIDs),
+            this.tokenCompute.getAllTokensPriceDerivedUSD(tokenIDs),
+        ]);
+
+        return totalRewardsForWeek
+            .reduce((acc, reward, index) => {
+                const rewardUSD = computeValueUSD(
                     reward.amount,
-                    token.decimals,
-                    rewardsPriceUSD,
+                    tokensMetadata[index].decimals,
+                    tokensPriceUSD[index],
                 );
-            }),
-        );
-
-        totalRewardsArray.forEach(
-            (reward) => (totalPriceUSD = totalPriceUSD.plus(reward)),
-        );
-        return totalPriceUSD.toFixed();
+                return acc.plus(rewardUSD);
+            }, new BigNumber(0))
+            .toFixed();
     }
 
     async computeTotalLockedTokensForWeekPriceUSD(
@@ -207,7 +200,7 @@ export class WeeklyRewardsSplittingComputeService
         const baseAssetTokenID = await this.energyAbi.baseAssetTokenID();
         let tokenPriceUSD = '0';
         if (scAddress.has(baseAssetTokenID)) {
-            tokenPriceUSD = await this.tokenCompute.computeTokenPriceDerivedUSD(
+            tokenPriceUSD = await this.tokenCompute.tokenPriceDerivedUSD(
                 baseAssetTokenID,
             );
         }

--- a/src/submodules/weekly-rewards-splitting/services/weekly.rewarrds.splitting.setter.service.ts
+++ b/src/submodules/weekly-rewards-splitting/services/weekly.rewarrds.splitting.setter.service.ts
@@ -113,4 +113,17 @@ export class WeeklyRewardsSplittingSetterService
             CacheTtlInfo.ContractState.localTtl,
         );
     }
+
+    async weekAPR(
+        scAddress: string,
+        week: number,
+        value: string,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('weekAPR', scAddress, week),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
 }

--- a/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
+++ b/src/submodules/weekly-rewards-splitting/specs/weekly-rewards-splitting.compute.service.spec.ts
@@ -103,9 +103,11 @@ describe('WeeklyRewardsSplittingComputeService', () => {
 
         jest.spyOn(
             tokenCompute,
-            'computeTokenPriceDerivedUSD',
-        ).mockImplementation((tokenID) => {
-            return Promise.resolve(priceMap.get(tokenID));
+            'getAllTokensPriceDerivedUSD',
+        ).mockImplementation((tokenIDs: string[]) => {
+            return Promise.resolve(
+                tokenIDs.map((tokenID) => priceMap.get(tokenID)),
+            );
         });
         jest.spyOn(
             weeklyRewardsSplittingAbi,
@@ -143,10 +145,9 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             );
             const tokenCompute =
                 module.get<TokenComputeService>(TokenComputeService);
-            jest.spyOn(
-                tokenCompute,
-                'computeTokenPriceDerivedUSD',
-            ).mockReturnValue(Promise.resolve('10'));
+            jest.spyOn(tokenCompute, 'tokenPriceDerivedUSD').mockReturnValue(
+                Promise.resolve('10'),
+            );
 
             let usdValue =
                 await service.computeTotalLockedTokensForWeekPriceUSD('0');
@@ -182,11 +183,18 @@ describe('WeeklyRewardsSplittingComputeService', () => {
                 module.get<WeeklyRewardsSplittingAbiService>(
                     WeeklyRewardsSplittingAbiService,
                 );
+            jest.spyOn(tokenCompute, 'tokenPriceDerivedUSD').mockImplementation(
+                (tokenID) => {
+                    return Promise.resolve(priceMap.get(tokenID));
+                },
+            );
             jest.spyOn(
                 tokenCompute,
-                'computeTokenPriceDerivedUSD',
-            ).mockImplementation((tokenID) => {
-                return Promise.resolve(priceMap.get(tokenID));
+                'getAllTokensPriceDerivedUSD',
+            ).mockImplementation((tokenIDs: string[]) => {
+                return Promise.resolve(
+                    tokenIDs.map((tokenID) => priceMap.get(tokenID)),
+                );
             });
             jest.spyOn(
                 weeklyRewardsSplittingAbi,
@@ -226,12 +234,11 @@ describe('WeeklyRewardsSplittingComputeService', () => {
         const tokenCompute =
             module.get<TokenComputeService>(TokenComputeService);
 
-        jest.spyOn(
-            tokenCompute,
-            'computeTokenPriceDerivedUSD',
-        ).mockImplementation((tokenID) => {
-            return Promise.resolve(priceMap.get(tokenID));
-        });
+        jest.spyOn(tokenCompute, 'tokenPriceDerivedUSD').mockImplementation(
+            (tokenID) => {
+                return Promise.resolve(priceMap.get(tokenID));
+            },
+        );
 
         const apr = await service.computeWeekAPR(Address.Zero().bech32(), 1);
         expect(apr).toEqual('371.8'); // 100 * 10 + 200 * 30
@@ -258,12 +265,11 @@ describe('WeeklyRewardsSplittingComputeService', () => {
             module.get<WeeklyRewardsSplittingAbiService>(
                 WeeklyRewardsSplittingAbiService,
             );
-        jest.spyOn(
-            tokenCompute,
-            'computeTokenPriceDerivedUSD',
-        ).mockImplementation((tokenID) => {
-            return Promise.resolve(priceMap.get(tokenID));
-        });
+        jest.spyOn(tokenCompute, 'tokenPriceDerivedUSD').mockImplementation(
+            (tokenID) => {
+                return Promise.resolve(priceMap.get(tokenID));
+            },
+        );
         jest.spyOn(
             weeklyRewardsSplittingAbi,
             'userEnergyForWeek',
@@ -307,12 +313,11 @@ describe('WeeklyRewardsSplittingComputeService', () => {
                 module.get<WeeklyRewardsSplittingAbiService>(
                     WeeklyRewardsSplittingAbiService,
                 );
-            jest.spyOn(
-                tokenCompute,
-                'computeTokenPriceDerivedUSD',
-            ).mockImplementation((tokenID) => {
-                return Promise.resolve(priceMap.get(tokenID));
-            });
+            jest.spyOn(tokenCompute, 'tokenPriceDerivedUSD').mockImplementation(
+                (tokenID) => {
+                    return Promise.resolve(priceMap.get(tokenID));
+                },
+            );
 
             jest.spyOn(
                 weeklyRewardsSplittingAbi,
@@ -381,12 +386,11 @@ describe('WeeklyRewardsSplittingComputeService', () => {
                 module.get<WeeklyRewardsSplittingAbiService>(
                     WeeklyRewardsSplittingAbiService,
                 );
-            jest.spyOn(
-                tokenCompute,
-                'computeTokenPriceDerivedUSD',
-            ).mockImplementation((tokenID) => {
-                return Promise.resolve(priceMap.get(tokenID));
-            });
+            jest.spyOn(tokenCompute, 'tokenPriceDerivedUSD').mockImplementation(
+                (tokenID) => {
+                    return Promise.resolve(priceMap.get(tokenID));
+                },
+            );
             jest.spyOn(
                 weeklyRewardsSplittingAbi,
                 'totalEnergyForWeek',
@@ -458,12 +462,11 @@ describe('WeeklyRewardsSplittingComputeService', () => {
                 module.get<WeeklyRewardsSplittingAbiService>(
                     WeeklyRewardsSplittingAbiService,
                 );
-            jest.spyOn(
-                tokenCompute,
-                'computeTokenPriceDerivedUSD',
-            ).mockImplementation((tokenID) => {
-                return Promise.resolve(priceMap.get(tokenID));
-            });
+            jest.spyOn(tokenCompute, 'tokenPriceDerivedUSD').mockImplementation(
+                (tokenID) => {
+                    return Promise.resolve(priceMap.get(tokenID));
+                },
+            );
             jest.spyOn(
                 weeklyRewardsSplittingAbi,
                 'totalEnergyForWeek',


### PR DESCRIPTION
## Reasoning
- the current implementation performs multiple single requests to redis when computing user rewards apr field
  
## Proposed Changes
- use batch get methods for token prices and metadata in weekly rewards compute methods
- cache warm rewards weekApr + invalidate smaller arrays in loop
- refactor week timekeeping cache warmer: cache warm start + end epochs for all claim weeks

## How to test
- N/A
