### PR TITLE
[MEX-734] Cache invalidation improvements

### DIFF
--- a/src/modules/farm/base-module/services/farm.abi.service.ts
+++ b/src/modules/farm/base-module/services/farm.abi.service.ts
@@ -35,8 +35,8 @@ export class FarmAbiService
     })
     @GetOrSetCache({
         baseKey: 'farm',
-        remoteTtl: CacheTtlInfo.Token.remoteTtl,
-        localTtl: CacheTtlInfo.Token.localTtl,
+        remoteTtl: CacheTtlInfo.TokenID.remoteTtl,
+        localTtl: CacheTtlInfo.TokenID.localTtl,
     })
     async farmedTokenID(farmAddress: string): Promise<string> {
         return this.getFarmedTokenIDRaw(farmAddress);
@@ -55,8 +55,8 @@ export class FarmAbiService
     })
     @GetOrSetCache({
         baseKey: 'farm',
-        remoteTtl: CacheTtlInfo.Token.remoteTtl,
-        localTtl: CacheTtlInfo.Token.localTtl,
+        remoteTtl: CacheTtlInfo.TokenID.remoteTtl,
+        localTtl: CacheTtlInfo.TokenID.localTtl,
     })
     async farmTokenID(farmAddress: string): Promise<string> {
         return this.getFarmTokenIDRaw(farmAddress);
@@ -85,8 +85,8 @@ export class FarmAbiService
     })
     @GetOrSetCache({
         baseKey: 'farm',
-        remoteTtl: CacheTtlInfo.Token.remoteTtl,
-        localTtl: CacheTtlInfo.Token.localTtl,
+        remoteTtl: CacheTtlInfo.TokenID.remoteTtl,
+        localTtl: CacheTtlInfo.TokenID.localTtl,
     })
     async farmingTokenID(farmAddress: string): Promise<string> {
         return this.getFarmingTokenIDRaw(farmAddress);

--- a/src/modules/farm/base-module/services/farm.setter.service.ts
+++ b/src/modules/farm/base-module/services/farm.setter.service.ts
@@ -16,11 +16,11 @@ export abstract class FarmSetterService extends GenericSetterService {
     }
 
     async setFarmTokenID(farmAddress: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('farmTokenID', farmAddress),
             value,
-            CacheTtlInfo.Token.remoteTtl,
-            CacheTtlInfo.Token.localTtl,
+            CacheTtlInfo.TokenID.remoteTtl,
+            CacheTtlInfo.TokenID.localTtl,
         );
     }
 
@@ -28,11 +28,11 @@ export abstract class FarmSetterService extends GenericSetterService {
         farmAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('farmingTokenID', farmAddress),
             value,
-            CacheTtlInfo.Token.remoteTtl,
-            CacheTtlInfo.Token.localTtl,
+            CacheTtlInfo.TokenID.remoteTtl,
+            CacheTtlInfo.TokenID.localTtl,
         );
     }
 
@@ -40,11 +40,11 @@ export abstract class FarmSetterService extends GenericSetterService {
         farmAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('farmedTokenID', farmAddress),
             value,
-            CacheTtlInfo.Token.remoteTtl,
-            CacheTtlInfo.Token.localTtl,
+            CacheTtlInfo.TokenID.remoteTtl,
+            CacheTtlInfo.TokenID.localTtl,
         );
     }
 
