### PR TITLE
[MEX-824] Trading Contest participant resolver cron

### DIFF
--- a/src/modules/trading-contest/services/trading.contest.cron.ts
+++ b/src/modules/trading-contest/services/trading.contest.cron.ts
@@ -1,0 +1,102 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { TradingContestService } from './trading.contest.service';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { LockAndRetry } from 'src/helpers/decorators/lock.retry.decorator';
+import { RedlockService } from '@multiversx/sdk-nestjs-cache';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { TradingContestSwapDocument } from '../schemas/trading.contest.swap.schema';
+import * as mongoose from 'mongoose';
+
+@Injectable()
+export class TradingContestCronService {
+    constructor(
+        private readonly tradingContestService: TradingContestService,
+        private readonly redLockService: RedlockService,
+        @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
+    ) {}
+
+    @Cron(CronExpression.EVERY_30_SECONDS)
+    @LockAndRetry({
+        lockKey: 'TradingContestCron',
+        lockName: 'updateContestParticipantForSwaps',
+    })
+    async updateContestParticipantForSwaps(): Promise<void> {
+        const swaps =
+            await this.tradingContestService.getSwapsWithoutParticipant();
+
+        if (!swaps || swaps.length === 0) {
+            return;
+        }
+
+        const swapsByHash: Record<string, TradingContestSwapDocument[]> = {};
+        swaps.forEach((swap) => {
+            if (swapsByHash[swap.txHash]) {
+                swapsByHash[swap.txHash].push(swap);
+            } else {
+                swapsByHash[swap.txHash] = [swap];
+            }
+        });
+
+        const deleteIds = [];
+        const bulkOps = [];
+        for (const hash of Object.keys(swapsByHash)) {
+            const sender =
+                await this.tradingContestService.getSenderFromElastic(hash);
+
+            if (sender === undefined) {
+                this.logger.warn(
+                    `Could not extract sender for hash ${hash}. Will delete all swaps`,
+                );
+                deleteIds.push(...swapsByHash[hash].map((s) => s._id));
+                continue;
+            }
+
+            for (const swap of swapsByHash[hash]) {
+                if (
+                    swap.contest === null ||
+                    swap.contest instanceof mongoose.Schema.Types.ObjectId
+                ) {
+                    this.logger.warn(
+                        `Contest for swap ${swap._id} is not populated. Will delete swap`,
+                    );
+                    deleteIds.push(swap._id);
+                    continue;
+                }
+
+                const participant =
+                    await this.tradingContestService.getOrCreateContestParticipant(
+                        swap.contest,
+                        sender,
+                    );
+
+                if (!participant) {
+                    this.logger.warn(
+                        `No participant for swap ${swap._id}. Will delete swap`,
+                    );
+                    deleteIds.push(swap._id);
+                    continue;
+                }
+
+                bulkOps.push({
+                    updateOne: {
+                        filter: { _id: swap._id },
+                        update: {
+                            $set: {
+                                participant: participant._id,
+                            },
+                        },
+                    },
+                });
+            }
+        }
+
+        if (deleteIds.length > 0) {
+            bulkOps.push({
+                deleteMany: { filter: { _id: deleteIds } },
+            });
+        }
+
+        await this.tradingContestService.bulkUpdateSwaps(bulkOps);
+    }
+}

--- a/src/modules/trading-contest/trading.contest.cron.module.ts
+++ b/src/modules/trading-contest/trading.contest.cron.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TradingContestCronService } from './services/trading.contest.cron';
+import { TradingContestModule } from './trading.contest.module';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+
+@Module({
+    imports: [TradingContestModule, DynamicModuleUtils.getRedlockModule()],
+    providers: [TradingContestCronService],
+})
+export class TradingContestCronModule {}

--- a/src/modules/trading-contest/trading.contest.module.ts
+++ b/src/modules/trading-contest/trading.contest.module.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/services/database/repositories/trading.contest.repository';
 import { TradingContestSwapHandlerService } from './services/trading.contest.swap.handler.service';
 import { TradingContestService } from './services/trading.contest.service';
+import { ElasticSearchModule } from 'src/services/elastic-search/elastic.search.module';
 
 @Module({
     imports: [
@@ -30,6 +31,7 @@ import { TradingContestService } from './services/trading.contest.service';
             },
             { name: TradingContestSwap.name, schema: TradingContestSwapSchema },
         ]),
+        ElasticSearchModule,
     ],
     providers: [
         TradingContestRepository,

--- a/src/services/cache.warmer.module.ts
+++ b/src/services/cache.warmer.module.ts
@@ -49,6 +49,7 @@ import { WeekTimekeepingCacheWarmerService } from './crons/week.timekeeping.cach
 import { WeeklyRewardsSplittingCacheWarmerService } from './crons/weekly.rewards.cache.warmer.service';
 import { RouterCacheWarmerService } from './crons/router.cache.warmer.service';
 import { SmartRouterEvaluationCronModule } from 'src/modules/smart-router-evaluation/smart.router.evaluation.cron.module';
+import { TradingContestCronModule } from 'src/modules/trading-contest/trading.contest.cron.module';
 
 @Module({
     imports: [
@@ -82,6 +83,7 @@ import { SmartRouterEvaluationCronModule } from 'src/modules/smart-router-evalua
         ElasticSearchModule,
         CurrencyConverterModule,
         SmartRouterEvaluationCronModule,
+        TradingContestCronModule,
     ],
     controllers: [],
     providers: [

--- a/src/services/elastic-search/services/es.operations.service.ts
+++ b/src/services/elastic-search/services/es.operations.service.ts
@@ -67,4 +67,31 @@ export class ESOperationsService {
 
         return operations;
     }
+
+    async getOperationsByHash(txHash: string): Promise<Operation[]> {
+        const pagination = new ElasticPagination();
+        pagination.size = 100;
+        const elasticQuery: ElasticQuery = new ElasticQuery().withPagination(
+            pagination,
+        );
+
+        elasticQuery.condition.must = [
+            QueryType.Should([
+                QueryType.Match('_id', txHash),
+                QueryType.Match('originalTxHash', txHash),
+            ]),
+        ];
+
+        elasticQuery.sort = [
+            { name: 'timestamp', order: ElasticSortOrder.descending },
+        ];
+
+        const operations: Operation[] = await this.elasticService.getList(
+            'operations',
+            '_search',
+            elasticQuery,
+        );
+
+        return operations;
+    }
 }


### PR DESCRIPTION
## Reasoning
- swap events (received through RabbitMQ) originating from transactions on the Composable Tasks or Router SCs don't expose the original sender. That information is found in Elastic Search operations index with a small delay

  
## Proposed Changes
- add cron for resolving contest participants (sender) from ES

## How to test
- N/A
