### PR TITLE
[MEX-857] Populate 'tokensPriceDeviationPercent' field on swap model

### DIFF
--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -500,6 +500,13 @@ export class AutoRouterService {
         parent: AutoRouteModel,
     ): Promise<TransactionModel[]> {
         if (parent.smartSwap !== undefined) {
+            if (
+                parent.smartSwap.tokensPriceDeviationPercent >
+                parent.maxPriceDeviationPercent
+            ) {
+                throw new Error('Spread too big!');
+            }
+
             try {
                 const transactions =
                     await this.autoRouterTransactionService.smartSwap(sender, {
@@ -657,9 +664,9 @@ export class AutoRouterService {
                     .error(`Spread too big validating auto route swap transaction ${tokenInID} => ${tokenOutID}.
                 amount in = ${amountIn}, usd value = ${amountInUSD};
                 amount out = ${amountOut}, usd value = ${amountOutUSD}`);
-
-                return priceDeviationPercent.toNumber();
             }
+
+            return priceDeviationPercent.toNumber();
         }
     }
 
@@ -738,9 +745,9 @@ export class AutoRouterService {
                         .error(`Spread too big validating smart swap transaction ${tokenInID} => ${tokenOutID}.
                 amount in = ${amountIn}, usd value = ${amountInUSD};
                 amount out = ${amountOut}, usd value = ${amountOutUSD}`);
-
-                    return priceDeviationPercent.toNumber();
                 }
+
+                return priceDeviationPercent.toNumber();
             }
         }
     }

--- a/src/modules/auto-router/specs/auto-router.service.spec.ts
+++ b/src/modules/auto-router/specs/auto-router.service.spec.ts
@@ -151,7 +151,7 @@ describe('AutoRouterService', () => {
                 ],
                 tolerance: 0.01,
                 maxPriceDeviationPercent: 1,
-                tokensPriceDeviationPercent: undefined,
+                tokensPriceDeviationPercent: 0.00309939099071823,
             }),
         );
     });
@@ -201,7 +201,7 @@ describe('AutoRouterService', () => {
                 ],
                 tolerance: 0.01,
                 maxPriceDeviationPercent: 1,
-                tokensPriceDeviationPercent: undefined,
+                tokensPriceDeviationPercent: 0.00319876216682394,
             }),
         );
     });
@@ -275,7 +275,7 @@ describe('AutoRouterService', () => {
                 ],
                 tolerance: 0.01,
                 maxPriceDeviationPercent: 1,
-                tokensPriceDeviationPercent: undefined,
+                tokensPriceDeviationPercent: 0.004001066100470686,
             }),
         );
     });
@@ -382,6 +382,48 @@ describe('AutoRouterService', () => {
                 guardianSignature: undefined,
             },
         ]);
+    });
+
+    it('should throw an error when spread is too big', async () => {
+        await expect(
+            service.getTransactions(
+                senderAddress,
+                new AutoRouteModel({
+                    swapType: 1,
+                    tokenInID: 'USDC-123456',
+                    tokenOutID: 'MEX-123456',
+                    tokenInExchangeRate: '99201792616073289490',
+                    tokenOutExchangeRate: '10080',
+                    tokenInExchangeRateDenom: '99.20179261607328949',
+                    tokenOutExchangeRateDenom: '0.01008',
+                    tokenInPriceUSD: '1',
+                    tokenOutPriceUSD: '0.01',
+                    amountIn: '10181267',
+                    amountOut: '1000000000000000000000',
+                    intermediaryAmounts: [
+                        '10080463',
+                        '1004013040121365097',
+                        '1000000000000000000000',
+                    ],
+                    tokenRoute: ['USDC-123456', 'WEGLD-123456', 'MEX-123456'],
+                    pairs: [
+                        new PairModel({
+                            address: Address.newFromHex(
+                                '0000000000000000000000000000000000000000000000000000000000000013',
+                            ).toBech32(),
+                        }),
+                        new PairModel({
+                            address: Address.newFromHex(
+                                '0000000000000000000000000000000000000000000000000000000000000012',
+                            ).toBech32(),
+                        }),
+                    ],
+                    tolerance: 0.01,
+                    maxPriceDeviationPercent: 0.004,
+                    tokensPriceDeviationPercent: 0.004001066100470686,
+                }),
+            ),
+        ).rejects.toThrow('Spread too big!');
     });
 
     it('should get a fixed output multi swap tx + unwrap tx', async () => {

--- a/src/modules/auto-router/specs/smart.router.service.spec.ts
+++ b/src/modules/auto-router/specs/smart.router.service.spec.ts
@@ -81,7 +81,7 @@ describe('SmartRouterService', () => {
         pairs: [availablePairs['WEGLD-TOK5']],
         tolerance: 0.01,
         maxPriceDeviationPercent: 1,
-        tokensPriceDeviationPercent: undefined,
+        tokensPriceDeviationPercent: 0.012841965602938701,
         parallelRouteSwap: {
             allocations: [
                 {
@@ -145,7 +145,7 @@ describe('SmartRouterService', () => {
         pairs: [availablePairs['WEGLD-TOK5']],
         tolerance: 0.01,
         maxPriceDeviationPercent: 1,
-        tokensPriceDeviationPercent: undefined,
+        tokensPriceDeviationPercent: 0.04123552717621264,
         parallelRouteSwap: {
             allocations: [
                 {
@@ -235,7 +235,7 @@ describe('SmartRouterService', () => {
             tokenInExchangeRateDenom: '97.106423592051608554',
             tokenOutExchangeRate: '10297979917384707',
             tokenOutExchangeRateDenom: '0.010297979917384707',
-            tokensPriceDeviationPercent: undefined,
+            tokensPriceDeviationPercent: 0.02640150083732185,
             feeAmount: '19421284718410321710',
             feePercentage: 0.005,
         }),
@@ -388,6 +388,18 @@ describe('SmartRouterService', () => {
                 guardianSignature: undefined,
             },
         ]);
+    });
+
+    it('should throw an error when spread is too big', async () => {
+        const autoRouteModel = new AutoRouteModel({
+            ...expectedAutoRouteWithSmartSwap,
+            maxPriceDeviationPercent: 0.02,
+            tokenInID: 'EGLD',
+        });
+
+        await expect(
+            autoRouterService.getTransactions(senderAddress, autoRouteModel),
+        ).rejects.toThrow('Spread too big!');
     });
 });
 

--- a/src/modules/pair/mocks/pair.constants.ts
+++ b/src/modules/pair/mocks/pair.constants.ts
@@ -174,6 +174,7 @@ export const Tokens = (tokenID: string): EsdtToken => {
                 accounts: 1,
                 transactions: 1,
                 assets: new AssetsModel(),
+                price: '0.1',
             });
         case 'TOK6-123456':
             return new EsdtToken({


### PR DESCRIPTION
## Reasoning
- the `tokensPriceDeviationPercent` field on swap models is currently only populated when the value exceedes the config value for `MAX_SWAP_SPREAD`
  
## Proposed Changes
- always return the value from the compute methods
- throw an error when a smart swap transaction is requested, and the spread is too large
- update unit tests : add tests that check for presence of error when spread is too large; update missing field where needed

## How to test
- N/A
