### PR TITLE
[MEX-774] Fix evaluation cron handling of multiple smart router swaps with same txHash

### DIFF
--- a/src/modules/smart-router-evaluation/services/smart.router.evaluation.cron.ts
+++ b/src/modules/smart-router-evaluation/services/smart.router.evaluation.cron.ts
@@ -74,7 +74,11 @@ export class SmartRouterEvaluationCronService {
         const deleteIds = [];
         const bulkOps = [];
         for (let index = 0; index < swapGroup.length; index++) {
-            if (index > operations.length - 1) {
+            const existingSwapRoute =
+                await this.evaluationService.getSwapRouteByTxHash(
+                    operations[index]._search,
+                );
+            if (index > operations.length - 1 || existingSwapRoute !== null) {
                 deleteIds.push(swapGroup[index]._id);
             } else {
                 bulkOps.push({

--- a/src/modules/smart-router-evaluation/services/smart.router.evaluation.service.ts
+++ b/src/modules/smart-router-evaluation/services/smart.router.evaluation.service.ts
@@ -115,12 +115,6 @@ export class SmartRouterEvaluationService {
                 autoRouterTokenRoute: swap.autoRouterTokenRoute,
                 autoRouterIntermediaryAmounts:
                     swap.autoRouterIntermediaryAmounts,
-                smartRouterAmountOut: swap.smartRouterAmountOut,
-                smartRouterTokenRoutes: swap.smartRouterTokenRoutes,
-                smartRouterIntermediaryAmounts:
-                    swap.smartRouterIntermediaryAmounts,
-                outputDelta: swap.outputDelta,
-                outputDeltaPercentage: swap.outputDeltaPercentage,
             };
 
             const optionsHash = crypto

--- a/src/modules/smart-router-evaluation/services/smart.router.evaluation.service.ts
+++ b/src/modules/smart-router-evaluation/services/smart.router.evaluation.service.ts
@@ -80,6 +80,12 @@ export class SmartRouterEvaluationService {
         }
     }
 
+    async getSwapRouteByTxHash(
+        txHash: string,
+    ): Promise<SwapRouteDocument | null> {
+        return await this.swapRouteRepository.findOne({ txHash });
+    }
+
     async getGroupedUnconfirmedSwapRoutes(
         cutoffTimestamp: number | undefined,
     ): Promise<Map<string, SwapRouteDocument[]>> {


### PR DESCRIPTION
## Reasoning
- the evaluation cron groups swap documents by performing a MD5 hash of the proposed transaction (sender, tx data, token in/out, auto router data, smart router data and output delta). 
Because the smart router output could be different for multiple swap documents representing the same tx, the resulting MD5 hash is different, and the cronjob interprets it as a separate transaction.  This results in multiple documents having the same txHash, skewing the result set.
  
## Proposed Changes
- check if a document with a txHash exists before performing an insert 

## How to test
- N/A