@@ -76,7 +76,7 @@ export abstract class FarmSetterService extends GenericSetterService {
         farmAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('rewardsPerBlock', farmAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -88,7 +88,7 @@ export abstract class FarmSetterService extends GenericSetterService {
         farmAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('penaltyPercent', farmAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -100,7 +100,7 @@ export abstract class FarmSetterService extends GenericSetterService {
         farmAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('minimumFarmingEpochs', farmAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -109,7 +109,7 @@ export abstract class FarmSetterService extends GenericSetterService {
     }
 
     async setState(farmAddress: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('state', farmAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -121,7 +121,7 @@ export abstract class FarmSetterService extends GenericSetterService {
         farmAddress: string,
         value: boolean,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('produceRewardsEnabled', farmAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,

--- a/src/modules/pair/services/pair.setter.service.ts
+++ b/src/modules/pair/services/pair.setter.service.ts
@@ -19,7 +19,7 @@ export class PairSetterService extends GenericSetterService {
     }
 
     async setFirstTokenID(pairAddress: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('firstTokenID', pairAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
@@ -31,7 +31,7 @@ export class PairSetterService extends GenericSetterService {
         pairAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('secondTokenID', pairAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
@@ -40,11 +40,11 @@ export class PairSetterService extends GenericSetterService {
     }
 
     async setLpTokenID(pairAddress: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('lpTokenID', pairAddress),
             value,
-            CacheTtlInfo.Token.remoteTtl,
-            CacheTtlInfo.Token.localTtl,
+            CacheTtlInfo.TokenID.remoteTtl,
+            CacheTtlInfo.TokenID.localTtl,
         );
     }
 
@@ -52,7 +52,7 @@ export class PairSetterService extends GenericSetterService {
         pairAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('totalFeePercent', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -64,7 +64,7 @@ export class PairSetterService extends GenericSetterService {
         pairAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('specialFeePercent', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -73,7 +73,7 @@ export class PairSetterService extends GenericSetterService {
     }
 
     async setState(pairAddress: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('state', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -82,7 +82,7 @@ export class PairSetterService extends GenericSetterService {
     }
 
     async setFeeState(pairAddress: string, value: boolean): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('feeState', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -340,7 +340,7 @@ export class PairSetterService extends GenericSetterService {
         pairAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('feesCollectorAddress', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -352,7 +352,7 @@ export class PairSetterService extends GenericSetterService {
         pairAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('feesCollectorCutPercentage', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -361,7 +361,7 @@ export class PairSetterService extends GenericSetterService {
     }
 
     async setHasFarms(pairAddress: string, value: boolean): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('hasFarms', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -373,7 +373,7 @@ export class PairSetterService extends GenericSetterService {
         pairAddress: string,
         value: boolean,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('hasDualFarms', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -403,7 +403,7 @@ export class PairSetterService extends GenericSetterService {
     }
 
     async setDeployedAt(pairAddress: string, value: number): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('deployedAt', pairAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,

--- a/src/modules/staking-proxy/services/staking.proxy.setter.service.ts
+++ b/src/modules/staking-proxy/services/staking.proxy.setter.service.ts
@@ -4,7 +4,6 @@ import { Constants } from '@multiversx/sdk-nestjs-common';
 import { CacheService } from 'src/services/caching/cache.service';
 import { CacheTtlInfo } from 'src/services/caching/cache.ttl.info';
 import { GenericSetterService } from 'src/services/generics/generic.setter.service';
-import { generateCacheKeyFromParams } from 'src/utils/generate-cache-key';
 import { Logger } from 'winston';
 
 @Injectable()
@@ -14,14 +13,15 @@ export class StakingProxySetterService extends GenericSetterService {
         @Inject(WINSTON_MODULE_PROVIDER) protected readonly logger: Logger,
     ) {
         super(cachingService, logger);
+        this.baseKey = 'stakeProxy';
     }
 
     async setLpFarmAddress(
         stakingProxyAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
-            this.getStakeProxyCacheKey(stakingProxyAddress, 'lpFarmAddress'),
+        return await this.setDataOrUpdateTtl(
+            this.getCacheKey('lpFarmAddress', stakingProxyAddress),
             value,
             Constants.oneHour(),
         );
@@ -31,11 +31,8 @@ export class StakingProxySetterService extends GenericSetterService {
         stakingProxyAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
-            this.getStakeProxyCacheKey(
-                stakingProxyAddress,
-                'stakingFarmAddress',
-            ),
+        return await this.setDataOrUpdateTtl(
+            this.getCacheKey('stakingFarmAddress', stakingProxyAddress),
             value,
             Constants.oneHour(),
         );
@@ -45,8 +42,8 @@ export class StakingProxySetterService extends GenericSetterService {
         stakingProxyAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
-            this.getStakeProxyCacheKey(stakingProxyAddress, 'pairAddress'),
+        return await this.setDataOrUpdateTtl(
+            this.getCacheKey('pairAddress', stakingProxyAddress),
             value,
             Constants.oneHour(),
         );
@@ -56,8 +53,8 @@ export class StakingProxySetterService extends GenericSetterService {
         stakingProxyAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
-            this.getStakeProxyCacheKey(stakingProxyAddress, 'stakingTokenID'),
+        return await this.setDataOrUpdateTtl(
+            this.getCacheKey('stakingTokenID', stakingProxyAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
             CacheTtlInfo.TokenID.localTtl,
@@ -68,8 +65,8 @@ export class StakingProxySetterService extends GenericSetterService {
         stakingProxyAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
-            this.getStakeProxyCacheKey(stakingProxyAddress, 'farmTokenID'),
+        return await this.setDataOrUpdateTtl(
+            this.getCacheKey('farmTokenID', stakingProxyAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
             CacheTtlInfo.TokenID.localTtl,
@@ -80,8 +77,8 @@ export class StakingProxySetterService extends GenericSetterService {
         stakingProxyAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
-            this.getStakeProxyCacheKey(stakingProxyAddress, 'dualYieldTokenID'),
+        return await this.setDataOrUpdateTtl(
+            this.getCacheKey('dualYieldTokenID', stakingProxyAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
             CacheTtlInfo.TokenID.localTtl,
@@ -92,19 +89,11 @@ export class StakingProxySetterService extends GenericSetterService {
         stakingProxyAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
-            this.getStakeProxyCacheKey(stakingProxyAddress, 'lpFarmTokenID'),
+        return await this.setDataOrUpdateTtl(
+            this.getCacheKey('lpFarmTokenID', stakingProxyAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
             CacheTtlInfo.TokenID.localTtl,
-        );
-    }
-
-    private getStakeProxyCacheKey(stakingProxyAddress: string, ...args: any) {
-        return generateCacheKeyFromParams(
-            'stakeProxy',
-            stakingProxyAddress,
-            ...args,
         );
     }
 }

--- a/src/modules/staking/services/staking.setter.service.ts
+++ b/src/modules/staking/services/staking.setter.service.ts
@@ -18,7 +18,7 @@ export class StakingSetterService extends GenericSetterService {
     }
 
     async setFarmTokenID(stakeAddress: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('farmTokenID', stakeAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
@@ -30,7 +30,7 @@ export class StakingSetterService extends GenericSetterService {
         stakeAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('farmingTokenID', stakeAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
@@ -42,7 +42,7 @@ export class StakingSetterService extends GenericSetterService {
         stakeAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('rewardTokenID', stakeAddress),
             value,
             CacheTtlInfo.TokenID.remoteTtl,
@@ -102,7 +102,7 @@ export class StakingSetterService extends GenericSetterService {
         stakeAddress: string,
         value: string,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('annualPercentageRewards', stakeAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -126,7 +126,7 @@ export class StakingSetterService extends GenericSetterService {
         stakeAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('minUnboundEpochs', stakeAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -162,7 +162,7 @@ export class StakingSetterService extends GenericSetterService {
         stakeAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('divisionSafetyConstant', stakeAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -171,7 +171,7 @@ export class StakingSetterService extends GenericSetterService {
     }
 
     async setState(stakeAddress: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('state', stakeAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -183,7 +183,7 @@ export class StakingSetterService extends GenericSetterService {
         stakeAddress: string,
         value: BoostedYieldsFactors,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('boostedYieldsFactors', stakeAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,

--- a/src/modules/tokens/services/token.setter.service.ts
+++ b/src/modules/tokens/services/token.setter.service.ts
@@ -41,7 +41,7 @@ export class TokenSetterService extends GenericSetterService {
     }
 
     async setEsdtTokenType(tokenID: string, type: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getTokenCacheKey(tokenID, 'getEsdtTokenType'),
             type,
             CacheTtlInfo.Token.remoteTtl,
@@ -147,7 +147,7 @@ export class TokenSetterService extends GenericSetterService {
     }
 
     async setCreatedAt(tokenID: string, value: string): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getTokenCacheKey(tokenID, 'tokenCreatedAt'),
             value,
             CacheTtlInfo.Token.remoteTtl,

--- a/src/services/crons/farm.cache.warmer.service.ts
+++ b/src/services/crons/farm.cache.warmer.service.ts
@@ -257,6 +257,14 @@ export class FarmCacheWarmerService {
     }
 
     private async deleteCacheKeys() {
+        this.invalidatedKeys = this.invalidatedKeys.filter(
+            (key) => key !== undefined,
+        );
+
+        if (this.invalidatedKeys.length === 0) {
+            return;
+        }
+
         await this.pubSub.publish('deleteCacheKeys', this.invalidatedKeys);
         this.invalidatedKeys = [];
     }

--- a/src/services/crons/pair.cache.warmer.service.ts
+++ b/src/services/crons/pair.cache.warmer.service.ts
@@ -383,6 +383,12 @@ export class PairCacheWarmerService {
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {
+        invalidatedKeys = invalidatedKeys.filter((key) => key !== undefined);
+
+        if (invalidatedKeys.length === 0) {
+            return;
+        }
+
         await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
     }
 }

--- a/src/services/crons/staking.cache.warmer.service.ts
+++ b/src/services/crons/staking.cache.warmer.service.ts
@@ -144,6 +144,12 @@ export class StakingCacheWarmerService {
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {
+        invalidatedKeys = invalidatedKeys.filter((key) => key !== undefined);
+
+        if (invalidatedKeys.length === 0) {
+            return;
+        }
+
         await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
     }
 }

--- a/src/services/crons/staking.proxy.cache.warmer.service.ts
+++ b/src/services/crons/staking.proxy.cache.warmer.service.ts
@@ -15,7 +15,7 @@ export class StakingProxyCacheWarmerService {
         @Inject(PUB_SUB) private pubSub: RedisPubSub,
     ) {}
 
-    @Cron(CronExpression.EVERY_HOUR)
+    @Cron(CronExpression.EVERY_30_MINUTES)
     async cacheFarmsStaking(): Promise<void> {
         const stakingProxiesAddress: string[] =
             await this.remoteConfigGetterService.getStakingProxyAddresses();
@@ -68,6 +68,12 @@ export class StakingProxyCacheWarmerService {
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {
+        invalidatedKeys = invalidatedKeys.filter((key) => key !== undefined);
+
+        if (invalidatedKeys.length === 0) {
+            return;
+        }
+
         await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
     }
 }

--- a/src/services/crons/tokens.cache.warmer.service.ts
+++ b/src/services/crons/tokens.cache.warmer.service.ts
@@ -209,6 +209,12 @@ export class TokensCacheWarmerService {
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {
+        invalidatedKeys = invalidatedKeys.filter((key) => key !== undefined);
+
+        if (invalidatedKeys.length === 0) {
+            return;
+        }
+
         await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
     }
 }

--- a/src/services/crons/week.timekeeping.cache.warmer.service.ts
+++ b/src/services/crons/week.timekeeping.cache.warmer.service.ts
@@ -94,6 +94,12 @@ export class WeekTimekeepingCacheWarmerService {
     }
 
     private async deleteCacheKeys(invalidatedKeys: string[]) {
+        invalidatedKeys = invalidatedKeys.filter((key) => key !== undefined);
+
+        if (invalidatedKeys.length === 0) {
+            return;
+        }
+
         await this.pubSub.publish('deleteCacheKeys', invalidatedKeys);
     }
 }

--- a/src/submodules/week-timekeeping/services/week-timekeeping.setter.service.ts
+++ b/src/submodules/week-timekeeping/services/week-timekeeping.setter.service.ts
@@ -17,7 +17,7 @@ export class WeekTimekeepingSetterService extends GenericSetterService {
     }
 
     async currentWeek(scAddress: string, value: number): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('currentWeek', scAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -29,7 +29,7 @@ export class WeekTimekeepingSetterService extends GenericSetterService {
         scAddress: string,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('firstWeekStartEpoch', scAddress),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -42,7 +42,7 @@ export class WeekTimekeepingSetterService extends GenericSetterService {
         week: number,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('startEpochForWeek', scAddress, week),
             value,
             CacheTtlInfo.ContractState.remoteTtl,
@@ -55,7 +55,7 @@ export class WeekTimekeepingSetterService extends GenericSetterService {
         week: number,
         value: number,
     ): Promise<string> {
-        return await this.setData(
+        return await this.setDataOrUpdateTtl(
             this.getCacheKey('endEpochForWeek', scAddress, week),
             value,
             CacheTtlInfo.ContractState.remoteTtl,


### PR DESCRIPTION
## Reasoning
- currently, the in-memory cache is being invalidated too frequently due to deleteCacheKeys events received via pubsub. These events, primarily triggered by the cache warmer instance, reduce the overall benefit of caching by causing unnecessary cache refreshes
  
## Proposed Changes
- add `setDataOrUpdateTtl` to the `GenericSetterService`. This method is designed to update cache entries without returning a cache key (unlike the existing setData method)
- utilize `setDataOrUpdateTtl` for updating specific fields that do not require frequent invalidation. This approach aims to maintain the integrity of in-memory caching while reducing unnecessary refresh events. 

## How to test
- N/A

