### PR TITLE
[MEX-774] Apply lock-and-retry decorator to evaluation cron

### DIFF
--- a/src/modules/smart-router-evaluation/smart.router.evaluation.cron.module.ts
+++ b/src/modules/smart-router-evaluation/smart.router.evaluation.cron.module.ts
@@ -2,9 +2,15 @@ import { Module } from '@nestjs/common';
 import { SmartRouterEvaluationCronService } from './services/smart.router.evaluation.cron';
 import { SmartRouterEvaluationModule } from './smart.router.evaluation.module';
 import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 
 @Module({
-    imports: [SmartRouterEvaluationModule, ElasticSearchModule],
+    imports: [
+        SmartRouterEvaluationModule,
+        ElasticSearchModule,
+        DynamicModuleUtils.getRedlockModule(),
+        DynamicModuleUtils.getCommonRedisModule(),
+    ],
     providers: [SmartRouterEvaluationCronService],
 })
 export class SmartRouterEvaluationCronModule {}

--- a/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
+++ b/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
@@ -5,6 +5,7 @@ import { SwapRoute, SwapRouteSchema } from './schemas/swap.route.schema';
 import { SwapRouteRepositoryService } from 'src/services/database/repositories/swap.route.repository';
 import { TokenModule } from '../tokens/token.module';
 import { ApiConfigService } from 'src/helpers/api.config.service';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 
 @Module({
     imports: [
@@ -12,6 +13,8 @@ import { ApiConfigService } from 'src/helpers/api.config.service';
             { name: SwapRoute.name, schema: SwapRouteSchema },
         ]),
         TokenModule,
+        DynamicModuleUtils.getRedlockModule(),
+        DynamicModuleUtils.getCommonRedisModule(),
     ],
     providers: [
         SmartRouterEvaluationService,

--- a/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
+++ b/src/modules/smart-router-evaluation/smart.router.evaluation.module.ts
@@ -5,7 +5,6 @@ import { SwapRoute, SwapRouteSchema } from './schemas/swap.route.schema';
 import { SwapRouteRepositoryService } from 'src/services/database/repositories/swap.route.repository';
 import { TokenModule } from '../tokens/token.module';
 import { ApiConfigService } from 'src/helpers/api.config.service';
-import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 
 @Module({
     imports: [
@@ -13,8 +12,6 @@ import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
             { name: SwapRoute.name, schema: SwapRouteSchema },
         ]),
         TokenModule,
-        DynamicModuleUtils.getRedlockModule(),
-        DynamicModuleUtils.getCommonRedisModule(),
     ],
     providers: [
         SmartRouterEvaluationService,


### PR DESCRIPTION
## Reasoning
- race condition in evaluation cron caused unpredictable behaviour when pruning swap mongodb documents 
  
## Proposed Changes
- use `@LockAndRetry` decorator 
- simplify cron by only issuing update operations (delete is handled when timestamp is > 10 minutes)
- add verbose logging

## How to test
- N/A

