### PR TITLE
[MEX-849] Expose fee in smart swap model

### DIFF
--- a/src/modules/auto-router/models/auto-route.model.ts
+++ b/src/modules/auto-router/models/auto-route.model.ts
@@ -91,6 +91,12 @@ export class SmartSwapModel {
     @Field(() => [SmartSwapRoute])
     routes: SmartSwapRoute[];
 
+    @Field(() => Number)
+    feePercentage: number;
+
+    @Field()
+    feeAmount: string;
+
     constructor(init?: Partial<SmartSwapModel>) {
         Object.assign(this, init);
     }

--- a/src/modules/auto-router/specs/smart.router.service.spec.ts
+++ b/src/modules/auto-router/specs/smart.router.service.spec.ts
@@ -190,7 +190,7 @@ describe('SmartRouterService', () => {
             totalResult: '3884256943682064342173',
         },
         smartSwap: new SmartSwapModel({
-            amountOut: '3884256943682064342173',
+            amountOut: '3864835658963654020462',
             routes: [
                 new SmartSwapRoute({
                     fees: ['0.072325244771647452519'],
@@ -236,6 +236,8 @@ describe('SmartRouterService', () => {
             tokenOutExchangeRate: '10297979917384707',
             tokenOutExchangeRateDenom: '0.010297979917384707',
             tokensPriceDeviationPercent: undefined,
+            feeAmount: '19421284718410321710',
+            feePercentage: 0.005,
         }),
     });
 


### PR DESCRIPTION
## Reasoning
- the fee for smart swaps was not exposed on the model; it was only used to compute the amount encoded in the transaction arguments 
  
## Proposed Changes
- add `feeAmount` and `feePercentage` fields to `SmartSwapModel`
- update the value of the `amountOut` field ( = the amount computed by the algorithm - the % fee)
- update unit tests

## How to test
- `swap` query 
```
query SmartSwapQueryWithFee {
  swap(
    amountIn: "900000000"
    tokenInID: "USDC-350c4e"
    tokenOutID: "EMR-6310dc"
    tolerance: 0.01
  ) {
    # ... other fields
    smartSwap {
      amountOut
      feeAmount
      feePercentage
      routes {
        tokenRoute
        pricesImpact
        intermediaryAmounts
        pairs {
          address
        }
      }
    }
  }
}
```
