### PR TITLE
[MEX-855] increase minimum permanent liquidity locked

### DIFF
--- a/src/modules/pair/services/pair.transactions.service.ts
+++ b/src/modules/pair/services/pair.transactions.service.ts
@@ -144,8 +144,10 @@ export class PairTransactionService {
                 new BigNumber(secondTokenInput.amount),
             );
 
-        if (permanentLockedAmountUSD.isGreaterThan(1)) {
-            throw new Error('Permanent locked amount must be less than 1 USD');
+        if (permanentLockedAmountUSD.isGreaterThan(1.5)) {
+            throw new Error(
+                'Permanent locked amount must be less than 1.5 USD',
+            );
         }
 
         return this.mxProxy.getPairSmartContractTransaction(


### PR DESCRIPTION
## Reasoning
- BTC based pools creation would hit the limitation because of the BTC price
  
## Proposed Changes
- increase the maximum requirement for permanently liquidity locked in a pool

## How to test
- N/A