### PR TITLE
[MEX-748] add fallback for ACCOUNTS_ELASTIC_SERVICE config

### DIFF
--- a/src/helpers/api.config.service.ts
+++ b/src/helpers/api.config.service.ts
@@ -387,10 +387,11 @@ export class ApiConfigService {
     }
 
     getAccountsElasticSearchUrl(): string {
-        const elasticSearchUrl =
-            this.configService.get<string>('ACCOUNTS_ELASTICSEARCH_URL');
+        const elasticSearchUrl = this.configService.get<string>(
+            'ACCOUNTS_ELASTICSEARCH_URL',
+        );
         if (!elasticSearchUrl) {
-            throw new Error('No Accounts Elastic Search url present');
+            return this.getElasticSearchUrl();
         }
 
         return elasticSearchUrl;


### PR DESCRIPTION
## Reasoning
- `ACCOUNTS_ELASTIC_SERVICE` can be undefined depending on the environment
  
## Proposed Changes
- added a fallback to default elastic search URL

## How to test
- API instances should not throw an error from ApiConfigService if env value is missing
