### PR TITLE
[MEX-845] Add token amounts to trading contest participant response

### DIFF
--- a/src/modules/trading-contest/pipelines/participant.token.stats.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/participant.token.stats.pipeline.ts
@@ -45,6 +45,26 @@ export const participantTokenStatsPipeline = (
                 tokenOut: '$tokenOut',
             },
             totalVolumeUSD: { $sum: '$volumeUSD' },
+            tokenInAmount: {
+                $sum: {
+                    $convert: {
+                        input: '$amountIn',
+                        to: 'decimal',
+                        onError: 0,
+                        onNull: 0,
+                    },
+                },
+            },
+            tokenOutAmount: {
+                $sum: {
+                    $convert: {
+                        input: '$amountOut',
+                        to: 'decimal',
+                        onError: 0,
+                        onNull: 0,
+                    },
+                },
+            },
             ...(includeTradeCount && { tradeCount: { $sum: 1 } }),
         },
     };
@@ -54,6 +74,8 @@ export const participantTokenStatsPipeline = (
             _id: 0,
             tokenIn: '$_id.tokenIn',
             tokenOut: '$_id.tokenOut',
+            tokenInAmount: { $toString: '$tokenInAmount' },
+            tokenOutAmount: { $toString: '$tokenOutAmount' },
             totalVolumeUSD: 1,
         },
     };

--- a/src/modules/trading-contest/services/trading.contest.service.ts
+++ b/src/modules/trading-contest/services/trading.contest.service.ts
@@ -34,6 +34,7 @@ import {
 import { participantStatsPipeline } from '../pipelines/participant.stats.pipeline';
 import { ESOperationsService } from 'src/services/elastic-search/services/es.operations.service';
 import { Address } from '@multiversx/sdk-core';
+import BigNumber from 'bignumber.js';
 
 @Injectable()
 export class TradingContestService {
@@ -361,13 +362,22 @@ export class TradingContestService {
         const tokenMap: Record<string, ContestParticipantTokenStats> = {};
 
         for (const stat of rawStats) {
-            const { tokenIn, tokenOut, totalVolumeUSD, tradeCount } = stat;
+            const {
+                tokenIn,
+                tokenOut,
+                totalVolumeUSD,
+                tradeCount,
+                tokenInAmount,
+                tokenOutAmount,
+            } = stat;
 
             if (!tokenMap[tokenIn]) {
                 tokenMap[tokenIn] = {
                     tokenID: tokenIn,
                     buyVolumeUSD: 0,
+                    buyAmount: '0',
                     sellVolumeUSD: 0,
+                    sellAmount: '0',
                 };
                 if (tradeCount) {
                     tokenMap[tokenIn].buyCount = 0;
@@ -379,7 +389,9 @@ export class TradingContestService {
                 tokenMap[tokenOut] = {
                     tokenID: tokenOut,
                     buyVolumeUSD: 0,
+                    buyAmount: '0',
                     sellVolumeUSD: 0,
+                    sellAmount: '0',
                 };
                 if (tradeCount) {
                     tokenMap[tokenOut].buyCount = 0;
@@ -387,8 +399,16 @@ export class TradingContestService {
                 }
             }
 
+            const sellAmount = new BigNumber(tokenInAmount).plus(
+                tokenMap[tokenIn].sellAmount,
+            );
+            const buyAmount = new BigNumber(tokenOutAmount).plus(
+                tokenMap[tokenIn].buyAmount,
+            );
             tokenMap[tokenIn].sellVolumeUSD += totalVolumeUSD;
+            tokenMap[tokenIn].sellAmount = sellAmount.toFixed();
             tokenMap[tokenOut].buyVolumeUSD += totalVolumeUSD;
+            tokenMap[tokenOut].buyAmount = buyAmount.toFixed();
 
             if (tradeCount) {
                 tokenMap[tokenIn].sellCount += tradeCount;

--- a/src/modules/trading-contest/types.ts
+++ b/src/modules/trading-contest/types.ts
@@ -28,14 +28,18 @@ export type ContestParticipantStats = {
 export type ContestParticipantTokenStats = {
     tokenID: string;
     buyVolumeUSD: number;
+    buyAmount: string;
     sellVolumeUSD: number;
+    sellAmount: string;
     buyCount?: number;
     sellCount?: number;
 };
 
 export type RawSwapStat = {
     tokenIn: string;
+    tokenInAmount: string;
     tokenOut: string;
+    tokenOutAmount: string;
     totalVolumeUSD: number;
     tradeCount?: number;
 };


### PR DESCRIPTION
## Reasoning
- information about the total swapped token amounts is needed, besides the computed USD value
  
## Proposed Changes
- update participant token stats aggregation pipeline
- update types

## How to test
- Response from `POST /trading-contests/<CONTEST_UUID>/participants/<ADDRESS>/token-stats` should look like this : 
```
[
    {
        "tokenID": "SPK-81618e",
        "buyVolumeUSD": 50.68056195024269,
        "buyAmount": "90652.446423604457233126",
        "sellVolumeUSD": 103.89205086538817,
        "sellAmount": "183849.097107306660264211",
        "buyCount": 2,
        "sellCount": 4
    },
    {
        "tokenID": "WEGLD-a28c59",
        "buyVolumeUSD": 103.89205086538817,
        "buyAmount": "6.904570039319697463",
        "sellVolumeUSD": 50.68056195024269,
        "sellAmount": "3.369568234352152333",
        "buyCount": 4,
        "sellCount": 2
    }
]
```
