### PR TITLE
[MEX-771] Fix token order for Coingecko endpoint

### DIFF
--- a/src/modules/aggregators/services/coin.gecko.service.ts
+++ b/src/modules/aggregators/services/coin.gecko.service.ts
@@ -6,7 +6,6 @@ import { PairComputeService } from 'src/modules/pair/services/pair.compute.servi
 import BigNumber from 'bignumber.js';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { denominateAmount } from 'src/utils/token.converters';
-import { PairMetadata } from 'src/modules/router/models/pair.metadata.model';
 import { determineBaseAndQuoteTokens } from 'src/utils/pair.utils';
 
 @Injectable()

--- a/src/modules/aggregators/services/coin.gecko.service.ts
+++ b/src/modules/aggregators/services/coin.gecko.service.ts
@@ -113,7 +113,7 @@ export class CoinGeckoService {
         commonTokens: string[],
     ): { baseToken: string; targetToken: string } => {
         const sortedCommonTokens = commonTokens.sort((a, b) => {
-            const order = ['USD', 'USH', 'EGLD'];
+            const order = ['USD', 'USH', 'WDAI', 'EGLD'];
             const indexA = order.findIndex((token) => a.includes(token));
             const indexB = order.findIndex((token) => b.includes(token));
             if (indexA === -1 && indexB === -1) return 0;

--- a/src/modules/aggregators/services/coin.gecko.service.ts
+++ b/src/modules/aggregators/services/coin.gecko.service.ts
@@ -7,6 +7,7 @@ import BigNumber from 'bignumber.js';
 import { TokenService } from 'src/modules/tokens/services/token.service';
 import { denominateAmount } from 'src/utils/token.converters';
 import { PairMetadata } from 'src/modules/router/models/pair.metadata.model';
+import { determineBaseAndQuoteTokens } from 'src/utils/pair.utils';
 
 @Injectable()
 export class CoinGeckoService {
@@ -60,8 +61,8 @@ export class CoinGeckoService {
         );
 
         return activePairs.map((pair, index) => {
-            const { baseToken, targetToken } =
-                this.determineBaseAndTargetTokens(pair, commonTokens);
+            const { baseToken: targetToken, quoteToken: baseToken } =
+                determineBaseAndQuoteTokens(pair, commonTokens);
 
             const firstToken = tokenMap.get(pair.firstTokenID);
             const secondToken = tokenMap.get(pair.secondTokenID);
@@ -107,36 +108,4 @@ export class CoinGeckoService {
             });
         });
     }
-
-    determineBaseAndTargetTokens = (
-        pair: PairMetadata,
-        commonTokens: string[],
-    ): { baseToken: string; targetToken: string } => {
-        const sortedCommonTokens = commonTokens.sort((a, b) => {
-            const order = ['USD', 'USH', 'WDAI', 'EGLD'];
-            const indexA = order.findIndex((token) => a.includes(token));
-            const indexB = order.findIndex((token) => b.includes(token));
-            if (indexA === -1 && indexB === -1) return 0;
-            if (indexA === -1) return 1;
-            if (indexB === -1) return -1;
-            return indexA - indexB;
-        });
-
-        for (const token of sortedCommonTokens) {
-            if (pair.firstTokenID === token || pair.secondTokenID === token) {
-                return {
-                    baseToken:
-                        pair.firstTokenID === token
-                            ? pair.secondTokenID
-                            : pair.firstTokenID,
-                    targetToken: token,
-                };
-            }
-        }
-
-        return {
-            baseToken: pair.firstTokenID,
-            targetToken: pair.secondTokenID,
-        };
-    };
 }


### PR DESCRIPTION
## Reasoning
- base and target currency should be inverted
  
## Proposed Changes
- add a method for determining base and target tokens

## How to test
- pairs returned on GET request to `/coingecko/tickers` should always have the common token as `targetCurrency` 