### PR TITLE
[MEX-826] Farms undistributed boosted rewards cache warmer

### DIFF
--- a/src/modules/farm/base-module/services/farm.setter.service.ts
+++ b/src/modules/farm/base-module/services/farm.setter.service.ts
@@ -289,4 +289,17 @@ export abstract class FarmSetterService extends GenericSetterService {
             CacheTtlInfo.ContractState.localTtl,
         );
     }
+
+    async setFarmUndistributedBoostedRewards(
+        farmAddress: string,
+        value: string,
+        week: number,
+    ): Promise<string> {
+        return await this.setData(
+            this.getCacheKey('undistributedBoostedRewards', farmAddress, week),
+            value,
+            CacheTtlInfo.ContractState.remoteTtl,
+            CacheTtlInfo.ContractState.localTtl,
+        );
+    }
 }

--- a/src/services/crons/farm.cache.warmer.service.ts
+++ b/src/services/crons/farm.cache.warmer.service.ts
@@ -259,7 +259,7 @@ export class FarmCacheWarmerService {
     }
 
     @Cron(CronExpression.EVERY_5_MINUTES)
-    async cacheFarmsV2UndistributedBoostedRewards(): Promise<void> {
+    async cacheFarmsV2Rewards(): Promise<void> {
         for (const address of farmsAddresses([FarmVersion.V2])) {
             const currentWeek = await this.weekTimekeepingAbi.currentWeek(
                 address,


### PR DESCRIPTION
## Reasoning
- slow response time on farms query requesting the `undistributedBoostedRewards` field. The underlying compute method can trigger up to 100 VM query calls (function `getRemainingBoostedRewardsToDistribute`) for each farm, resulting in ~2000 VM query calls on a cache miss

  
## Proposed Changes
- add a cron job that refreshes the cache value for `undistributedBoostedRewards` of each v2 farm


## How to test
- N/A

