### PR TITLE
[MEX-859] Fix compute feesUSD value in swap handler

### DIFF
--- a/src/modules/rabbitmq/handlers/pair.swap.handler.service.ts
+++ b/src/modules/rabbitmq/handlers/pair.swap.handler.service.ts
@@ -143,14 +143,9 @@ export class SwapEventHandler {
         let volumeUSD: BigNumber;
         let feesUSD: BigNumber;
 
-        let feeAmount =
-            event.getTokenIn().tokenID === firstToken.identifier
-                ? new BigNumber(firstTokenAmount)
-                      .times(totalFeePercent)
-                      .toFixed()
-                : new BigNumber(secondTokenAmount)
-                      .times(totalFeePercent)
-                      .toFixed();
+        let feeAmount = new BigNumber(event.getTokenIn().amount)
+            .times(totalFeePercent)
+            .toFixed();
 
         if (
             commonTokensIDs.includes(firstToken.identifier) &&


### PR DESCRIPTION
## Reasoning
- `feesUSD` value that gets persisted in timescaledb is distorted for swaps in low liquidity pools
  
## Proposed Changes
- compute fees USD value in relation to common tokens

## How to test
- N/A
