### PR TITLE
[MEX-737] position creator gas fix

### DIFF
--- a/src/modules/position-creator/services/position.creator.transaction.ts
+++ b/src/modules/position-creator/services/position.creator.transaction.ts
@@ -71,6 +71,10 @@ export class PositionCreatorTransactionService {
             swapRoutes.length < 2
                 ? []
                 : this.serializeSwapRouteArgs(swapRoutes[0]);
+        const swapsCount =
+            swapRoutes.length > 1
+                ? swapRoutes[0].pairs.length + 1
+                : swapRoutes.length;
 
         const [amount0Min, amount1Min] =
             await this.getMinimumAmountsForLiquidity(
@@ -80,8 +84,7 @@ export class PositionCreatorTransactionService {
         const gasLimit =
             gasConfig.positionCreator.singleToken.liquidityPosition +
             gasConfig.pairs.addLiquidity +
-            gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                swapRoutes[0].pairs.length;
+            gasConfig.pairs.swapTokensFixedInput.withFeeSwap * swapsCount;
 
         const transactionOptions = new TransactionOptions({
             sender: sender,
@@ -206,6 +209,10 @@ export class PositionCreatorTransactionService {
             swapRoutes.length < 2
                 ? []
                 : this.serializeSwapRouteArgs(swapRoutes[0]);
+        const swapsCount =
+            swapRoutes.length > 1
+                ? swapRoutes[0].pairs.length + 1
+                : swapRoutes.length;
 
         const [amount0Min, amount1Min] =
             await this.getMinimumAmountsForLiquidity(
@@ -216,8 +223,7 @@ export class PositionCreatorTransactionService {
             gasConfig.positionCreator.singleToken.farmPosition +
             gasConfig.pairs.addLiquidity +
             gasConfig.farms[FarmVersion.V2].enterFarm.withTokenMerge +
-            gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                swapRoutes[0].pairs.length;
+            gasConfig.pairs.swapTokensFixedInput.withFeeSwap * swapsCount;
 
         const transactionOptions = new TransactionOptions({
             sender: sender,
@@ -359,6 +365,10 @@ export class PositionCreatorTransactionService {
             swapRoutes.length < 2
                 ? []
                 : this.serializeSwapRouteArgs(swapRoutes[0]);
+        const swapsCount =
+            swapRoutes.length > 1
+                ? swapRoutes[0].pairs.length + 1
+                : swapRoutes.length;
 
         const [amount0Min, amount1Min] =
             payments[0].tokenIdentifier === lpTokenID
@@ -367,18 +377,12 @@ export class PositionCreatorTransactionService {
                       swapRoutes[swapRoutes.length - 1],
                   );
 
-        let gasLimit =
+        const gasLimit =
             gasConfig.positionCreator.singleToken.dualFarmPosition +
             gasConfig.pairs.addLiquidity +
             gasConfig.farms[FarmVersion.V2].enterFarm.withTokenMerge +
-            gasConfig.stakeProxy.stakeFarmTokens.withTokenMerge;
-
-        gasLimit =
-            swapRoutes.length < 1
-                ? gasLimit
-                : gasLimit +
-                  gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                      swapRoutes[0].pairs.length;
+            gasConfig.stakeProxy.stakeFarmTokens.withTokenMerge +
+            gasConfig.pairs.swapTokensFixedInput.withFeeSwap * swapsCount;
 
         const transactionOptions = new TransactionOptions({
             sender: sender,

--- a/src/modules/position-creator/specs/position.creator.transaction.spec.ts
+++ b/src/modules/position-creator/specs/position.creator.transaction.spec.ts
@@ -151,7 +151,7 @@ describe('PositionCreatorTransaction', () => {
                 gasConfig.positionCreator.singleToken.liquidityPosition +
                 gasConfig.pairs.addLiquidity +
                 gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                    swapRoutes[0].pairs.length;
+                    (swapRoutes[0].pairs.length + 1);
 
             expect(transactions).toEqual([
                 {
@@ -219,7 +219,7 @@ describe('PositionCreatorTransaction', () => {
                 gasConfig.positionCreator.singleToken.liquidityPosition +
                 gasConfig.pairs.addLiquidity +
                 gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                    swapRoutes[0].pairs.length;
+                    (swapRoutes[0].pairs.length + 1);
 
             expect(transactions).toEqual([
                 {
@@ -472,7 +472,7 @@ describe('PositionCreatorTransaction', () => {
                 gasConfig.pairs.addLiquidity +
                 gasConfig.farms[FarmVersion.V2].enterFarm.withTokenMerge +
                 gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                    swapRoutes[0].pairs.length;
+                    (swapRoutes[0].pairs.length + 1);
 
             expect(transactions).toEqual([
                 {
@@ -633,7 +633,7 @@ describe('PositionCreatorTransaction', () => {
                 gasConfig.pairs.addLiquidity +
                 gasConfig.farms[FarmVersion.V2].enterFarm.withTokenMerge +
                 gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                    swapRoutes[0].pairs.length;
+                    (swapRoutes[0].pairs.length + 1);
 
             expect(transactions).toEqual([
                 {
@@ -702,7 +702,7 @@ describe('PositionCreatorTransaction', () => {
                 gasConfig.pairs.addLiquidity +
                 gasConfig.farms[FarmVersion.V2].enterFarm.withTokenMerge +
                 gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                    swapRoutes[0].pairs.length;
+                    (swapRoutes[0].pairs.length + 1);
 
             expect(transactions).toEqual([
                 {
@@ -967,7 +967,7 @@ describe('PositionCreatorTransaction', () => {
                 gasConfig.farms[FarmVersion.V2].enterFarm.withTokenMerge +
                 gasConfig.stakeProxy.stakeFarmTokens.withTokenMerge +
                 gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                    swapRoutes[0].pairs.length;
+                    (swapRoutes[0].pairs.length + 1);
 
             expect(transaction).toEqual([
                 {
@@ -1144,7 +1144,7 @@ describe('PositionCreatorTransaction', () => {
                 gasConfig.farms[FarmVersion.V2].enterFarm.withTokenMerge +
                 gasConfig.stakeProxy.stakeFarmTokens.withTokenMerge +
                 gasConfig.pairs.swapTokensFixedInput.withFeeSwap *
-                    swapRoutes[0].pairs.length;
+                    (swapRoutes[0].pairs.length + 1);
 
             expect(transaction).toEqual([
                 {


### PR DESCRIPTION
## Reasoning
- not enough gas set on position creator single tokens transactions
  
## Proposed Changes
- fixed compute gas limit for single tokens transactions with multiple swaps

## How to test
- N/A
