### PR TITLE
MEX-730 New Global Rewards query

### DIFF
--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -22,6 +22,9 @@ import { AnalyticsModule as AnalyticsServicesModule } from 'src/services/analyti
 import { WeeklyRewardsSplittingModule } from 'src/submodules/weekly-rewards-splitting/weekly-rewards-splitting.module';
 import { AnalyticsSetterService } from './services/analytics.setter.service';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { GlobalRewardsService } from './services/global.rewards.service';
+import { GlobalRewardsResolver } from './global.rewards.resolver';
+import { FarmModuleV2 } from '../farm/v2/farm.v2.module';
 
 @Module({
     imports: [
@@ -31,6 +34,7 @@ import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.
         forwardRef(() => RouterModule),
         PairModule,
         FarmModule,
+        FarmModuleV2,
         ProxyModule,
         LockedAssetModule,
         TokenModule,
@@ -50,12 +54,15 @@ import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.
         AnalyticsSetterService,
         AnalyticsPairService,
         PairDayDataResolver,
+        GlobalRewardsService,
+        GlobalRewardsResolver,
     ],
     exports: [
         AnalyticsAWSGetterService,
         AnalyticsAWSSetterService,
         AnalyticsComputeService,
         AnalyticsSetterService,
+        GlobalRewardsService,
     ],
 })
 export class AnalyticsModule {}

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -5,7 +5,7 @@ import {
     CandleDataModel,
     HistoricDataModel,
 } from 'src/modules/analytics/models/analytics.model';
-import { AnalyticsQueryArgs, PriceCandlesQueryArgs } from './models/query.args';
+import { AnalyticsQueryArgs, GlobalRewardsArgs, PriceCandlesQueryArgs } from './models/query.args';
 import { AnalyticsAWSGetterService } from './services/analytics.aws.getter.service';
 import { AnalyticsComputeService } from './services/analytics.compute.service';
 import { PairComputeService } from '../pair/services/pair.compute.service';
@@ -14,6 +14,8 @@ import { AnalyticsPairService } from './services/analytics.pair.service';
 import { PriceCandlesArgsValidationPipe } from './validators/price.candles.args.validator';
 import { TradingActivityModel } from './models/trading.activity.model';
 import { RouterAbiService } from '../router/services/router.abi.service';
+import { GlobalRewardsModel } from './models/global.rewards.model';
+import { GlobalRewardsService } from './services/global.rewards.service';
 
 @Resolver()
 export class AnalyticsResolver {
@@ -24,6 +26,7 @@ export class AnalyticsResolver {
         private readonly analyticsCompute: AnalyticsComputeService,
         private readonly analyticsPairService: AnalyticsPairService,
         private readonly analyticsAWSGetter: AnalyticsAWSGetterService,
+        private readonly globalRewardsService: GlobalRewardsService,
     ) {}
 
     @Query(() => String)
@@ -217,5 +220,13 @@ export class AnalyticsResolver {
         }
 
         throw new Error('Invalid parameters');
+    }
+
+    @Query(() => GlobalRewardsModel)
+    async globalRewards(
+        @Args() args: GlobalRewardsArgs,
+    ): Promise<GlobalRewardsModel> {
+        const model = await this.globalRewardsService.getGlobalRewards(args.weekOffset);
+        return Object.assign(model, { weekOffset: args.weekOffset });
     }
 }

--- a/src/modules/analytics/analytics.resolver.ts
+++ b/src/modules/analytics/analytics.resolver.ts
@@ -5,7 +5,7 @@ import {
     CandleDataModel,
     HistoricDataModel,
 } from 'src/modules/analytics/models/analytics.model';
-import { AnalyticsQueryArgs, GlobalRewardsArgs, PriceCandlesQueryArgs } from './models/query.args';
+import { AnalyticsQueryArgs, PriceCandlesQueryArgs } from './models/query.args';
 import { AnalyticsAWSGetterService } from './services/analytics.aws.getter.service';
 import { AnalyticsComputeService } from './services/analytics.compute.service';
 import { PairComputeService } from '../pair/services/pair.compute.service';
@@ -14,8 +14,6 @@ import { AnalyticsPairService } from './services/analytics.pair.service';
 import { PriceCandlesArgsValidationPipe } from './validators/price.candles.args.validator';
 import { TradingActivityModel } from './models/trading.activity.model';
 import { RouterAbiService } from '../router/services/router.abi.service';
