### PR TITLE
[MEX-793] xPortal Push Notification wrapper endpoint

### DIFF
--- a/src/modules/push-notifications/push.notifications.controller.ts
+++ b/src/modules/push-notifications/push.notifications.controller.ts
@@ -1,9 +1,13 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { JwtOrNativeAdminGuard } from '../auth/jwt.or.native.admin.guard';
-import {
-    NotificationPayload,
-    XPortalApiService,
-} from 'src/services/multiversx-communication/mx.xportal.api.service';
+import { XPortalApiService } from 'src/services/multiversx-communication/mx.xportal.api.service';
+import { pushNotificationsConfig } from 'src/config';
+import { NotificationType } from './models/push.notifications.types';
+
+interface PushNotificationPayload {
+    addresses: string[];
+    type: NotificationType;
+}
 
 @Controller()
 export class PushNotificationsController {
@@ -12,11 +16,13 @@ export class PushNotificationsController {
     @UseGuards(JwtOrNativeAdminGuard)
     @Post('/push-notifications/send')
     async sendPushNotifications(
-        @Body() notificationPayload: NotificationPayload,
+        @Body() payload: PushNotificationPayload,
     ): Promise<boolean> {
-        const result = await this.xPortalApiService.sendPushNotifications(
-            notificationPayload,
-        );
+        const result = await this.xPortalApiService.sendPushNotifications({
+            addresses: payload.addresses,
+            chainId: pushNotificationsConfig.options.chainId,
+            ...pushNotificationsConfig[payload.type],
+        });
         return result;
     }
 }

--- a/src/services/multiversx-communication/mx.xportal.api.service.ts
+++ b/src/services/multiversx-communication/mx.xportal.api.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ApiConfigService } from '../../helpers/api.config.service';
 import { ApiService } from '@multiversx/sdk-nestjs-http';
 
-export type NotificationPayload = {
+type NotificationPayload = {
     addresses: string[];
     chainId: number;
     title: string;


### PR DESCRIPTION
## Reasoning
- Need of a manual way to trigger the xPortal Push Notification
  
## Proposed Changes
- Create a private endpoint to access the xPortal Push Notification API

## How to test
```
curl --location 'http://localhost:4001/push-notifications/send' \
--header 'Accept: application/json, text/plain, */*' \
--header 'Content-Type: application/json' \
--data '{
    "addresses": [""],
    "type": "feesCollectorRewards"
}'
```
