### PR TITLE
[MEX-766] Smart Router evaluation REST endpoints

### DIFF
--- a/src/modules/smart-router-evaluation/dtos/swaps.evaluation.params.ts
+++ b/src/modules/smart-router-evaluation/dtos/swaps.evaluation.params.ts
@@ -1,0 +1,26 @@
+import { IsIn, IsInt, IsNumber, IsOptional, Min } from 'class-validator';
+import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
+
+export class SwapsEvaluationParams {
+    @IsInt()
+    @Min(0)
+    offset: number;
+    @IsIn([5, 10, 50, 100, 200, 500, 1000])
+    size: number;
+    @IsNumber()
+    delta: number;
+    @IsIn(['lt', 'gt', 'eq'])
+    deltaComparison: 'lt' | 'gt' | 'eq';
+    @IsOptional()
+    @IsInt()
+    @IsValidUnixTime()
+    start?: number;
+    @IsOptional()
+    @IsInt()
+    @IsValidUnixTime()
+    end?: number;
+    @IsOptional()
+    tokenIn?: string;
+    @IsOptional()
+    tokenOut?: string;
+}

--- a/src/modules/smart-router-evaluation/smart.router.evaluation.controller.ts
+++ b/src/modules/smart-router-evaluation/smart.router.evaluation.controller.ts
@@ -36,8 +36,9 @@ export class SmartRouterEvaluationController {
     @UseGuards(JwtOrNativeAdminGuard)
     @Get('/swaps/tokens')
     async getDistinctTokens(): Promise<{
-        tokensIn: BaseEsdtToken[];
-        tokensOut: BaseEsdtToken[];
+        tokensIn: string[];
+        tokensOut: string[];
+        allTokensMetadata: BaseEsdtToken[];
     }> {
         return this.smartRouterEvaluationService.getDistinctTokens();
     }

--- a/src/modules/smart-router-evaluation/smart.router.evaluation.controller.ts
+++ b/src/modules/smart-router-evaluation/smart.router.evaluation.controller.ts
@@ -1,0 +1,44 @@
+import {
+    Controller,
+    Get,
+    Query,
+    UseGuards,
+    ValidationPipe,
+} from '@nestjs/common';
+import { SmartRouterEvaluationService } from './services/smart.router.evaluation.service';
+import { SwapRoute } from './schemas/swap.route.schema';
+import { SwapsEvaluationParams } from './dtos/swaps.evaluation.params';
+import { BaseEsdtToken } from '../tokens/models/esdtToken.model';
+import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
+
+@Controller('smart-router')
+export class SmartRouterEvaluationController {
+    constructor(
+        private readonly smartRouterEvaluationService: SmartRouterEvaluationService,
+    ) {}
+
+    @UseGuards(JwtOrNativeAdminGuard)
+    @Get('/swaps')
+    async getComparisonSwapRoutes(
+        @Query(
+            new ValidationPipe({
+                transform: true,
+                transformOptions: { enableImplicitConversion: true },
+            }),
+        )
+        params: SwapsEvaluationParams,
+    ): Promise<{ totalCount: number; swaps: SwapRoute[] }> {
+        return this.smartRouterEvaluationService.getComparisonSwapRoutes(
+            params,
+        );
+    }
+
+    @UseGuards(JwtOrNativeAdminGuard)
+    @Get('/swaps/tokens')
+    async getDistinctTokens(): Promise<{
+        tokensIn: BaseEsdtToken[];
+        tokensOut: BaseEsdtToken[];
+    }> {
+        return this.smartRouterEvaluationService.getDistinctTokens();
+    }
+}

--- a/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
+++ b/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
@@ -5,7 +5,6 @@ import { SwapRoute, SwapRouteSchema } from './schemas/swap.route.schema';
 import { SwapRouteRepositoryService } from 'src/services/database/repositories/swap.route.repository';
 import { TokenModule } from '../tokens/token.module';
 import { ApiConfigService } from 'src/helpers/api.config.service';
-import { SmartRouterEvaluationController } from './smart.router.evaluation.controller';
 
 @Module({
     imports: [
@@ -17,7 +16,6 @@ import { SmartRouterEvaluationController } from './smart.router.evaluation.contr
     providers: [
         SmartRouterEvaluationService,
         SwapRouteRepositoryService,
-        SmartRouterEvaluationController,
         ApiConfigService,
     ],
     exports: [SmartRouterEvaluationService],

--- a/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
+++ b/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
@@ -3,14 +3,23 @@ import { SmartRouterEvaluationService } from './services/smart.router.evaluation
 import { MongooseModule } from '@nestjs/mongoose';
 import { SwapRoute, SwapRouteSchema } from './schemas/swap.route.schema';
 import { SwapRouteRepositoryService } from 'src/services/database/repositories/swap.route.repository';
+import { TokenModule } from '../tokens/token.module';
+import { ApiConfigService } from 'src/helpers/api.config.service';
+import { SmartRouterEvaluationController } from './smart.router.evaluation.controller';
 
 @Module({
     imports: [
         MongooseModule.forFeature([
             { name: SwapRoute.name, schema: SwapRouteSchema },
         ]),
+        TokenModule,
     ],
-    providers: [SmartRouterEvaluationService, SwapRouteRepositoryService],
+    providers: [
+        SmartRouterEvaluationService,
+        SwapRouteRepositoryService,
+        SmartRouterEvaluationController,
+        ApiConfigService,
+    ],
     exports: [SmartRouterEvaluationService],
 })
 export class SmartRouterEvaluationModule {}

--- a/src/private.app.module.ts
+++ b/src/private.app.module.ts
@@ -8,6 +8,8 @@ import { TokenController } from './modules/tokens/token.controller';
 import { TokenModule } from './modules/tokens/token.module';
 import { DynamicModuleUtils } from './utils/dynamic.module.utils';
 import { ESTransactionsService } from './services/elastic-search/services/es.transactions.service';
+import { SmartRouterEvaluationModule } from './modules/smart-router-evaluation/smart.router.evaluation.module';
+import { SmartRouterEvaluationController } from './modules/smart-router-evaluation/smart.router.evaluation.controller';
 
 @Module({
     imports: [
@@ -16,8 +18,14 @@ import { ESTransactionsService } from './services/elastic-search/services/es.tra
         TokenModule,
         RemoteConfigModule,
         DynamicModuleUtils.getCacheModule(),
+        SmartRouterEvaluationModule,
     ],
-    controllers: [MetricsController, TokenController, RemoteConfigController],
+    controllers: [
+        MetricsController,
+        TokenController,
+        RemoteConfigController,
+        SmartRouterEvaluationController,
+    ],
     providers: [ESTransactionsService],
 })
 export class PrivateAppModule {}


### PR DESCRIPTION
## Reasoning
- we need a way to extract information stored in the mongoDB
  
## Proposed Changes
- add private app controller that exposes endpoints needed to populate dashboard
- add service methods for querying mongodb (with pagination, filtering and sorting)

## How to test
- GET request to `<PRIVATE_API_URL>/smart-router/swaps?offset=0&size=10&deltaComparison=gt&delta=-1` should return an array of comparisson documents like this : 
```
[
...
{
      _id: "680f95e6f3984c2210170bef",
      sender: "erd1rwsq0fxjrce9955hvvl3qrpl96xmuuxch9m6wlhxx6zs0n2v3hvqyu4lm5",
      txHash: "fbcc8df11c595fdd1b3979f85c3b1c1416e92ce070625dae22d7d3db50669a67",
      txData: "Y29tcG9zZVRhc2tzQDAwMDAwMDBiNTU1MzQ0NDMyZDMzMzUzMDYzMzQ2NTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwNDAyMWRhZGIwQEBAMDJAMDAwMDAwMTQ3Mzc3NjE3MDU0NmY2YjY1NmU3MzQ2Njk3ODY1NjQ0OTZlNzA3NTc0MDAwMDAwMGI1NTUzNDQ0MzJkMzMzNTMwNjMzNDY1MDAwMDAwMDQwMjFkYWRiMA==",
      timestamp: 1745851878,
      tokenIn: "EGLD",
      tokenOut: "USDC-350c4e",
      amountIn: "2100000000000000000",
      autoRouterAmountOut: "35534940",
      autoRouterTokenRoute: [
         "WEGLD-a28c59",
         "USDC-350c4e"
      ],
      autoRouterIntermediaryAmounts: [
         "2100000000000000000",
         "35534940"
      ],
      smartRouterAmountOut: "35591160",
      smartRouterTokenRoutes: [
        [ "WEGLD-a28c59",  "USDC-350c4e"],
        [ "WEGLD-a28c59", "OPT-94923d", "USDC-350c4e"]
      ],
      smartRouterIntermediaryAmounts: [
        ["2079760031598216932", "35192474"],
        ["20239968401783068", "575551258685882855575", "398686"]
      ],
      outputDelta: "56220",
      outputDeltaPercentage: 0.15821048241533545,
},
...
]
```