-import { GlobalRewardsModel } from './models/global.rewards.model';
-import { GlobalRewardsService } from './services/global.rewards.service';
 
 @Resolver()
 export class AnalyticsResolver {
@@ -26,7 +24,6 @@ export class AnalyticsResolver {
         private readonly analyticsCompute: AnalyticsComputeService,
         private readonly analyticsPairService: AnalyticsPairService,
         private readonly analyticsAWSGetter: AnalyticsAWSGetterService,
-        private readonly globalRewardsService: GlobalRewardsService,
     ) {}
 
     @Query(() => String)
@@ -220,13 +217,5 @@ export class AnalyticsResolver {
         }
 
         throw new Error('Invalid parameters');
-    }
-
-    @Query(() => GlobalRewardsModel)
-    async globalRewards(
-        @Args() args: GlobalRewardsArgs,
-    ): Promise<GlobalRewardsModel> {
-        const model = await this.globalRewardsService.getGlobalRewards(args.weekOffset);
-        return Object.assign(model, { weekOffset: args.weekOffset });
     }
 }

--- a/src/modules/analytics/global.rewards.resolver.ts
+++ b/src/modules/analytics/global.rewards.resolver.ts
@@ -1,0 +1,36 @@
+import { Resolver, ResolveField, Parent } from '@nestjs/graphql';
+import {
+    GlobalRewardsModel,
+    FeesCollectorGlobalRewards,
+    FarmsGlobalRewards,
+    StakingGlobalRewards,
+} from './models/global.rewards.model';
+import { GlobalRewardsService } from './services/global.rewards.service';
+
+@Resolver(() => GlobalRewardsModel)
+export class GlobalRewardsResolver {
+    constructor(private readonly globalRewardsService: GlobalRewardsService) {}
+
+    @ResolveField(() => FeesCollectorGlobalRewards)
+    async feesCollectorGlobalRewards(
+        @Parent() parent: GlobalRewardsModel & { weekOffset: number },
+    ): Promise<FeesCollectorGlobalRewards> {
+        return this.globalRewardsService.feesCollectorRewards(
+            parent.weekOffset,
+        );
+    }
+
+    @ResolveField(() => [FarmsGlobalRewards])
+    async farmsGlobalRewards(
+        @Parent() parent: GlobalRewardsModel & { weekOffset: number },
+    ): Promise<FarmsGlobalRewards[]> {
+        return this.globalRewardsService.farmRewards(parent.weekOffset);
+    }
+
+    @ResolveField(() => [StakingGlobalRewards])
+    async stakingGlobalRewards(
+        @Parent() parent: GlobalRewardsModel & { weekOffset: number },
+    ): Promise<StakingGlobalRewards[]> {
+        return this.globalRewardsService.stakingRewards(parent.weekOffset);
+    }
+}

