### PR TITLE
[MEX-784] Fix local cache TTL for undefined values

### DIFF
--- a/src/helpers/decorators/caching.decorator.ts
+++ b/src/helpers/decorators/caching.decorator.ts
@@ -57,13 +57,20 @@ export function GetOrSetCache(cachingOptions: ICachingOptions) {
             if (cachedValue !== undefined) {
                 MetricsCollector.incrementCachedApiHit(genericCacheKey);
 
-                cachingService.setLocal(
-                    cacheKey,
-                    cachedValue,
+                const parsedValue = parseCachedNullOrUndefined(cachedValue);
+                let localTtl =
                     cachingOptions.localTtl ??
-                        Math.floor(cachingOptions.remoteTtl / 2),
-                );
-                return parseCachedNullOrUndefined(cachedValue);
+                    Math.floor(cachingOptions.remoteTtl / 2);
+
+                if (
+                    typeof parsedValue === 'undefined' ||
+                    parsedValue === null
+                ) {
+                    localTtl = CacheTtlInfo.NullValue.localTtl;
+                }
+
+                cachingService.setLocal(cacheKey, cachedValue, localTtl);
+                return parsedValue;
             }
 
             const value = await originalMethod.apply(this, args);


### PR DESCRIPTION
## Reasoning
- the TTL for the in-memory caching of `undefined` / `null` is currently incorrect, when a value is present in the remote cache, and the local cache is updated with that value.  
- the current implementation of the `setDataOrUpdateTtl` in the `GenericSetterService`  can lead to stale / out-of-sync data in the in-memory cache on the cache warmer instance

  
## Proposed Changes
- update `GetOrSetCache` decorator: set correct TTL when updating local cache from remote cached value
- update `setDataOrUpdateTtl` method in generic setter: add extra check -> compare remote cached value with in-memory cached value when deciding if a TTL update is sufficient

## How to test
- N/A
