### PR TITLE
[MEX-781] Composable tasks splippage fix

### DIFF
--- a/src/modules/auto-router/services/auto-router.transactions.service.ts
+++ b/src/modules/auto-router/services/auto-router.transactions.service.ts
@@ -223,6 +223,22 @@ export class AutoRouterTransactionService {
                 : this.multiPairFixedOutputSwaps(args);
         const swaps = this.convertMultiPairSwapsToBytesValues(typedArgs);
 
+        const toleranceAmount = new BigNumber(
+            args.intermediaryAmounts[args.intermediaryAmounts.length - 1],
+        ).multipliedBy(args.tolerance);
+
+        const amountOutMin =
+            args.swapType === SWAP_TYPE.fixedInput
+                ? new BigNumber(
+                      args.intermediaryAmounts[
+                          args.intermediaryAmounts.length - 1
+                      ],
+                  )
+                      .minus(toleranceAmount)
+                      .integerValue()
+                      .toFixed()
+                : args.intermediaryAmounts[args.intermediaryAmounts.length - 1];
+
         return this.composeTasksTransactionService.getComposeTasksTransaction(
             sender,
             new EsdtTokenPayment({
@@ -233,9 +249,7 @@ export class AutoRouterTransactionService {
             new EgldOrEsdtTokenPayment({
                 tokenIdentifier: args.tokenRoute[args.tokenRoute.length - 1],
                 nonce: 0,
-                amount: args.intermediaryAmounts[
-                    args.intermediaryAmounts.length - 1
-                ],
+                amount: amountOutMin,
             }),
             [
                 {
@@ -261,6 +275,22 @@ export class AutoRouterTransactionService {
                 : this.multiPairFixedOutputSwaps(args);
         const swaps = this.convertMultiPairSwapsToBytesValues(typedArgs);
 
+        const toleranceAmount = new BigNumber(
+            args.intermediaryAmounts[args.intermediaryAmounts.length - 1],
+        ).multipliedBy(args.tolerance);
+
+        const amountOutMin =
+            args.swapType === SWAP_TYPE.fixedInput
+                ? new BigNumber(
+                      args.intermediaryAmounts[
+                          args.intermediaryAmounts.length - 1
+                      ],
+                  )
+                      .minus(toleranceAmount)
+                      .integerValue()
+                      .toFixed()
+                : args.intermediaryAmounts[args.intermediaryAmounts.length - 1];
+
         return this.composeTasksTransactionService.getComposeTasksTransaction(
             sender,
             new EsdtTokenPayment({
@@ -271,9 +301,7 @@ export class AutoRouterTransactionService {
             new EgldOrEsdtTokenPayment({
                 tokenIdentifier: 'EGLD',
                 nonce: 0,
-                amount: args.intermediaryAmounts[
-                    args.intermediaryAmounts.length - 1
-                ],
+                amount: amountOutMin,
             }),
             [
                 {

--- a/src/modules/auto-router/specs/auto-router.service.spec.ts
+++ b/src/modules/auto-router/specs/auto-router.service.spec.ts
@@ -327,6 +327,61 @@ describe('AutoRouterService', () => {
         ]);
     });
 
+    it('should get a fixed input multi swap tx + unwrap tx', async () => {
+        const transactions = await service.getTransactions(
+            senderAddress,
+            new AutoRouteModel({
+                swapType: 0,
+                tokenInID: 'USDC-123456',
+                tokenOutID: 'EGLD',
+                tokenInExchangeRate: '4962567499999999',
+                tokenOutExchangeRate: '201508594089652181902',
+                tokenInPriceUSD: '1',
+                tokenOutPriceUSD: '100',
+                amountIn: '101761840015274351860',
+                amountOut: '500000000000000000',
+                intermediaryAmounts: [
+                    '503014183917413680',
+                    '626881033727',
+                    '500000000000000000',
+                ],
+                tokenRoute: ['USDC-123456', 'WEGLD-123456', 'MEX-123456'],
+                pairs: [
+                    new PairModel({
+                        address: Address.newFromHex(
+                            '0000000000000000000000000000000000000000000000000000000000000013',
+                        ).toBech32(),
+                    }),
+                    new PairModel({
+                        address: Address.newFromHex(
+                            '0000000000000000000000000000000000000000000000000000000000000012',
+                        ).toBech32(),
+                    }),
+                ],
+                tolerance: 0.01,
+            }),
+        );
+        expect(transactions).toEqual([
+            {
+                nonce: 0,
+                value: '0',
+                receiver: Address.Zero().toBech32(),
+                sender: senderAddress,
+                receiverUsername: undefined,
+                senderUsername: undefined,
+                gasPrice: 1000000000,
+                gasLimit: 75200000,
+                data: 'RVNEVFRyYW5zZmVyQDU1NTM0NDQzMmQzMTMyMzMzNDM1MzZAMDZmYjEwYmMzNTYxNjUzMEA2MzZmNmQ3MDZmNzM2NTU0NjE3MzZiNzNAMDAwMDAwMDQ0NTQ3NGM0NDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwODA2ZGU5N2UwOWJkMTgwMDBAMDNAMDAwMDAwMjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEzMDAwMDAwMTQ3Mzc3NjE3MDU0NmY2YjY1NmU3MzQ2Njk3ODY1NjQ0OTZlNzA3NTc0MDAwMDAwMGM1NzQ1NDc0YzQ0MmQzMTMyMzMzNDM1MzYwMDAwMDAwNTkwN2Y1ZjAxOWQwMDAwMDAyMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTIwMDAwMDAxNDczNzc2MTcwNTQ2ZjZiNjU2ZTczNDY2OTc4NjU2NDQ5NmU3MDc1NzQwMDAwMDAwYTRkNDU1ODJkMzEzMjMzMzQzNTM2MDAwMDAwMDgwNmU3Nzk5ZDM3YzFjMDAwQDAxQA==',
+                chainID: 'T',
+                version: 2,
+                options: undefined,
+                signature: undefined,
+                guardian: undefined,
+                guardianSignature: undefined,
+            },
+        ]);
+    });
+
     it('should get a fixed output multi swap tx + unwrap tx', async () => {
         const transactions = await service.getTransactions(
             senderAddress,


### PR DESCRIPTION
## Reasoning
- The first argument for the `composeTasks` transaction of the [composable tasks SC](https://github.com/multiversx/mx-exchange-tools-sc/blob/20a65feb1707a3c9f4b4ed3dfb06e21b16602fad/composable-tasks/src/compose_tasks.rs#L36) is a struct containing the minimum expected token out. 
The value provided by the current implementation (in the case of multi swap + unwrap txs / wrap + multi swap txs) does not account for possible slippage. This results in failed transactions even if the resulting token amount is within the expected slippage provided by the user. 

  
## Proposed Changes
- subtract tolerance amount from expected amount out argument
- add unit tests

## How to test
- transactions where slippage occures, but within the amount specified by the user, should not fail

