### PR TITLE
[MEX-779] fix undistributed boosted rewards

### DIFF
--- a/src/modules/farm/specs/farm.v2.compute.service.spec.ts
+++ b/src/modules/farm/specs/farm.v2.compute.service.spec.ts
@@ -74,24 +74,9 @@ describe('FarmServiceV2', () => {
             'erd18h5dulxp5zdp80qjndd2w25kufx0rm5yqd2h7ajrfucjhr82y8vqyq0hye',
             10,
         );
-        const expectedTotal = new BigNumber('5000')
-            .plus('4000')
-            .integerValue()
-            .toFixed(); // 4 weeks * 1000
+        const expectedTotal = new BigNumber('4000').integerValue().toFixed(); // 4 weeks * 1000
         expect(result).toEqual(expectedTotal);
-        // expect(mockFarmAbi.undistributedBoostedRewards).toHaveBeenCalled();
-        // expect(mockFarmAbi.lastUndistributedBoostedRewardsCollectWeek).toHaveBeenCalled();
-        // expect(mockFarmAbi.remainingBoostedRewardsToDistribute).toHaveBeenCalledTimes(4);
     });
-    // it("should return undistributedBoostedRewards if firstWeek > lastWeek", async () => {
-    //     const service = module.get<FarmComputeServiceV2>(
-    //         FarmComputeServiceV2,
-    //     );
-    //     const result = await service.computeUndistributedBoostedRewards('erd18h5dulxp5zdp80qjndd2w25kufx0rm5yqd2h7ajrfucjhr82y8vqyq0hye', 5);
-    //     expect(result).toEqual('5000');
-    //     // expect(mockFarmAbi.undistributedBoostedRewards).toHaveBeenCalled();
-    //     // expect(mockFarmAbi.lastUndistributedBoostedRewardsCollectWeek).toHaveBeenCalled();
-    // }, 10000);
 
     it('should compute blocks in week', async () => {
         const service = module.get<FarmComputeServiceV2>(FarmComputeServiceV2);

--- a/src/modules/farm/v2/services/farm.v2.abi.service.ts
+++ b/src/modules/farm/v2/services/farm.v2.abi.service.ts
@@ -195,7 +195,7 @@ export class FarmAbiServiceV2
     ): Promise<number> {
         return this.gatewayService.getSCStorageKey(
             farmAddress,
-            'lastUndistributedBoostedRewardsCollectWeek',
+            'lastCollectUndistWeek',
         );
     }
 

--- a/src/modules/staking/services/staking.abi.service.ts
+++ b/src/modules/staking/services/staking.abi.service.ts
@@ -648,7 +648,7 @@ export class StakingAbiService
     ): Promise<number> {
         return this.gatewayService.getSCStorageKey(
             stakeAddress,
-            'lastUndistributedBoostedRewardsCollectWeek',
+            'lastCollectUndistWeek',
         );
     }
 


### PR DESCRIPTION
## Reasoning
- xExchange v3.3 protocol release removed the view function: `getUndistributedBoostedRewards`
  
## Proposed Changes
- updated storage name for last claim undistributed boosted rewards week
- updated compute for claimable undistributed boosted rewards

## How to test
```
query Farms {
    farms {
        ... on FarmModelV2 {
            address
            farmToken {
                collection
            }
            undistributedBoostedRewards
        }
    }
}
```
- query should return value if there were no claims between `last_claim_week` and `current week - (USER_MAX_CLAIM_WEEKS + 1)`