### PR TITLE
[MEX-748] Fix failed notifications handling

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -705,7 +705,8 @@
     "pushNotifications": {
         "options": {
             "batchSize": 100,
-            "chainId": 508
+            "chainId": 508,
+            "requestsDelayMs": 70
         },
         "feesCollectorRewards": {
             "title": "xExchange: Energy rewards",

--- a/src/modules/push-notifications/services/push.notifications.energy.service.ts
+++ b/src/modules/push-notifications/services/push.notifications.energy.service.ts
@@ -114,9 +114,17 @@ export class PushNotificationsEnergyService {
         const notificationTypes = Object.values(NotificationType);
 
         for (const notificationType of notificationTypes) {
-            await this.pushNotificationsService.retryFailedNotifications(
-                notificationType,
-            );
+            const { successful, failed } =
+                await this.pushNotificationsService.retryFailedNotifications(
+                    notificationType,
+                );
+
+            if (successful > 0 || failed > 0) {
+                this.logger.info(
+                    `Retry failed '${notificationType}' notifications completed. Successful: ${successful}, Failed: ${failed}`,
+                    { context: PushNotificationsEnergyService.name },
+                );
+            }
         }
     }
 }

--- a/src/modules/push-notifications/services/push.notifications.setter.service.ts
+++ b/src/modules/push-notifications/services/push.notifications.setter.service.ts
@@ -22,9 +22,15 @@ export class PushNotificationsSetterService {
         await this.redisCacheService.expire(redisKey, ttl);
     }
 
-    async getFailedNotifications(notificationKey: string): Promise<string[]> {
+    async getFailedNotifications(
+        notificationKey: string,
+        count = 1000,
+    ): Promise<string[]> {
         const redisKey = `${this.failedNotificationsPrefix}.${notificationKey}`;
-        return await this.redisCacheService.smembers(redisKey);
+        return await this.redisCacheService['redis'].srandmember(
+            redisKey,
+            count,
+        );
     }
 
     async removeFailedNotifications(


### PR DESCRIPTION
## Reasoning
- the cronjob for retrying failed notifications crashes if the redis set contains tens of thousands of members. This results in the same notification being sent multiple time to the same addresses 

  
## Proposed Changes
- attempt notification resending for a slice of the failed addresses redis Set
- add a delay between requests to xportal API


## How to test
- N/A

