### PR TITLE
[MEX-791] Fix factory series TVL

### DIFF
--- a/src/services/analytics/services/analytics.query.service.ts
+++ b/src/services/analytics/services/analytics.query.service.ts
@@ -41,6 +41,7 @@ export class AnalyticsQueryService implements AnalyticsQueryInterface {
     async getValues24h(args: {
         series: any;
         metric: any;
+        time?: string;
     }): Promise<HistoricDataModel[]> {
         const service = await this.getService();
         return await service.getValues24h(args);

--- a/src/services/analytics/timescaledb/timescaledb.query.service.ts
+++ b/src/services/analytics/timescaledb/timescaledb.query.service.ts
@@ -217,14 +217,25 @@ export class TimescaleDBQueryService implements AnalyticsQueryInterface {
     async getValues24h({
         series,
         metric,
+        time,
     }: AnalyticsQueryArgs): Promise<HistoricDataModel[]> {
         try {
-            const endDate = moment().utc().toDate();
-            const startDate = moment()
+            let endDate = moment().utc().toDate();
+            let startDate = moment()
                 .subtract(1, 'day')
                 .utc()
                 .startOf('hour')
                 .toDate();
+
+            if (time) {
+                endDate = moment.unix(parseInt(time)).toDate();
+                startDate = moment
+                    .unix(parseInt(time))
+                    .subtract(1, 'day')
+                    .utc()
+                    .startOf('hour')
+                    .toDate();
+            }
 
             const query = await this.closeHourly
                 .createQueryBuilder()

--- a/src/services/crons/aws.query.cache.warmer.service.ts
+++ b/src/services/crons/aws.query.cache.warmer.service.ts
@@ -16,6 +16,7 @@ import { constantsConfig } from 'src/config';
 import { HistoricDataModel } from 'src/modules/analytics/models/analytics.model';
 import BigNumber from 'bignumber.js';
 import { PairComputeService } from 'src/modules/pair/services/pair.compute.service';
+import moment from 'moment';
 
 @Injectable()
 export class AWSQueryCacheWarmerService {
@@ -135,6 +136,8 @@ export class AWSQueryCacheWarmerService {
         > = {};
         const timestampsSetCompleteValues = new Set<string>();
 
+        const startTime = moment().utc().unix();
+
         for (const pairAddress of pairsAddresses) {
             const currentLockedValueUSD = await this.pairCompute.lockedValueUSD(
                 pairAddress,
@@ -143,6 +146,7 @@ export class AWSQueryCacheWarmerService {
             const lockedValueUSD24h = await this.analyticsQuery.getValues24h({
                 series: pairAddress,
                 metric: 'lockedValueUSD',
+                time: startTime.toString(),
             });
 
             if (


### PR DESCRIPTION
## Reasoning
- the query `values24h(series: "factory", metric: "totalLockedValueUSD")` sporadically returns the wrong amount for the current hour. The bug occurs whenever the analytics cache warmer cron runs over an hour boundary (eg. starts at 08:50 and runs until 09:01). The Set with unique timestamps across all pairs will contain an extra value - for hour 09:00. Since not all pairs have values for this timestamp (the runs before 09:00), the last value in the array will be smaller.
  
## Proposed Changes
- add `time` parameter to 'getValues24h' method in `TimescaleDBQueryService`
- use same timestamp for all queries performed by the analytics cache warmer

## How to test
- The query should return the correct values even if the cron job runs past an hour boundary
```
query chartLatestCompleteValues {
  values24h(series: "factory", metric: "totalLockedValueUSD") {
    timestamp
    value
  }
}
```

