### PR TITLE
[MEX-776] Limit max routes for smart swaps

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -612,6 +612,7 @@
         "STAKING_UNBOND_ATTRIBUTES_LEN": 12,
         "MAX_USER_NFTS": 10000,
         "MAX_SWAP_ROUTE_DEPTH": 4,
+        "MAX_SMART_SWAP_ROUTES": 4,
         "endpoints": [
             "wrapEgld",
             "unwrapEgld",


### PR DESCRIPTION
## Reasoning
- the smart router algorithm can currently recommend up to 15 separate routes. This is not feasible due to gas cost

  
## Proposed Changes
- introduce a loop that prunes the route getting the smallest share of input (it adds the least to total output - its marginal return is lowest by construction of the Lagrange solution) and recomputes optimal phi after every removal
- the loop runs as long as the number of suggested routes > config `MAX_SMART_SWAP_ROUTES`


## How to test
- persisted smart swaps should have at most 4 routes

