### PR TITLE
MEX-748 Deactivate Negative Energy Notifications

### DIFF
--- a/src/modules/push-notifications/crons/push.notifications.energy.ts
+++ b/src/modules/push-notifications/crons/push.notifications.energy.ts
@@ -85,7 +85,6 @@ export class PushNotificationsEnergyCron {
         );
     }
 
-    @Cron('0 12 */2 * *') // Every 2 days at noon
     @LockAndRetry({
         lockKey: 'pushNotifications',
         lockName: 'negativeEnergy',


### PR DESCRIPTION
## Reasoning
- This Cron is not tested properly, will be activated in the future
  
## Proposed Changes
- Deactivate temporarily the cron

## How to test
- N/A