--- a/src/modules/analytics/global.rewards.resolver.ts
+++ b/src/modules/analytics/global.rewards.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, ResolveField, Parent } from '@nestjs/graphql';
+import { Resolver, ResolveField, Parent, Query, Args } from '@nestjs/graphql';
 import {
     GlobalRewardsModel,
     FeesCollectorGlobalRewards,
@@ -6,10 +6,20 @@ import {
     StakingGlobalRewards,
 } from './models/global.rewards.model';
 import { GlobalRewardsService } from './services/global.rewards.service';
+import { GlobalRewardsArgs } from './models/query.args';
 
 @Resolver(() => GlobalRewardsModel)
 export class GlobalRewardsResolver {
     constructor(private readonly globalRewardsService: GlobalRewardsService) {}
+
+    @Query(() => GlobalRewardsModel)
+    async globalRewards(
+        @Args() args: GlobalRewardsArgs,
+    ): Promise<GlobalRewardsModel> {
+        return Object.assign(new GlobalRewardsModel({}), {
+            weekOffset: args.weekOffset,
+        });
+    }
 
     @ResolveField(() => FeesCollectorGlobalRewards)
     async feesCollectorGlobalRewards(

--- a/src/modules/analytics/global.rewards.resolver.ts
+++ b/src/modules/analytics/global.rewards.resolver.ts
@@ -7,12 +7,15 @@ import {
 } from './models/global.rewards.model';
 import { GlobalRewardsService } from './services/global.rewards.service';
 import { GlobalRewardsArgs } from './models/query.args';
+import { UsePipes } from '@nestjs/common';
+import { QueryArgsValidationPipe } from 'src/helpers/validators/query.args.validation.pipe';
 
 @Resolver(() => GlobalRewardsModel)
 export class GlobalRewardsResolver {
     constructor(private readonly globalRewardsService: GlobalRewardsService) {}
 
     @Query(() => GlobalRewardsModel)
+    @UsePipes(new QueryArgsValidationPipe())
     async globalRewards(
         @Args() args: GlobalRewardsArgs,
     ): Promise<GlobalRewardsModel> {

--- a/src/modules/analytics/models/global.rewards.model.ts
+++ b/src/modules/analytics/models/global.rewards.model.ts
@@ -1,4 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql';
+import { nestedFieldComplexity } from 'src/helpers/complexity/field.estimators';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 
 @ObjectType()
@@ -19,10 +20,10 @@ export class FarmsGlobalRewards {
     @Field()
     pairAddress: string;
 
-    @Field(() => EsdtToken, { nullable: true })
+    @Field(() => EsdtToken, { nullable: true, complexity: nestedFieldComplexity })
     firstToken?: EsdtToken;
 
-    @Field(() => EsdtToken, { nullable: true })
+    @Field(() => EsdtToken, { nullable: true, complexity: nestedFieldComplexity })
     secondToken?: EsdtToken;
 
     @Field()
@@ -44,7 +45,7 @@ export class FarmsGlobalRewards {
 
 @ObjectType()
 export class StakingGlobalRewards {
-    @Field(() => EsdtToken, { nullable: true })
+    @Field(() => EsdtToken, { nullable: true, complexity: nestedFieldComplexity })
     farmingToken?: EsdtToken;
 
     @Field()

--- a/src/modules/analytics/models/global.rewards.model.ts
+++ b/src/modules/analytics/models/global.rewards.model.ts
@@ -9,6 +9,12 @@ export class FeesCollectorGlobalRewards {
     @Field()
     energyRewardsUSD: string;
 
+    @Field()
+    totalEnergyAmount: string;
+
+    @Field()
+    totalMexAmount: string;
+
     constructor(init?: Partial<FeesCollectorGlobalRewards>) {
         Object.assign(this, init);
     }
@@ -31,6 +37,12 @@ export class FarmsGlobalRewards {
     @Field()
     energyRewardsUSD: string;
 
+    @Field()
+    totalEnergyAmount: string;
+
+    @Field()
+    totalMexAmount: string;
+
     constructor(init?: Partial<FarmsGlobalRewards>) {
         Object.assign(this, init);
         if (init?.firstToken) {
@@ -52,6 +64,12 @@ export class StakingGlobalRewards {
 
     @Field()
     energyRewardsUSD: string;
+
+    @Field()
+    totalEnergyAmount: string;
+
+    @Field()
+    totalMexAmount: string;
 
     constructor(init?: Partial<StakingGlobalRewards>) {
         Object.assign(this, init);

--- a/src/modules/analytics/models/global.rewards.model.ts
+++ b/src/modules/analytics/models/global.rewards.model.ts
@@ -1,0 +1,93 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
+
+@ObjectType()
+export class FeesCollectorGlobalRewards {
+    @Field()
+    totalRewardsUSD: string;
+
+    @Field()
+    energyRewardsUSD: string;
+
+    constructor(init?: Partial<FeesCollectorGlobalRewards>) {
+        Object.assign(this, init);
+    }
+}
+
+@ObjectType()
+export class FarmsGlobalRewards {
+    @Field()
+    pairAddress: string;
+
+    @Field(() => EsdtToken, { nullable: true })
+    firstToken?: EsdtToken;
+
+    @Field(() => EsdtToken, { nullable: true })
+    secondToken?: EsdtToken;
+
+    @Field()
+    totalRewardsUSD: string;
+
+    @Field()
+    energyRewardsUSD: string;
+
+    constructor(init?: Partial<FarmsGlobalRewards>) {
+        Object.assign(this, init);
+        if (init?.firstToken) {
+            this.firstToken = new EsdtToken(init.firstToken);
+        }
+        if (init?.secondToken) {
+            this.secondToken = new EsdtToken(init.secondToken);
+        }
+    }
+}
+
+@ObjectType()
+export class StakingGlobalRewards {
+    @Field(() => EsdtToken, { nullable: true })
+    farmingToken?: EsdtToken;
+
+    @Field()
+    totalRewardsUSD: string;
+
+    @Field()
+    energyRewardsUSD: string;
+
+    constructor(init?: Partial<StakingGlobalRewards>) {
+        Object.assign(this, init);
+        if (init?.farmingToken) {
+            this.farmingToken = new EsdtToken(init.farmingToken);
+        }
+    }
+}
+
+@ObjectType()
+export class GlobalRewardsModel {
+    @Field(() => FeesCollectorGlobalRewards)
+    feesCollectorGlobalRewards: FeesCollectorGlobalRewards;
+
+    @Field(() => [FarmsGlobalRewards])
+    farmsGlobalRewards: FarmsGlobalRewards[];
+
+    @Field(() => [StakingGlobalRewards])
+    stakingGlobalRewards: StakingGlobalRewards[];
+
+    constructor(init?: Partial<GlobalRewardsModel>) {
+        Object.assign(this, init);
+        if (init?.feesCollectorGlobalRewards) {
+            this.feesCollectorGlobalRewards = new FeesCollectorGlobalRewards(
+                init.feesCollectorGlobalRewards,
+            );
+        }
+        if (init?.farmsGlobalRewards) {
+            this.farmsGlobalRewards = init.farmsGlobalRewards.map(
+                (farm) => new FarmsGlobalRewards(farm),
+            );
+        }
+        if (init?.stakingGlobalRewards) {
+            this.stakingGlobalRewards = init.stakingGlobalRewards.map(
+                (staking) => new StakingGlobalRewards(staking),
+            );
+        }
+    }
+}

--- a/src/modules/analytics/models/global.rewards.model.ts
+++ b/src/modules/analytics/models/global.rewards.model.ts
@@ -9,12 +9,6 @@ export class FeesCollectorGlobalRewards {
     @Field()
     energyRewardsUSD: string;
 
-    @Field()
-    totalEnergyAmount: string;
-
-    @Field()
-    totalMexAmount: string;
-
     constructor(init?: Partial<FeesCollectorGlobalRewards>) {
         Object.assign(this, init);
     }
@@ -37,12 +31,6 @@ export class FarmsGlobalRewards {
     @Field()
     energyRewardsUSD: string;
 
-    @Field()
-    totalEnergyAmount: string;
-
-    @Field()
-    totalMexAmount: string;
-
     constructor(init?: Partial<FarmsGlobalRewards>) {
         Object.assign(this, init);
         if (init?.firstToken) {
@@ -64,12 +52,6 @@ export class StakingGlobalRewards {
 
     @Field()
     energyRewardsUSD: string;
-
-    @Field()
-    totalEnergyAmount: string;
-
-    @Field()
-    totalMexAmount: string;
 
     constructor(init?: Partial<StakingGlobalRewards>) {
         Object.assign(this, init);

--- a/src/modules/analytics/models/query.args.ts
+++ b/src/modules/analytics/models/query.args.ts
@@ -57,15 +57,9 @@ export class PriceCandlesQueryArgs {
 
 @ArgsType()
 export class GlobalRewardsArgs {
-    @Field(() => Number, { nullable: true })
+    @Field(() => Number, { nullable: true, defaultValue: 0 })
     @IsNumber()
     @IsOptional()
-    @Transform(({ value }) => {
-        if (value === undefined || value === null) {
-            return 0;
-        }
-        return Number(value);
-    })
     weekOffset?: number;
 }
 

--- a/src/modules/analytics/models/query.args.ts
+++ b/src/modules/analytics/models/query.args.ts
@@ -1,6 +1,5 @@
-import { ArgsType, Field, registerEnumType } from '@nestjs/graphql';
-import { IsNotEmpty, IsNumber, IsOptional, Matches } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { ArgsType, Field, Int, registerEnumType } from '@nestjs/graphql';
+import { IsNotEmpty, Matches, Max, Min } from 'class-validator';
 import { IsValidMetric } from 'src/helpers/validators/metric.validator';
 import { IsValidSeries } from 'src/helpers/validators/series.validator';
 import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
@@ -57,9 +56,9 @@ export class PriceCandlesQueryArgs {
 
 @ArgsType()
 export class GlobalRewardsArgs {
-    @Field(() => Number, { nullable: true, defaultValue: 0 })
-    @IsNumber()
-    @IsOptional()
+    @Field(() => Int, { nullable: true, defaultValue: 0 })
+    @Min(0)
+    @Max(4)
     weekOffset?: number;
 }
 

--- a/src/modules/analytics/models/query.args.ts
+++ b/src/modules/analytics/models/query.args.ts
@@ -1,5 +1,6 @@
 import { ArgsType, Field, registerEnumType } from '@nestjs/graphql';
-import { IsNotEmpty, Matches } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, Matches } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { IsValidMetric } from 'src/helpers/validators/metric.validator';
 import { IsValidSeries } from 'src/helpers/validators/series.validator';
 import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
@@ -52,4 +53,18 @@ export class PriceCandlesQueryArgs {
     end?: string;
     @Field(() => PriceCandlesResolutions)
     resolution: PriceCandlesResolutions;
+}
+
+@ArgsType()
+export class GlobalRewardsArgs {
+    @Field(() => Number, { nullable: true })
+    @IsNumber()
+    @IsOptional()
+    @Transform(({ value }) => {
+        if (value === undefined || value === null) {
+            return 0;
+        }
+        return Number(value);
+    })
+    weekOffset?: number;
 }

--- a/src/modules/analytics/services/analytics.setter.service.ts
+++ b/src/modules/analytics/services/analytics.setter.service.ts
@@ -5,6 +5,7 @@ import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
 import { Logger } from 'winston';
 import { TradingActivityModel } from '../models/trading.activity.model';
+import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 
 export class AnalyticsSetterService extends GenericSetterService {
     constructor(
@@ -107,6 +108,42 @@ export class AnalyticsSetterService extends GenericSetterService {
             value,
             Constants.oneMinute() * 10,
             Constants.oneMinute() * 5,
+        );
+    }
+
+    async feesCollectorRewards(
+        weekOffset: number,
+        value: any,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('feesCollectorRewards', weekOffset),
+            value,
+            Constants.oneHour() * 6,
+            Constants.oneHour() * 4,
+        );
+    }
+
+    async farmRewards(
+        weekOffset: number,
+        value: any,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('farmRewards', weekOffset),
+            value,
+            Constants.oneHour() * 6,
+            Constants.oneHour() * 4,
+        );
+    }
+
+    async stakingRewards(
+        weekOffset: number,
+        value: any,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('stakingRewards', weekOffset),
+            value,
+            Constants.oneHour() * 6,
+            Constants.oneHour() * 4,
         );
     }
 }

--- a/src/modules/analytics/services/global.rewards.service.ts
+++ b/src/modules/analytics/services/global.rewards.service.ts
@@ -47,7 +47,7 @@ export class GlobalRewardsService {
     async feesCollectorRewards(
         weekOffset: number,
     ): Promise<FeesCollectorGlobalRewards> {
-        return await this.processFeesCollectorRewards(weekOffset);
+        return await this.computeFeesCollectorRewards(weekOffset);
     }
 
     @GetOrSetCache({
@@ -57,7 +57,7 @@ export class GlobalRewardsService {
     })
     @ErrorLoggerAsync()
     async farmRewards(weekOffset: number): Promise<FarmsGlobalRewards[]> {
-        return await this.processFarmsRewards(weekOffset);
+        return await this.computeFarmsRewards(weekOffset);
     }
 
     @GetOrSetCache({
@@ -67,10 +67,10 @@ export class GlobalRewardsService {
     })
     @ErrorLoggerAsync()
     async stakingRewards(weekOffset: number): Promise<StakingGlobalRewards[]> {
-        return await this.processStakingRewards(weekOffset);
+        return await this.computeStakingRewards(weekOffset);
     }
 
-    private async processFeesCollectorRewards(
+    private async computeFeesCollectorRewards(
         weekOffset: number,
     ): Promise<FeesCollectorGlobalRewards> {
         const feesCollectorAddress = scAddress.feesCollector;
@@ -93,7 +93,7 @@ export class GlobalRewardsService {
         });
     }
 
-    private async processFarmsRewards(
+    private async computeFarmsRewards(
         weekOffset: number,
     ): Promise<FarmsGlobalRewards[]> {
         const farmsData: FarmsGlobalRewards[] = [];
@@ -204,7 +204,7 @@ export class GlobalRewardsService {
         });
     }
 
-    private async processStakingRewards(
+    private async computeStakingRewards(
         weekOffset: number,
     ): Promise<StakingGlobalRewards[]> {
         const stakingRewards: StakingGlobalRewards[] = [];

--- a/src/modules/analytics/services/global.rewards.service.ts
+++ b/src/modules/analytics/services/global.rewards.service.ts
@@ -1,0 +1,266 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { WeeklyRewardsSplittingAbiService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.abi.service';
+import { TokenService } from 'src/modules/tokens/services/token.service';
+import { PairComputeService } from 'src/modules/pair/services/pair.compute.service';
+import { GlobalRewardsModel } from '../models/global.rewards.model';
+import {
+    FarmsGlobalRewards,
+    FeesCollectorGlobalRewards,
+    StakingGlobalRewards,
+} from '../models/global.rewards.model';
+import { BigNumber } from 'bignumber.js';
+import { FarmAbiServiceV2 } from 'src/modules/farm/v2/services/farm.v2.abi.service';
+import { StakingAbiService } from 'src/modules/staking/services/staking.abi.service';
+import { StakingService } from 'src/modules/staking/services/staking.service';
+import { scAddress } from 'src/config';
+import { RemoteConfigGetterService } from 'src/modules/remote-config/remote-config.getter.service';
+import { WeeklyRewardsSplittingComputeService } from 'src/submodules/weekly-rewards-splitting/services/weekly-rewards-splitting.compute.service';
+import { FarmFactoryService } from 'src/modules/farm/farm.factory';
+import { WeekTimekeepingAbiService } from 'src/submodules/week-timekeeping/services/week-timekeeping.abi.service';
+import { farmsAddresses } from 'src/utils/farm.utils';
+import { FarmVersion } from 'src/modules/farm/models/farm.model';
+import { PairService } from 'src/modules/pair/services/pair.service';
+import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
+import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
+import { Constants } from '@multiversx/sdk-nestjs-common';
+
+@Injectable()
+export class GlobalRewardsService {
+    private readonly logger = new Logger(GlobalRewardsService.name);
+
+    constructor(
+        private readonly weeklyRewardsSplitting: WeeklyRewardsSplittingAbiService,
+        private readonly weeklyRewardsSplittingCompute: WeeklyRewardsSplittingComputeService,
+        private readonly farmAbiV2: FarmAbiServiceV2,
+        private readonly stakingAbi: StakingAbiService,
+        private readonly tokenService: TokenService,
+        private readonly pairCompute: PairComputeService,
+        private readonly pairService: PairService,
+        private readonly remoteConfig: RemoteConfigGetterService,
+        private readonly farmFactory: FarmFactoryService,
+        private readonly weekTimekeepingAbi: WeekTimekeepingAbiService,
+        private readonly tokenCompute: TokenComputeService,
+        private readonly stakingService: StakingService,
+    ) {}
+
+    async getGlobalRewards(weekOffset: number): Promise<GlobalRewardsModel> {
+        return new GlobalRewardsModel({});
+    }
+
+    @GetOrSetCache({
+        baseKey: 'analytics',
+        remoteTtl: Constants.oneHour() * 6,
+        localTtl: Constants.oneHour() * 4,
+    })
+    async feesCollectorRewards(
+        weekOffset: number,
+    ): Promise<FeesCollectorGlobalRewards> {
+        try {
+            return await this.processFeesCollectorRewards(weekOffset);
+        } catch (error) {
+            this.logger.error(
+                `Error getting fees collector rewards: ${error.message}`,
+            );
+            throw new Error('Error getting fees collector rewards');
+        }
+    }
+
+    @GetOrSetCache({
+        baseKey: 'analytics',
+        remoteTtl: Constants.oneHour() * 6,
+        localTtl: Constants.oneHour() * 4,
+    })
+    async farmRewards(weekOffset: number): Promise<FarmsGlobalRewards[]> {
+        try {
+            return await this.processFarmsRewards(weekOffset);
+        } catch (error) {
+            this.logger.error(`Error getting farms rewards: ${error.message}`);
+            throw new Error('Error getting farms rewards');
+        }
+    }
+
+    @GetOrSetCache({
+        baseKey: 'analytics',
+        remoteTtl: Constants.oneHour() * 6,
+        localTtl: Constants.oneHour() * 4,
+    })
+    async stakingRewards(weekOffset: number): Promise<StakingGlobalRewards[]> {
+        try {
+            return await this.processStakingRewards(weekOffset);
+        } catch (error) {
+            this.logger.error(
+                `Error getting staking rewards: ${error.message}`,
+            );
+            throw new Error('Error getting staking rewards');
+        }
+    }
+
+    private async processFeesCollectorRewards(
+        weekOffset: number,
+    ): Promise<FeesCollectorGlobalRewards> {
+        let energyRewardsUSD = new BigNumber(0);
+        const feesCollectorAddress = scAddress.feesCollector;
+
+        const currentWeek =
+            await this.weeklyRewardsSplitting.lastGlobalUpdateWeek(
+                feesCollectorAddress,
+            );
+
+        const targetWeek = Math.max(0, currentWeek - weekOffset);
+
+        const weekRewardsUSD =
+            await this.weeklyRewardsSplittingCompute.totalRewardsForWeekUSD(
+                feesCollectorAddress,
+                targetWeek,
+            );
+
+        if (weekRewardsUSD && weekRewardsUSD !== '0') {
+            energyRewardsUSD = energyRewardsUSD.plus(
+                new BigNumber(weekRewardsUSD),
+            );
+        }
+
+        const totalRewardsUSD = energyRewardsUSD.dividedBy(0.6);
+
+        return new FeesCollectorGlobalRewards({
+            totalRewardsUSD: totalRewardsUSD.toFixed(),
+            energyRewardsUSD: energyRewardsUSD.toFixed(),
+        });
+    }
+
+    private async processFarmsRewards(
+        weekOffset: number,
+    ): Promise<FarmsGlobalRewards[]> {
+        const farmsData: FarmsGlobalRewards[] = [];
+        const farmAddresses = farmsAddresses([FarmVersion.V2]);
+
+        const pairAddresses = await this.farmAbiV2.getAllPairContractAddresses(
+            farmAddresses,
+        );
+
+        const firstTokens = await this.pairService.getAllFirstTokens(
+            pairAddresses,
+        );
+        const secondTokens = await this.pairService.getAllSecondTokens(
+            pairAddresses,
+        );
+        const allPairsTokens = [...firstTokens, ...secondTokens];
+
+        for (let i = 0; i < farmAddresses.length; i++) {
+            const farmAddress = farmAddresses[i];
+
+            const currentWeek = await this.weekTimekeepingAbi.currentWeek(
+                farmAddress,
+            );
+            const weekToCheck = Math.max(0, currentWeek - weekOffset);
+
+            const rewards =
+                await this.weeklyRewardsSplitting.totalRewardsForWeek(
+                    farmAddress,
+                    weekToCheck,
+                );
+
+            const rewardTokenIDs = rewards.map((reward) => reward.tokenID);
+            const tokensMetadata = allPairsTokens.filter((token) =>
+                rewardTokenIDs.includes(token.identifier),
+            );
+
+            const tokenPrices =
+                await this.tokenCompute.getAllTokensPriceDerivedUSD(
+                    rewardTokenIDs,
+                );
+
+            const energyRewardsUSD = rewards.reduce((acc, reward, j) => {
+                const rewardTokenMetadata = tokensMetadata.find(
+                    (token) => token.identifier === reward.tokenID,
+                );
+                const tokenDecimals = rewardTokenMetadata.decimals;
+                const tokenPrice = tokenPrices[j];
+
+                const tokenAmount = new BigNumber(reward.amount).dividedBy(
+                    new BigNumber(10).pow(tokenDecimals),
+                );
+
+                const rewardUSD = tokenAmount.multipliedBy(tokenPrice);
+
+                return acc.plus(rewardUSD);
+            }, new BigNumber(0));
+
+            const totalRewardsUSD = energyRewardsUSD.dividedBy(0.6);
+
+            farmsData.push(
+                new FarmsGlobalRewards({
+                    pairAddress: pairAddresses[i],
+                    firstToken: firstTokens[i],
+                    secondToken: secondTokens[i],
+                    totalRewardsUSD: totalRewardsUSD.toString(),
+                    energyRewardsUSD: energyRewardsUSD.toString(),
+                }),
+            );
+        }
+
+        return farmsData;
+    }
+
+    private async processStakingRewards(
+        weekOffset: number,
+    ): Promise<StakingGlobalRewards[]> {
+        const stakingRewards: StakingGlobalRewards[] = [];
+        const stakingFarmsAddresses =
+            await this.remoteConfig.getStakingAddresses();
+
+        const farmingTokens = await this.stakingService.getAllFarmingTokens(
+            stakingFarmsAddresses,
+        );
+
+        for (let i = 0; i < stakingFarmsAddresses.length; i++) {
+            const address = stakingFarmsAddresses[i];
+            const currentWeek = await this.weekTimekeepingAbi.currentWeek(
+                address,
+            );
+            const targetWeek = Math.max(0, currentWeek - weekOffset);
+
+            const weeklyRewards =
+                await this.weeklyRewardsSplitting.totalRewardsForWeek(
+                    address,
+                    targetWeek,
+                );
+
+            const rewardTokenIDs = weeklyRewards.map(
+                (reward) => reward.tokenID,
+            );
+            const allRewardsTokens =
+                await this.tokenService.getAllTokensMetadata(rewardTokenIDs);
+
+            const tokenPrices =
+                await this.tokenCompute.getAllTokensPriceDerivedUSD(
+                    rewardTokenIDs,
+                );
+
+            const energyRewardsUSD = weeklyRewards.reduce((acc, reward, j) => {
+                const tokenMetadata = allRewardsTokens.find(
+                    (token) => token.identifier === reward.tokenID,
+                );
+                const tokenAmount = new BigNumber(reward.amount).dividedBy(
+                    new BigNumber(10).pow(tokenMetadata.decimals),
+                );
+
+                const tokenPrice = tokenPrices[j];
+                const tokenValueUSD = tokenAmount.multipliedBy(tokenPrice);
+                return new BigNumber(acc).plus(tokenValueUSD).toFixed();
+            }, '0');
+
+            const totalRewardsUSD = new BigNumber(energyRewardsUSD)
+                .dividedBy(0.6)
+                .toFixed();
+
+            stakingRewards.push({
+                farmingToken: farmingTokens[i],
+                totalRewardsUSD,
+                energyRewardsUSD,
+            });
+        }
+
+        return stakingRewards;
+    }
+}

--- a/src/modules/analytics/services/global.rewards.service.ts
+++ b/src/modules/analytics/services/global.rewards.service.ts
@@ -143,6 +143,15 @@ export class GlobalRewardsService {
         mexMetadata: EsdtToken,
         mexPrice: string,
     ): Promise<FarmsGlobalRewards> {
+        const farmBoostedPercentage =
+            await this.farmAbiV2.boostedYieldsRewardsPercenatage(farmAddress);
+
+        const boostedYieldRewardsPercentage = new BigNumber(
+            farmBoostedPercentage,
+        )
+            .dividedBy(constantsConfig.MAX_PERCENT)
+            .toNumber();
+
         const currentWeek = await this.weekTimekeepingAbi.currentWeek(
             farmAddress,
         );
@@ -170,7 +179,7 @@ export class GlobalRewardsService {
         ).toFixed();
 
         const totalRewardsUSD = new BigNumber(energyRewardsUSD)
-            .dividedBy(0.6)
+            .dividedBy(boostedYieldRewardsPercentage)
             .toFixed();
 
         return new FarmsGlobalRewards({
@@ -210,6 +219,17 @@ export class GlobalRewardsService {
         weekOffset: number,
         farmingToken: EsdtToken,
     ): Promise<StakingGlobalRewards> {
+        const stakingBoostedPercentage =
+            await this.stakingAbi.boostedYieldsRewardsPercenatage(
+                stakingAddress,
+            );
+
+        const boostedYieldRewardsPercentage = new BigNumber(
+            stakingBoostedPercentage,
+        )
+            .dividedBy(constantsConfig.MAX_PERCENT)
+            .toNumber();
+
         const currentWeek = await this.weekTimekeepingAbi.currentWeek(
             stakingAddress,
         );
@@ -250,7 +270,7 @@ export class GlobalRewardsService {
         ).toFixed();
 
         const totalRewardsUSD = new BigNumber(energyRewardsUSD)
-            .dividedBy(0.6)
+            .dividedBy(boostedYieldRewardsPercentage)
             .toFixed();
 
         return new StakingGlobalRewards({

--- a/src/modules/analytics/services/global.rewards.service.ts
+++ b/src/modules/analytics/services/global.rewards.service.ts
@@ -19,7 +19,6 @@ import { PairService } from 'src/modules/pair/services/pair.service';
 import { TokenComputeService } from 'src/modules/tokens/services/token.compute.service';
 import { GetOrSetCache } from 'src/helpers/decorators/caching.decorator';
 import { Constants, ErrorLoggerAsync } from '@multiversx/sdk-nestjs-common';
-import { EsdtTokenPayment } from 'src/models/esdtTokenPayment.model';
 import { StakingAbiService } from 'src/modules/staking/services/staking.abi.service';
 import { EsdtToken } from 'src/modules/tokens/models/esdtToken.model';
 import { computeValueUSD } from 'src/utils/token.converters';
@@ -71,7 +70,7 @@ export class GlobalRewardsService {
         return await this.computeStakingRewards(weekOffset);
     }
 
-    private async computeFeesCollectorRewards(
+    async computeFeesCollectorRewards(
         weekOffset: number,
     ): Promise<FeesCollectorGlobalRewards> {
         const feesCollectorAddress = scAddress.feesCollector;
@@ -94,7 +93,7 @@ export class GlobalRewardsService {
         });
     }
 
-    private async computeFarmsRewards(
+    async computeFarmsRewards(
         weekOffset: number,
     ): Promise<FarmsGlobalRewards[]> {
         const farmsData: FarmsGlobalRewards[] = [];
@@ -183,7 +182,7 @@ export class GlobalRewardsService {
         });
     }
 
-    private async computeStakingRewards(
+    async computeStakingRewards(
         weekOffset: number,
     ): Promise<StakingGlobalRewards[]> {
         const stakingRewards: StakingGlobalRewards[] = [];

--- a/src/modules/farm/base-module/services/farm.abi.service.ts
+++ b/src/modules/farm/base-module/services/farm.abi.service.ts
@@ -381,6 +381,16 @@ export class FarmAbiService
         }
     }
 
+    async getAllPairContractAddresses(farmAddresses: string[]): Promise<string[]> {
+        return await getAllKeys<string>(
+            this.cacheService,
+            farmAddresses,
+            'farm.pairContractAddress',
+            this.pairContractAddress.bind(this),
+            CacheTtlInfo.ContractState,
+        );
+    }
+
     @ErrorLoggerAsync({
         logArgs: true,
     })

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -128,8 +128,6 @@ export class AnalyticsCacheWarmerService {
 
         const allData = await Promise.all(
             weekOffsets.map(async (weekOffset) => {
-                await this.globalRewardsService.getGlobalRewards(weekOffset);
-
                 const feesRewards =
                     await this.globalRewardsService.feesCollectorRewards(
                         weekOffset,

--- a/src/services/crons/analytics.cache.warmer.service.ts
+++ b/src/services/crons/analytics.cache.warmer.service.ts
@@ -135,13 +135,13 @@ export class AnalyticsCacheWarmerService {
         const allData = await Promise.all(
             weekOffsets.map(async (weekOffset) => {
                 const feesRewards =
-                    await this.globalRewardsService.feesCollectorRewards(
+                    await this.globalRewardsService.computeFeesCollectorRewards(
                         weekOffset,
                     );
                 const farmsRewards =
-                    await this.globalRewardsService.farmRewards(weekOffset);
+                    await this.globalRewardsService.computeFarmsRewards(weekOffset);
                 const stakingRewards =
-                    await this.globalRewardsService.stakingRewards(weekOffset);
+                    await this.globalRewardsService.computeStakingRewards(weekOffset);
 
                 return {
                     weekOffset,


### PR DESCRIPTION
## Reasoning
- Front end needs data regarding rewards distribution for the past 4 weeks from feesCollector, farms and staking farms
  
## Proposed Changes
- Implemented a new query

## How to test
```
query {
  globalRewards (weekOffset: 1) {
    feesCollectorGlobalRewards {
      __typename
      totalRewardsUSD,
      energyRewardsUSD
    },
    farmsGlobalRewards {
      __typename
      pairAddress
      firstToken {
        identifier, 
        name,
        price
      },
      secondToken {
        identifier, 
        name,
        price
      },
      totalRewardsUSD,
      energyRewardsUSD
    }
    stakingGlobalRewards {
      __typename
      farmingToken {
        identifier, 
        name,
        price
      },
      totalRewardsUSD,
      energyRewardsUSD
    }
  }
}
```
