### PR TITLE
[MEX-825] Trading Contest REST API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2914,9 +2914,9 @@
             }
         },
         "node_modules/@multiversx/sdk-exchange": {
-            "version": "0.2.21",
-            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.21.tgz",
-            "integrity": "sha512-ZjaOrpgzF9v504awOC8T+b3lGp4FvHKcIxmA6yuugGcdr45f/hZXd8v6HlZhpR/mRp494zLaPyzgrzkWvJ41wQ==",
+            "version": "0.2.22",
+            "resolved": "https://registry.npmjs.org/@multiversx/sdk-exchange/-/sdk-exchange-0.2.22.tgz",
+            "integrity": "sha512-mRo1U9Fj9S+O4BNGR4Gs9g9+T7hUw/cGoGe2rzqUsGLimfudaGWtHLlkV20Wm3GITVMe2zcFbDFewxkprnSjhg==",
             "dependencies": {
                 "@multiversx/sdk-core": "^13.6.3",
                 "bignumber.js": "9.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@golevelup/nestjs-rabbitmq": "^4.0.0",
                 "@isaacs/ttlcache": "^1.4.1",
                 "@multiversx/sdk-core": "^13.6.3",
-                "@multiversx/sdk-exchange": "^0.2.21",
+                "@multiversx/sdk-exchange": "^0.2.22",
                 "@multiversx/sdk-native-auth-server": "1.0.19",
                 "@multiversx/sdk-nestjs-cache": "^4.2.0",
                 "@multiversx/sdk-nestjs-common": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@golevelup/nestjs-rabbitmq": "^4.0.0",
         "@isaacs/ttlcache": "^1.4.1",
         "@multiversx/sdk-core": "^13.6.3",
-        "@multiversx/sdk-exchange": "^0.2.21",
+        "@multiversx/sdk-exchange": "^0.2.22",
         "@multiversx/sdk-native-auth-server": "1.0.19",
         "@multiversx/sdk-nestjs-cache": "^4.2.0",
         "@multiversx/sdk-nestjs-common": "^4.2.0",

--- a/src/modules/trading-contest/controllers/trading.contest.admin.controller.ts
+++ b/src/modules/trading-contest/controllers/trading.contest.admin.controller.ts
@@ -1,0 +1,107 @@
+import {
+    Body,
+    Controller,
+    Get,
+    HttpException,
+    HttpStatus,
+    Param,
+    Post,
+    UseGuards,
+    UsePipes,
+    ValidationPipe,
+} from '@nestjs/common';
+import { TradingContestService } from '../services/trading.contest.service';
+import { TradingContest } from '../schemas/trading.contest.schema';
+import { CreateTradingContestDto } from '../dtos/create.contest.dto';
+import { ContestParticipantStats, LeaderBoardEntry } from '../types';
+import { TradingContestParticipant } from '../schemas/trading.contest.participant.schema';
+import { AuthUser } from 'src/modules/auth/auth.user';
+import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard';
+import { UserAuthResult } from 'src/modules/auth/user.auth.result';
+import { JwtOrNativeAdminGuard } from 'src/modules/auth/jwt.or.native.admin.guard';
+
+@Controller('trading-contests')
+export class TradingContestAdminController {
+    constructor(
+        private readonly tradingContestService: TradingContestService,
+    ) {}
+
+    @UseGuards(JwtOrNativeAdminGuard)
+    @Post('/')
+    @UsePipes(
+        new ValidationPipe({
+            transform: true,
+            transformOptions: { enableImplicitConversion: true },
+        }),
+    )
+    async createContest(
+        @Body() createContestDto: CreateTradingContestDto,
+    ): Promise<TradingContest> {
+        return this.tradingContestService.createContest(createContestDto);
+    }
+
+    @UseGuards(JwtOrNativeAdminGuard)
+    @Get('/')
+    async getAllContests(): Promise<TradingContest[]> {
+        return this.tradingContestService.getContests();
+    }
+
+    @UseGuards(JwtOrNativeAdminGuard)
+    @Get('/:uuid')
+    async getContest(@Param('uuid') uuid: string): Promise<TradingContest> {
+        const contest = await this.tradingContestService.getContestByUuid(uuid);
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return contest;
+    }
+
+    @UseGuards(JwtOrNativeAdminGuard)
+    @Get('/:uuid/leaderboard')
+    async getContestLeaderboard(
+        @Param('uuid') uuid: string,
+    ): Promise<LeaderBoardEntry[]> {
+        const contest = await this.tradingContestService.getContestByUuid(uuid);
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.getLeaderboard(contest);
+    }
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Post('/:uuid/participants')
+    async joinContest(
+        @Param('uuid') uuid: string,
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TradingContestParticipant> {
+        const contest = await this.tradingContestService.getContestByUuid(uuid);
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.createContestParticipant(
+            contest,
+            user.address,
+        );
+    }
+
+    @UseGuards(JwtOrNativeAdminGuard)
+    @Get('/:uuid/participants/:address')
+    async getContestParticipant(
+        @Param('uuid') uuid: string,
+        @Param('address') address: string,
+    ): Promise<ContestParticipantStats> {
+        const contest = await this.tradingContestService.getContestByUuid(uuid);
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.getParticipantStats(contest, address);
+    }
+}

--- a/src/modules/trading-contest/controllers/trading.contest.admin.controller.ts
+++ b/src/modules/trading-contest/controllers/trading.contest.admin.controller.ts
@@ -2,9 +2,6 @@ import {
     Body,
     Controller,
     Get,
-    HttpException,
-    HttpStatus,
-    Param,
     Post,
     UseGuards,
     UsePipes,
@@ -13,11 +10,6 @@ import {
 import { TradingContestService } from '../services/trading.contest.service';
 import { TradingContest } from '../schemas/trading.contest.schema';
 import { CreateTradingContestDto } from '../dtos/create.contest.dto';
-import { ContestParticipantStats, LeaderBoardEntry } from '../types';
-import { TradingContestParticipant } from '../schemas/trading.contest.participant.schema';
-import { AuthUser } from 'src/modules/auth/auth.user';
-import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard';
-import { UserAuthResult } from 'src/modules/auth/user.auth.result';
 import { JwtOrNativeAdminGuard } from 'src/modules/auth/jwt.or.native.admin.guard';
 
 @Controller('trading-contests')
@@ -44,64 +36,5 @@ export class TradingContestAdminController {
     @Get('/')
     async getAllContests(): Promise<TradingContest[]> {
         return this.tradingContestService.getContests();
-    }
-
-    @UseGuards(JwtOrNativeAdminGuard)
-    @Get('/:uuid')
-    async getContest(@Param('uuid') uuid: string): Promise<TradingContest> {
-        const contest = await this.tradingContestService.getContestByUuid(uuid);
-
-        if (!contest) {
-            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
-        }
-
-        return contest;
-    }
-
-    @UseGuards(JwtOrNativeAdminGuard)
-    @Get('/:uuid/leaderboard')
-    async getContestLeaderboard(
-        @Param('uuid') uuid: string,
-    ): Promise<LeaderBoardEntry[]> {
-        const contest = await this.tradingContestService.getContestByUuid(uuid);
-
-        if (!contest) {
-            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
-        }
-
-        return this.tradingContestService.getLeaderboard(contest);
-    }
-
-    @UseGuards(JwtOrNativeAuthGuard)
-    @Post('/:uuid/participants')
-    async joinContest(
-        @Param('uuid') uuid: string,
-        @AuthUser() user: UserAuthResult,
-    ): Promise<TradingContestParticipant> {
-        const contest = await this.tradingContestService.getContestByUuid(uuid);
-
-        if (!contest) {
-            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
-        }
-
-        return this.tradingContestService.createContestParticipant(
-            contest,
-            user.address,
-        );
-    }
-
-    @UseGuards(JwtOrNativeAdminGuard)
-    @Get('/:uuid/participants/:address')
-    async getContestParticipant(
-        @Param('uuid') uuid: string,
-        @Param('address') address: string,
-    ): Promise<ContestParticipantStats> {
-        const contest = await this.tradingContestService.getContestByUuid(uuid);
-
-        if (!contest) {
-            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
-        }
-
-        return this.tradingContestService.getParticipantStats(contest, address);
     }
 }

--- a/src/modules/trading-contest/controllers/trading.contest.controller.ts
+++ b/src/modules/trading-contest/controllers/trading.contest.controller.ts
@@ -1,0 +1,145 @@
+import {
+    Body,
+    Controller,
+    Get,
+    HttpException,
+    HttpStatus,
+    Param,
+    Post,
+    UseGuards,
+    UsePipes,
+    ValidationPipe,
+} from '@nestjs/common';
+import { TradingContestService } from '../services/trading.contest.service';
+import { TradingContest } from '../schemas/trading.contest.schema';
+import {
+    TradingContestLeaderboardDto,
+    TradingContestParticipantDto,
+} from '../dtos/contest.leaderboard.dto';
+import {
+    ContestParticipantStats,
+    LeaderBoardEntry,
+    ContestParticipantTokenStats,
+} from '../types';
+import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard';
+import { AuthUser } from 'src/modules/auth/auth.user';
+import { UserAuthResult } from 'src/modules/auth/user.auth.result';
+import { TradingContestParticipant } from '../schemas/trading.contest.participant.schema';
+
+@Controller('trading-contests')
+export class TradingContestController {
+    constructor(
+        private readonly tradingContestService: TradingContestService,
+    ) {}
+
+    @Get('/:uuid')
+    async getContest(@Param('uuid') uuid: string): Promise<TradingContest> {
+        const contest = await this.tradingContestService.getContestByUuid(uuid);
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return contest;
+    }
+
+    @UseGuards(JwtOrNativeAuthGuard)
+    @Post('/:uuid/participants')
+    async joinContest(
+        @Param('uuid') uuid: string,
+        @AuthUser() user: UserAuthResult,
+    ): Promise<TradingContestParticipant> {
+        const contest = await this.tradingContestService.getContestByUuid(uuid);
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.createContestParticipant(
+            contest,
+            user.address,
+        );
+    }
+
+    @UsePipes(
+        new ValidationPipe({
+            transform: true,
+            transformOptions: { enableImplicitConversion: true },
+        }),
+    )
+    @Post('/:uuid/leaderboard')
+    async contestLeaderboard(
+        @Param('uuid') uuid: string,
+        @Body() contestLeaderboardDto: TradingContestLeaderboardDto,
+    ): Promise<LeaderBoardEntry[]> {
+        const contest = await this.tradingContestService.getContestByUuid(
+            uuid,
+            { _id: 1 },
+        );
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.getLeaderboard(
+            contest,
+            contestLeaderboardDto,
+        );
+    }
+
+    @UsePipes(
+        new ValidationPipe({
+            transform: true,
+            transformOptions: { enableImplicitConversion: true },
+        }),
+    )
+    @Post('/:uuid/participants/:address')
+    async getContestParticipantStats(
+        @Param('uuid') uuid: string,
+        @Param('address') address: string,
+        @Body() parameters: TradingContestParticipantDto,
+    ): Promise<ContestParticipantStats> {
+        const contest = await this.tradingContestService.getContestByUuid(
+            uuid,
+            { _id: 1 },
+        );
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.getParticipantStats(
+            contest,
+            address,
+            parameters,
+        );
+    }
+
+    @UsePipes(
+        new ValidationPipe({
+            transform: true,
+            transformOptions: { enableImplicitConversion: true },
+        }),
+    )
+    @Post('/:uuid/participants/:address/token-stats')
+    async getContestParticipantTokenStats(
+        @Param('uuid') uuid: string,
+        @Param('address') address: string,
+        @Body() parameters: TradingContestParticipantDto,
+    ): Promise<ContestParticipantTokenStats[]> {
+        const contest = await this.tradingContestService.getContestByUuid(
+            uuid,
+            { _id: 1 },
+        );
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.getParticipantTokenStats(
+            contest,
+            address,
+            parameters,
+        );
+    }
+}

--- a/src/modules/trading-contest/dtos/contest.leaderboard.dto.ts
+++ b/src/modules/trading-contest/dtos/contest.leaderboard.dto.ts
@@ -1,0 +1,55 @@
+import {
+    IsBoolean,
+    IsInt,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    Max,
+    Min,
+    ValidateIf,
+} from 'class-validator';
+import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
+
+class AggregationParamsDto {
+    @IsOptional()
+    @IsInt()
+    @IsValidUnixTime()
+    startTimestamp?: number;
+
+    @IsOptional()
+    @IsInt()
+    @IsValidUnixTime()
+    endTimestamp?: number;
+
+    @IsBoolean()
+    includeTradeCount = false;
+
+    @IsBoolean()
+    includeFees = false;
+
+    @IsBoolean()
+    includeRank = false;
+}
+
+export class TradingContestLeaderboardDto extends AggregationParamsDto {
+    @IsInt()
+    @Min(0)
+    offset? = 0;
+
+    @IsInt()
+    @Min(1)
+    @Max(25)
+    limit? = 25;
+}
+
+export class TradingContestParticipantDto extends AggregationParamsDto {
+    @ValidateIf((o) => o.secondToken)
+    @IsNotEmpty()
+    @IsString()
+    firstToken?: string;
+
+    @ValidateIf((o) => o.firstToken)
+    @IsNotEmpty()
+    @IsString()
+    secondToken?: string;
+}

--- a/src/modules/trading-contest/dtos/create.contest.dto.ts
+++ b/src/modules/trading-contest/dtos/create.contest.dto.ts
@@ -1,0 +1,36 @@
+import {
+    ArrayMinSize,
+    IsArray,
+    IsBoolean,
+    IsInt,
+    IsNotEmpty,
+    Min,
+    ValidateIf,
+} from 'class-validator';
+import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
+
+export class CreateTradingContestDto {
+    @IsNotEmpty()
+    name: string;
+    @ValidateIf((o) => !o.pairAddresses || o.pairAddresses === 0)
+    @IsArray()
+    @ArrayMinSize(1)
+    tokens?: string[];
+    @ValidateIf((o) => !o.tokens || o.tokens.length === 0)
+    @IsArray()
+    pairAddresses?: string[];
+    @IsNotEmpty()
+    @IsBoolean()
+    requiresRegistration: boolean;
+    @IsNotEmpty()
+    @IsInt()
+    @IsValidUnixTime()
+    start: number;
+    @IsNotEmpty()
+    @IsInt()
+    @IsValidUnixTime()
+    end: number;
+    @IsInt()
+    @Min(1)
+    minSwapAmountUSD: number;
+}

--- a/src/modules/trading-contest/dtos/create.contest.dto.ts
+++ b/src/modules/trading-contest/dtos/create.contest.dto.ts
@@ -1,24 +1,34 @@
 import {
+    ArrayMaxSize,
     ArrayMinSize,
     IsArray,
     IsBoolean,
     IsInt,
     IsNotEmpty,
+    IsOptional,
+    IsString,
     Min,
-    ValidateIf,
 } from 'class-validator';
 import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
 
 export class CreateTradingContestDto {
     @IsNotEmpty()
     name: string;
-    @ValidateIf((o) => !o.pairAddresses || o.pairAddresses === 0)
+    @IsOptional()
     @IsArray()
     @ArrayMinSize(1)
+    @IsString({ each: true })
     tokens?: string[];
-    @ValidateIf((o) => !o.tokens || o.tokens.length === 0)
+    @IsOptional()
     @IsArray()
+    @IsString({ each: true })
     pairAddresses?: string[];
+    @IsOptional()
+    @IsArray()
+    @ArrayMinSize(2)
+    @ArrayMaxSize(2)
+    @IsString({ each: true })
+    tokensPair?: [string, string];
     @IsNotEmpty()
     @IsBoolean()
     requiresRegistration: boolean;

--- a/src/modules/trading-contest/pipelines/global.leaderboard.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/global.leaderboard.pipeline.ts
@@ -1,0 +1,45 @@
+import mongoose, { PipelineStage } from 'mongoose';
+
+export const globalLeaderboardPipeline = (
+    limit = 100,
+    contest: string,
+): PipelineStage[] => [
+    /* 1. filter by contest */
+    { $match: { contest: new mongoose.Types.ObjectId(contest) } },
+
+    /* 2. crunch the numbers for each wallet */
+    {
+        $group: {
+            _id: '$participant',
+            totalVolumeUSD: { $sum: '$volumeUSD' },
+            tradeCount: { $sum: 1 },
+            totalFeesUSD: { $sum: '$feesUSD' },
+        },
+    },
+
+    /* 3. order by biggest volume */
+    { $sort: { totalVolumeUSD: -1 as -1 } },
+
+    /* 4. apply a window-function rank */
+    {
+        $setWindowFields: {
+            sortBy: { totalVolumeUSD: -1 as -1 },
+            output: { rank: { $rank: {} } },
+        },
+    },
+
+    /* 5. reshape the document */
+    {
+        $project: {
+            _id: 0,
+            sender: '$_id',
+            totalVolumeUSD: 1,
+            tradeCount: 1,
+            totalFeesUSD: 1,
+            rank: 1,
+        },
+    },
+
+    /* 6. cut the response down to size */
+    { $limit: limit },
+];

--- a/src/modules/trading-contest/pipelines/participant.stats.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/participant.stats.pipeline.ts
@@ -1,0 +1,32 @@
+import mongoose, { PipelineStage } from 'mongoose';
+
+export const participantStatsPipeline = (
+    contestId: string,
+    participantId: string,
+): PipelineStage[] => [
+    { $match: { contest: new mongoose.Types.ObjectId(contestId) } },
+    {
+        $group: {
+            _id: '$participant',
+            totalVolumeUSD: { $sum: '$volumeUSD' },
+            tradeCount: { $sum: 1 },
+            totalFeesUSD: { $sum: '$feesUSD' },
+        },
+    },
+    {
+        $setWindowFields: {
+            sortBy: { totalVolumeUSD: -1 },
+            output: { rank: { $rank: {} } },
+        },
+    },
+    { $match: { _id: new mongoose.Types.ObjectId(participantId) } },
+    {
+        $project: {
+            _id: 0,
+            totalVolumeUSD: { $ifNull: ['$totalVolumeUSD', 0] },
+            tradeCount: { $ifNull: ['$tradeCount', 0] },
+            totalFeesUSD: { $ifNull: ['$totalFeesUSD', 0] },
+            rank: 1,
+        },
+    },
+];

--- a/src/modules/trading-contest/pipelines/participant.stats.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/participant.stats.pipeline.ts
@@ -1,32 +1,73 @@
 import mongoose, { PipelineStage } from 'mongoose';
+import { TradingContestParticipantDto } from '../dtos/contest.leaderboard.dto';
 
 export const participantStatsPipeline = (
     contestId: string,
     participantId: string,
-): PipelineStage[] => [
-    { $match: { contest: new mongoose.Types.ObjectId(contestId) } },
-    {
+    parameters: TradingContestParticipantDto,
+): PipelineStage[] => {
+    const {
+        startTimestamp,
+        endTimestamp,
+        includeTradeCount,
+        includeFees,
+        includeRank,
+    } = parameters;
+
+    const matchStage: PipelineStage.Match = {
+        $match: {
+            contest: new mongoose.Types.ObjectId(contestId),
+        },
+    };
+
+    if (startTimestamp !== undefined || endTimestamp !== undefined) {
+        matchStage.$match.timestamp = {};
+        if (startTimestamp !== undefined) {
+            matchStage.$match.timestamp.$gte = startTimestamp;
+        }
+        if (endTimestamp !== undefined) {
+            matchStage.$match.timestamp.$lte = endTimestamp;
+        }
+    }
+
+    const groupStage: PipelineStage.Group = {
         $group: {
             _id: '$participant',
             totalVolumeUSD: { $sum: '$volumeUSD' },
-            tradeCount: { $sum: 1 },
-            totalFeesUSD: { $sum: '$feesUSD' },
+            ...(includeTradeCount && { tradeCount: { $sum: 1 } }),
+            ...(includeFees && { totalFeesUSD: { $sum: '$feesUSD' } }),
         },
-    },
-    {
-        $setWindowFields: {
-            sortBy: { totalVolumeUSD: -1 },
-            output: { rank: { $rank: {} } },
-        },
-    },
-    { $match: { _id: new mongoose.Types.ObjectId(participantId) } },
-    {
+    };
+
+    const projectStage: PipelineStage.Project = {
         $project: {
             _id: 0,
             totalVolumeUSD: { $ifNull: ['$totalVolumeUSD', 0] },
-            tradeCount: { $ifNull: ['$tradeCount', 0] },
-            totalFeesUSD: { $ifNull: ['$totalFeesUSD', 0] },
-            rank: 1,
         },
-    },
-];
+    };
+
+    if (includeFees) {
+        projectStage.$project.totalFeesUSD = { $ifNull: ['$totalFeesUSD', 0] };
+    }
+
+    if (includeTradeCount) {
+        projectStage.$project.tradeCount = { $ifNull: ['$tradeCount', 0] };
+    }
+
+    if (includeRank) {
+        projectStage.$project.rank = 1;
+    }
+
+    return [
+        matchStage,
+        groupStage,
+        {
+            $setWindowFields: {
+                sortBy: { totalVolumeUSD: -1 },
+                output: { rank: { $rank: {} } },
+            },
+        },
+        { $match: { _id: new mongoose.Types.ObjectId(participantId) } },
+        projectStage,
+    ];
+};

--- a/src/modules/trading-contest/pipelines/participant.token.stats.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/participant.token.stats.pipeline.ts
@@ -1,25 +1,32 @@
 import mongoose, { PipelineStage } from 'mongoose';
-import { TradingContestLeaderboardDto } from '../dtos/contest.leaderboard.dto';
+import { TradingContestParticipantDto } from '../dtos/contest.leaderboard.dto';
 
-export const globalLeaderboardPipeline = (
+export const participantTokenStatsPipeline = (
     contestId: string,
-    parameters: TradingContestLeaderboardDto,
+    participantId: string,
+    parameters: TradingContestParticipantDto,
 ): PipelineStage[] => {
     const {
         startTimestamp,
         endTimestamp,
+        firstToken,
+        secondToken,
         includeTradeCount,
-        includeFees,
-        includeRank,
-        limit,
-        offset,
     } = parameters;
 
     const matchStage: PipelineStage.Match = {
         $match: {
             contest: new mongoose.Types.ObjectId(contestId),
+            participant: new mongoose.Types.ObjectId(participantId),
         },
     };
+
+    if (firstToken && secondToken) {
+        matchStage.$match.$or = [
+            { tokenIn: firstToken, tokenOut: secondToken },
+            { tokenIn: secondToken, tokenOut: firstToken },
+        ];
+    }
 
     if (startTimestamp !== undefined || endTimestamp !== undefined) {
         matchStage.$match.timestamp = {};
@@ -33,45 +40,34 @@ export const globalLeaderboardPipeline = (
 
     const groupStage: PipelineStage.Group = {
         $group: {
-            _id: '$participant',
+            _id: {
+                tokenIn: '$tokenIn',
+                tokenOut: '$tokenOut',
+            },
             totalVolumeUSD: { $sum: '$volumeUSD' },
             ...(includeTradeCount && { tradeCount: { $sum: 1 } }),
-            ...(includeFees && { totalFeesUSD: { $sum: '$feesUSD' } }),
         },
     };
 
     const projectStage: PipelineStage.Project = {
         $project: {
             _id: 0,
-            sender: '$_id',
+            tokenIn: '$_id.tokenIn',
+            tokenOut: '$_id.tokenOut',
             totalVolumeUSD: 1,
         },
     };
-
-    if (includeFees) {
-        projectStage.$project.totalFeesUSD = 1;
-    }
 
     if (includeTradeCount) {
         projectStage.$project.tradeCount = 1;
     }
 
-    if (includeRank) {
-        projectStage.$project.rank = 1;
-    }
-
     return [
         matchStage,
         groupStage,
-        { $sort: { totalVolumeUSD: -1 as const } },
-        {
-            $setWindowFields: {
-                sortBy: { totalVolumeUSD: -1 as const },
-                output: { rank: { $rank: {} } },
-            },
-        },
         projectStage,
-        { $skip: offset },
-        { $limit: limit },
+        {
+            $sort: { totalVolumeUSD: -1 },
+        },
     ];
 };

--- a/src/modules/trading-contest/schemas/trading.contest.schema.ts
+++ b/src/modules/trading-contest/schemas/trading.contest.schema.ts
@@ -23,6 +23,16 @@ export class TradingContest {
     pairAddresses: string[];
     @Prop()
     requiresRegistration: boolean;
+    @Prop({
+        type: [String],
+        validate: [
+            (val: string[]) => val.length === 2,
+            'Must be exactly two strings',
+        ],
+        required: false,
+        default: [],
+    })
+    tokensPair: string[];
     @Prop()
     start: number;
     @Prop()

--- a/src/modules/trading-contest/schemas/trading.contest.schema.ts
+++ b/src/modules/trading-contest/schemas/trading.contest.schema.ts
@@ -25,10 +25,6 @@ export class TradingContest {
     requiresRegistration: boolean;
     @Prop({
         type: [String],
-        validate: [
-            (val: string[]) => val.length === 2,
-            'Must be exactly two strings',
-        ],
         required: false,
         default: [],
     })

--- a/src/modules/trading-contest/services/trading.contest.service.ts
+++ b/src/modules/trading-contest/services/trading.contest.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import moment from 'moment';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import {
@@ -11,8 +11,17 @@ import {
     TradingContestSwap,
     TradingContestSwapDocument,
 } from '../schemas/trading.contest.swap.schema';
-import { TradingContestDocument } from '../schemas/trading.contest.schema';
+import {
+    TradingContest,
+    TradingContestDocument,
+} from '../schemas/trading.contest.schema';
 import { TradingContestParticipantDocument } from '../schemas/trading.contest.participant.schema';
+import { CreateTradingContestDto } from '../dtos/create.contest.dto';
+import { randomUUID } from 'node:crypto';
+import { ContestParticipantStats, LeaderBoardEntry } from '../types';
+import { globalLeaderboardPipeline } from '../pipelines/global.leaderboard.pipeline';
+import { participantStatsPipeline } from '../pipelines/participant.stats.pipeline';
+import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 
 @Injectable()
 export class TradingContestService {
@@ -20,6 +29,7 @@ export class TradingContestService {
         private readonly swapRepository: TradingContestSwapRepository,
         private readonly contestRepository: TradingContestRepository,
         private readonly participantRepository: TradingContestParticipantRepository,
+        private readonly routerAbi: RouterAbiService,
         @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
     ) {}
 
@@ -117,5 +127,182 @@ export class TradingContestService {
             this.logger.error(error);
             throw error;
         }
+    }
+
+    async getParticipantStats(
+        contest: TradingContestDocument,
+        address: string,
+    ): Promise<ContestParticipantStats> {
+        const participant = await this.getContestParticipant(contest, address);
+
+        if (!participant) {
+            throw new HttpException(
+                `Address is not a valid participant for contest ${contest.uuid}`,
+                HttpStatus.BAD_REQUEST,
+            );
+        }
+
+        const [stats] = await this.swapRepository
+            .getModel()
+            .aggregate<ContestParticipantStats>(
+                participantStatsPipeline(contest._id, participant._id),
+            )
+            .exec();
+
+        return (
+            stats ?? {
+                totalVolumeUSD: 0,
+                tradeCount: 0,
+                totalFeesUSD: 0,
+                rank: 0,
+            }
+        );
+    }
+
+    async getContestByUuid(uuid: string): Promise<TradingContestDocument> {
+        return this.contestRepository.findOne(
+            {
+                uuid: uuid,
+            },
+            { _id: 1 },
+        );
+    }
+
+    async getContests(): Promise<TradingContestDocument[]> {
+        return this.contestRepository.find({});
+    }
+
+    async getLeaderboard(
+        contest: TradingContestDocument,
+    ): Promise<LeaderBoardEntry[]> {
+        const result = await this.swapRepository
+            .getModel()
+            .aggregate<LeaderBoardEntry>(
+                globalLeaderboardPipeline(100, contest._id),
+            )
+            .allowDiskUse(true) // safety net for very large datasets
+            .exec();
+
+        await this.participantRepository.getModel().populate(result, {
+            path: 'sender',
+            select: { address: 1, _id: 0 },
+        });
+
+        return result;
+    }
+
+    async createContest(
+        createContestDto: CreateTradingContestDto,
+    ): Promise<TradingContestDocument> {
+        try {
+            await this.validateContestDto(createContestDto);
+
+            const contest: TradingContest = {
+                name: createContestDto.name,
+                uuid: randomUUID(),
+                start: createContestDto.start,
+                end: createContestDto.end,
+                minSwapAmountUSD: createContestDto.minSwapAmountUSD,
+                tokens: createContestDto.tokens,
+                pairAddresses: createContestDto.pairAddresses,
+                requiresRegistration: createContestDto.requiresRegistration,
+            };
+
+            const result = await this.contestRepository.create(contest);
+            return result;
+        } catch (error) {
+            this.logger.error(error, { context: TradingContestService.name });
+
+            if (error.name === 'MongoServerError' && error.code === 11000) {
+                throw new HttpException(
+                    'Duplicate key error. A contest with the same name already exists',
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private async validateContestDto(
+        contestDto: CreateTradingContestDto,
+    ): Promise<void> {
+        if (contestDto.pairAddresses?.length && contestDto.tokens?.length) {
+            throw new Error(
+                'You can supply either tokens OR pairs, not both at the same time',
+            );
+        }
+
+        const start = moment.unix(contestDto.start);
+        const end = moment.unix(contestDto.end);
+        const now = moment();
+
+        if (
+            !start.isValid() ||
+            !end.isValid() ||
+            start.isAfter(end) ||
+            end.isBefore(now)
+        ) {
+            throw new Error('Invalid start or end date');
+        }
+
+        const tokenIDs: Set<string> = new Set();
+        const pairAddresses: string[] = [];
+
+        const [activeContests, pairsMetadata] = await Promise.all([
+            this.getActiveContests(),
+            this.routerAbi.pairsMetadata(),
+        ]);
+
+        pairsMetadata.forEach((pair) => {
+            tokenIDs.add(pair.firstTokenID);
+            tokenIDs.add(pair.secondTokenID);
+            pairAddresses.push(pair.address);
+        });
+
+        if (contestDto.pairAddresses?.length) {
+            contestDto.pairAddresses.forEach((address) => {
+                if (!pairAddresses.includes(address)) {
+                    throw new Error(`Invalid pair address ${address}`);
+                }
+            });
+
+            activeContests
+                .filter(
+                    (contest) =>
+                        contest.pairAddresses &&
+                        contest.pairAddresses.length > 0,
+                )
+                .forEach((contest) => {
+                    if (
+                        JSON.stringify(contest.pairAddresses.sort()) ==
+                        JSON.stringify(contestDto.pairAddresses.sort())
+                    ) {
+                        throw new Error(
+                            `A contest with the same pairs is already active`,
+                        );
+                    }
+                });
+            return;
+        }
+
+        contestDto.tokens.forEach((token) => {
+            if (!tokenIDs.has(token)) {
+                throw new Error(`Invalid token identifier ${token}`);
+            }
+        });
+
+        activeContests
+            .filter((contest) => contest.tokens && contest.tokens.length > 0)
+            .forEach((contest) => {
+                if (
+                    JSON.stringify(contest.tokens.sort()) ==
+                    JSON.stringify(contestDto.tokens.sort())
+                ) {
+                    throw new Error(
+                        `A contest with the same tokens is already active`,
+                    );
+                }
+            });
     }
 }

--- a/src/modules/trading-contest/trading.contest.module.ts
+++ b/src/modules/trading-contest/trading.contest.module.ts
@@ -20,6 +20,8 @@ import {
 import { TradingContestSwapHandlerService } from './services/trading.contest.swap.handler.service';
 import { TradingContestService } from './services/trading.contest.service';
 import { RouterModule } from '../router/router.module';
+import { TradingContestController } from './controllers/trading.contest.controller';
+import { ApiConfigService } from 'src/helpers/api.config.service';
 
 @Module({
     imports: [
@@ -39,7 +41,9 @@ import { RouterModule } from '../router/router.module';
         TradingContestParticipantRepository,
         TradingContestService,
         TradingContestSwapHandlerService,
+        ApiConfigService,
     ],
     exports: [TradingContestService, TradingContestSwapHandlerService],
+    controllers: [TradingContestController],
 })
 export class TradingContestModule {}

--- a/src/modules/trading-contest/trading.contest.module.ts
+++ b/src/modules/trading-contest/trading.contest.module.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/services/database/repositories/trading.contest.repository';
 import { TradingContestSwapHandlerService } from './services/trading.contest.swap.handler.service';
 import { TradingContestService } from './services/trading.contest.service';
+import { RouterModule } from '../router/router.module';
 
 @Module({
     imports: [
@@ -30,6 +31,7 @@ import { TradingContestService } from './services/trading.contest.service';
             },
             { name: TradingContestSwap.name, schema: TradingContestSwapSchema },
         ]),
+        RouterModule,
     ],
     providers: [
         TradingContestRepository,
@@ -39,6 +41,5 @@ import { TradingContestService } from './services/trading.contest.service';
         TradingContestSwapHandlerService,
     ],
     exports: [TradingContestService, TradingContestSwapHandlerService],
-    controllers: [],
 })
 export class TradingContestModule {}

--- a/src/modules/trading-contest/types.ts
+++ b/src/modules/trading-contest/types.ts
@@ -9,3 +9,18 @@ export type SwapEventPairData = {
     volumeUSD: string;
     feesUSD: string;
 };
+
+export type LeaderBoardEntry = {
+    sender: { address: string };
+    totalVolumeUSD: number;
+    tradeCount: number;
+    totalFeesUSD: number;
+    rank: number;
+};
+
+export type ContestParticipantStats = {
+    totalVolumeUSD: number;
+    tradeCount: number;
+    totalFeesUSD: number;
+    rank: number;
+};

--- a/src/modules/trading-contest/types.ts
+++ b/src/modules/trading-contest/types.ts
@@ -24,3 +24,18 @@ export type ContestParticipantStats = {
     totalFeesUSD: number;
     rank: number;
 };
+
+export type ContestParticipantTokenStats = {
+    tokenID: string;
+    buyVolumeUSD: number;
+    sellVolumeUSD: number;
+    buyCount?: number;
+    sellCount?: number;
+};
+
+export type RawSwapStat = {
+    tokenIn: string;
+    tokenOut: string;
+    totalVolumeUSD: number;
+    tradeCount?: number;
+};

--- a/src/private.app.module.ts
+++ b/src/private.app.module.ts
@@ -13,6 +13,8 @@ import { SmartRouterEvaluationController } from './modules/smart-router-evaluati
 import { PushNotificationsController } from './modules/push-notifications/push.notifications.controller';
 import { XPortalApiService } from './services/multiversx-communication/mx.xportal.api.service';
 import { PushNotificationsModule } from './modules/push-notifications/push.notifications.module';
+import { TradingContestAdminController } from './modules/trading-contest/controllers/trading.contest.admin.controller';
+import { TradingContestModule } from './modules/trading-contest/trading.contest.module';
 
 @Module({
     imports: [
@@ -23,13 +25,15 @@ import { PushNotificationsModule } from './modules/push-notifications/push.notif
         DynamicModuleUtils.getCacheModule(),
         SmartRouterEvaluationModule,
         PushNotificationsModule,
+        TradingContestModule,
     ],
     controllers: [
         MetricsController,
         TokenController,
         RemoteConfigController,
         SmartRouterEvaluationController,
-        PushNotificationsController
+        PushNotificationsController,
+        TradingContestAdminController,
     ],
     providers: [ESTransactionsService, XPortalApiService],
 })

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -42,6 +42,7 @@ import { QueryMetricsPlugin } from './utils/query.metrics.plugin';
 import { CurrencyConverterModule } from './modules/currency-converter/currency.converter.module';
 import { ConditionalModule } from '@nestjs/config';
 import { ComplexityModule } from './complexity.module';
+import { TradingContestModule } from './modules/trading-contest/trading.contest.module';
 
 @Module({
     imports: [
@@ -110,6 +111,7 @@ import { ComplexityModule } from './complexity.module';
             ComplexityModule,
             (env: NodeJS.ProcessEnv) => env['ENABLE_COMPLEXITY'] === 'true',
         ),
+        TradingContestModule,
     ],
     providers: [QueryMetricsPlugin],
 })


### PR DESCRIPTION
## Reasoning
- expose endpoints for creating contests, viewing contest leaderboards, and specific address ranking
  
## Proposed Changes
- add admin controller and expose `/trading-contests` route in private app
- add aggregation pipelines for leader board and specific address rank

## How to test
Exposed in private API : 
- `GET /trading-contests` - returns all trading contests
- `POST /trading-contests` - with the following body to create a new contest : 
```
{
    "name": "Stable Competition",
    "minSwapAmountUSD": 5,
    "start": 1750076131,
    "end": 1751276548,
    "tokensPair": ["USDC-350c4e", "MEX-a659d0"],
    "tokens": [],
    "pairAddresses": []
    "requiresRegistration": false,
}
```
 The endpoint accepts a `tokens` array, a `pairAddresses` array (to create contests focused on specific pairs), and a `tokensPair` array of exactly 2 items (to create constests that track indirect swaps between 2 tokens via `multiPairSwap`)  
 
 Exposed in public API : 
- `GET /trading-contests/<CONTEST_UUID>` - returns a specific contest
- `POST /trading-contests/<CONTEST_UUID>/leaderboard` - returns the top traders (by volume USD) in a specific contest
Request body (all parameters are optional) : 
```
{
    "offset": 0,
    "limit": 25,
    "startTimestamp": 1748754055,
    "endTimestamp": 1751300503,
    "includeTradeCount": true,
    "includeRank": true
}
```
Response : 
```
[
    {
        "totalVolumeUSD": 10949.686866965156,
        "tradeCount": 4,
        "rank": 1,
        "sender": {
            "address": "erd1cevsw7mq5uvqymjqzwqvpqtdrhckehwfz99n7praty3y7q2j7yps842mqh"
        }
    },
    {
        "totalVolumeUSD": 1511.3300829038183,
        "tradeCount": 2,
        "rank": 2,
        "sender": {
            "address": "erd1eyuqj52kz2umjphlhl3503x94zcdr5c04fqkefrw3qfrjpk3uzxqm5039w"
        }
    },
    ...
]
```

- `POST /trading-contests/<CONTEST_UUID>/participants` - a request with a valid native auth token, will register the address for a specific contest

- `POST /trading-contests/<CONTEST_UUID>/participants/<ADDRESS>` - returns stats for a specific participant (address)
Request body (`firstToken` and `secondToken` are optional, but cannot be added separately - both / none) : 
```
{
    "startTimestamp": 1748754055,
    "endTimestamp": 1751300503,
    "firstToken": "MEX-a659d0",
    "secondToken": "USDC-350c4e",
    "includeTradeCount": true,
    "includeRank": true
}
```
Response : 
```
{
    "rank": 4,
    "totalVolumeUSD": 195.79225249514678,
    "tradeCount": 6
}
```

- `POST /trading-contests/<CONTEST_UUID>/participants/<ADDRESS>/token-stats` - returns stats grouped by token for a specific participant (address). The request body accepts the same fields as the request above
Response : 
```
[
    {
        "tokenID": "MEX-a659d0",
        "buyVolumeUSD": 41.943666166459536,
        "sellVolumeUSD": 125.86456132868726,
        "buyCount": 3,
        "sellCount": 2
    },
    {
        "tokenID": "USDC-350c4e",
        "buyVolumeUSD": 125.86456132868726,
        "sellVolumeUSD": 41.943666166459536,
        "buyCount": 2,
        "sellCount": 3
    }
]
```