### PR TITLE
[MEX-769] wxmex unlock transaction fix

### DIFF
--- a/src/modules/locked-token-wrapper/services/locked-token-wrapper.transaction.service.ts
+++ b/src/modules/locked-token-wrapper/services/locked-token-wrapper.transaction.service.ts
@@ -2,62 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { MXProxyService } from '../../../services/multiversx-communication/mx.proxy.service';
 import { TransactionModel } from '../../../models/transaction.model';
 import { Token, TokenTransfer } from '@multiversx/sdk-core';
-import { gasConfig, scAddress } from '../../../config';
+import { gasConfig } from '../../../config';
 import { InputTokenModel } from '../../../models/inputToken.model';
-import { MXApiService } from 'src/services/multiversx-communication/mx.api.service';
-import { ContextGetterService } from 'src/services/context/context.getter.service';
-import { tokenIdentifier } from 'src/utils/token.converters';
-import {
-    LockedTokenAttributes,
-    WrappedLockedTokenAttributes,
-} from '@multiversx/sdk-exchange';
-import { EnergyAbiService } from 'src/modules/energy/services/energy.abi.service';
 import { TransactionOptions } from 'src/modules/common/transaction.options';
 
 @Injectable()
 export class LockedTokenWrapperTransactionService {
-    constructor(
-        private readonly energyAbi: EnergyAbiService,
-        private readonly mxProxy: MXProxyService,
-        private readonly mxApi: MXApiService,
-        private readonly contextGetter: ContextGetterService,
-    ) {}
+    constructor(private readonly mxProxy: MXProxyService) {}
 
     async unwrapLockedToken(
         sender: string,
         inputToken: InputTokenModel,
     ): Promise<TransactionModel> {
-        const [currentEpoch, lockedTokenID, wrappedLockedTokenAttributesRaw] =
-            await Promise.all([
-                this.contextGetter.getCurrentEpoch(),
-                this.energyAbi.lockedTokenID(),
-                this.mxApi.getNftAttributesByTokenIdentifier(
-                    sender,
-                    tokenIdentifier(inputToken.tokenID, inputToken.nonce),
-                ),
-            ]);
-
-        const wrappedLockedTokenAttributes =
-            WrappedLockedTokenAttributes.fromAttributes(
-                wrappedLockedTokenAttributesRaw,
-            );
-        const LockedTokenAttributesRaw =
-            await this.mxApi.getNftAttributesByTokenIdentifier(
-                scAddress.lockedTokenWrapper,
-                tokenIdentifier(
-                    lockedTokenID,
-                    wrappedLockedTokenAttributes.lockedTokenNonce,
-                ),
-            );
-
-        const lockedTokenAttributes = LockedTokenAttributes.fromAttributes(
-            LockedTokenAttributesRaw,
-        );
-
-        if (currentEpoch >= lockedTokenAttributes.unlockEpoch) {
-            throw new Error('Cannot unwrap token after unlock epoch');
-        }
-
         return this.mxProxy.getLockedTokenWrapperSmartContractTransaction(
             new TransactionOptions({
                 sender: sender,

--- a/src/modules/locked-token-wrapper/specs/locked.token.wrapper.transaction.service.spec.ts
+++ b/src/modules/locked-token-wrapper/specs/locked.token.wrapper.transaction.service.spec.ts
@@ -43,33 +43,6 @@ describe('LockedTokenWrapperTransactionService', () => {
         expect(service).toBeDefined();
     });
 
-    it('should get error when unwrapLockedToken transaction', async () => {
-        const service = module.get<LockedTokenWrapperTransactionService>(
-            LockedTokenWrapperTransactionService,
-        );
-        const mxApi = module.get<MXApiService>(MXApiService);
-        jest.spyOn(
-            mxApi,
-            'getNftAttributesByTokenIdentifier',
-        ).mockImplementation(async (address: string, nftIdentifier: string) => {
-            if (nftIdentifier === 'WXMEX-123456-01') {
-                return 'AAAAAAAAAAE=';
-            }
-
-            if (nftIdentifier === 'ELKMEX-123456-01') {
-                return 'AAAACk1FWC00NTVjNTcAAAAAAAAAAAAAAAAAAAAB';
-            }
-        });
-
-        await expect(
-            service.unwrapLockedToken(Address.Zero().toBech32(), {
-                tokenID: 'WXMEX-123456',
-                nonce: 1,
-                amount: '1',
-            }),
-        ).rejects.toThrowError('Cannot unwrap token after unlock epoch');
-    });
-
     it('should get unwrapLockedToken transaction', async () => {
         const service = module.get<LockedTokenWrapperTransactionService>(
             LockedTokenWrapperTransactionService,


### PR DESCRIPTION
## Reasoning
- WXMEX SC doesn't check for unlocking epoch anymore
  
## Proposed Changes
- removed check for wrapped locked token unlock epoch for underlying token

## How to test
```
query UnwrapLockedToken {
    unwrapLockedToken(
        inputTokens: { tokenID: "WXMEX-0b76a1", nonce: 1, amount: "1" }
    ) {
        data
        gasLimit
    }
}
```
- query should return transaction even though the xMEX wrapped in unlockable