### PR TITLE
[MEX-863] Trading Contest stats endpoints

### DIFF
--- a/src/modules/trading-contest/controllers/trading.contest.controller.ts
+++ b/src/modules/trading-contest/controllers/trading.contest.controller.ts
@@ -13,13 +13,14 @@ import {
 import { TradingContestService } from '../services/trading.contest.service';
 import { TradingContest } from '../schemas/trading.contest.schema';
 import {
+    AggregationParamsDto,
     TradingContestLeaderboardDto,
-    TradingContestParticipantDto,
+    TradingContestParamsDto,
 } from '../dtos/contest.leaderboard.dto';
 import {
     ContestParticipantStats,
-    LeaderBoardEntry,
-    ContestParticipantTokenStats,
+    ContestTokenStats,
+    LeaderBoardResponse,
 } from '../types';
 import { JwtOrNativeAuthGuard } from 'src/modules/auth/jwt.or.native.auth.guard';
 import { AuthUser } from 'src/modules/auth/auth.user';
@@ -41,6 +42,55 @@ export class TradingContestController {
         }
 
         return contest;
+    }
+
+    @UsePipes(
+        new ValidationPipe({
+            transform: true,
+            transformOptions: { enableImplicitConversion: true },
+        }),
+    )
+    @Post('/:uuid/stats')
+    async getContestStats(
+        @Param('uuid') uuid: string,
+        @Body() parameters: AggregationParamsDto,
+    ): Promise<any> {
+        const contest = await this.tradingContestService.getContestByUuid(
+            uuid,
+            { _id: 1 },
+        );
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.getContestStats(contest, parameters);
+    }
+
+    @UsePipes(
+        new ValidationPipe({
+            transform: true,
+            transformOptions: { enableImplicitConversion: true },
+        }),
+    )
+    @Post('/:uuid/token-stats')
+    async getContestTokenStats(
+        @Param('uuid') uuid: string,
+        @Body() parameters: TradingContestParamsDto,
+    ): Promise<ContestTokenStats[]> {
+        const contest = await this.tradingContestService.getContestByUuid(
+            uuid,
+            { _id: 1 },
+        );
+
+        if (!contest) {
+            throw new HttpException('Contest not found', HttpStatus.NOT_FOUND);
+        }
+
+        return this.tradingContestService.getContestTokenStats(
+            contest,
+            parameters,
+        );
     }
 
     @UseGuards(JwtOrNativeAuthGuard)
@@ -71,7 +121,7 @@ export class TradingContestController {
     async contestLeaderboard(
         @Param('uuid') uuid: string,
         @Body() contestLeaderboardDto: TradingContestLeaderboardDto,
-    ): Promise<LeaderBoardEntry[]> {
+    ): Promise<LeaderBoardResponse> {
         const contest = await this.tradingContestService.getContestByUuid(
             uuid,
             { _id: 1 },
@@ -97,7 +147,7 @@ export class TradingContestController {
     async getContestParticipantStats(
         @Param('uuid') uuid: string,
         @Param('address') address: string,
-        @Body() parameters: TradingContestParticipantDto,
+        @Body() parameters: TradingContestParamsDto,
     ): Promise<ContestParticipantStats> {
         const contest = await this.tradingContestService.getContestByUuid(
             uuid,
@@ -125,8 +175,8 @@ export class TradingContestController {
     async getContestParticipantTokenStats(
         @Param('uuid') uuid: string,
         @Param('address') address: string,
-        @Body() parameters: TradingContestParticipantDto,
-    ): Promise<ContestParticipantTokenStats[]> {
+        @Body() parameters: TradingContestParamsDto,
+    ): Promise<ContestTokenStats[]> {
         const contest = await this.tradingContestService.getContestByUuid(
             uuid,
             { _id: 1 },

--- a/src/modules/trading-contest/controllers/trading.contest.controller.ts
+++ b/src/modules/trading-contest/controllers/trading.contest.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '../dtos/contest.leaderboard.dto';
 import {
     ContestParticipantStats,
+    ContestStats,
     ContestTokenStats,
     LeaderBoardResponse,
 } from '../types';
@@ -54,7 +55,7 @@ export class TradingContestController {
     async getContestStats(
         @Param('uuid') uuid: string,
         @Body() parameters: AggregationParamsDto,
-    ): Promise<any> {
+    ): Promise<ContestStats> {
         const contest = await this.tradingContestService.getContestByUuid(
             uuid,
             { _id: 1 },

--- a/src/modules/trading-contest/dtos/contest.leaderboard.dto.ts
+++ b/src/modules/trading-contest/dtos/contest.leaderboard.dto.ts
@@ -10,7 +10,7 @@ import {
 } from 'class-validator';
 import { IsValidUnixTime } from 'src/helpers/validators/unix.time.validator';
 
-class AggregationParamsDto {
+export class AggregationParamsDto {
     @IsOptional()
     @IsInt()
     @IsValidUnixTime()
@@ -42,7 +42,7 @@ export class TradingContestLeaderboardDto extends AggregationParamsDto {
     limit? = 25;
 }
 
-export class TradingContestParticipantDto extends AggregationParamsDto {
+export class TradingContestParamsDto extends AggregationParamsDto {
     @ValidateIf((o) => o.secondToken)
     @IsNotEmpty()
     @IsString()

--- a/src/modules/trading-contest/pipelines/contest.stats.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/contest.stats.pipeline.ts
@@ -1,0 +1,169 @@
+import mongoose, { AccumulatorOperator, PipelineStage } from 'mongoose';
+import { AggregationParamsDto } from '../dtos/contest.leaderboard.dto';
+
+export const contestStatsPipeline = (
+    contestId: string,
+    parameters: AggregationParamsDto,
+): PipelineStage[] => {
+    const { startTimestamp, endTimestamp, includeTradeCount, includeFees } =
+        parameters;
+
+    const matchStage: PipelineStage.Match = {
+        $match: {
+            contest: new mongoose.Types.ObjectId(contestId),
+            participant: { $ne: null },
+        },
+    };
+
+    if (startTimestamp !== undefined || endTimestamp !== undefined) {
+        matchStage.$match.timestamp = {};
+        if (startTimestamp !== undefined) {
+            matchStage.$match.timestamp.$gte = startTimestamp;
+        }
+        if (endTimestamp !== undefined) {
+            matchStage.$match.timestamp.$lte = endTimestamp;
+        }
+    }
+
+    const commonGroupStage: Record<string, AccumulatorOperator> = {
+        totalVolumeUSD: { $sum: '$volumeUSD' },
+        minTradeUSD: { $min: '$volumeUSD' },
+        maxTradeUSD: { $max: '$volumeUSD' },
+    };
+
+    const participantsGroupStage: Record<string, AccumulatorOperator> = {
+        participantsSet: {
+            $addToSet: {
+                $cond: [
+                    { $ne: ['$participant', null] },
+                    '$participant',
+                    '$$REMOVE',
+                ],
+            },
+        },
+    };
+
+    const commonProjectStage: Record<string, any> = {
+        totalVolumeUSD: 1,
+        minTradeUSD: 1,
+        maxTradeUSD: 1,
+    };
+
+    if (includeTradeCount) {
+        commonGroupStage.tradeCount = { $sum: 1 };
+
+        commonProjectStage.tradeCount = 1;
+        commonProjectStage.averageTradeUSD = {
+            $cond: [
+                { $gt: ['$tradeCount', 0] },
+                {
+                    $divide: ['$totalVolumeUSD', '$tradeCount'],
+                },
+                0,
+            ],
+        };
+    }
+
+    if (includeFees) {
+        commonGroupStage.totalFeesUSD = { $sum: '$feesUSD' };
+        commonProjectStage.totalFeesUSD = 1;
+    }
+
+    const participantsProjectStage: Record<string, any> = {
+        distinctParticipants: {
+            $size: { $ifNull: ['$participantsSet', []] },
+        },
+    };
+
+    return [
+        matchStage,
+        {
+            $facet: {
+                summary: [
+                    {
+                        $group: {
+                            _id: null,
+                            ...participantsGroupStage,
+                            ...commonGroupStage,
+                        },
+                    },
+                    {
+                        $project: {
+                            _id: 0,
+                            ...participantsProjectStage,
+                            ...commonProjectStage,
+                        },
+                    },
+                ],
+
+                bySwapType: [
+                    {
+                        $group: {
+                            _id: '$swapType',
+                            ...commonGroupStage,
+                        },
+                    },
+                    {
+                        $project: {
+                            _id: 0,
+                            swapType: '$_id',
+                            ...commonProjectStage,
+                        },
+                    },
+                    { $sort: { swapType: 1 } },
+                ],
+
+                daily: [
+                    {
+                        $addFields: {
+                            tsDate: {
+                                $toDate: { $multiply: ['$timestamp', 1000] },
+                            },
+                        },
+                    },
+                    {
+                        $group: {
+                            _id: {
+                                $dateTrunc: {
+                                    date: '$tsDate',
+                                    unit: 'day',
+                                },
+                            },
+                            ...participantsGroupStage,
+                            ...commonGroupStage,
+                        },
+                    },
+                    {
+                        $project: {
+                            _id: 0,
+                            date: '$_id',
+                            ...participantsProjectStage,
+                            ...commonProjectStage,
+                        },
+                    },
+                    { $sort: { date: 1 } },
+                ],
+            },
+        },
+        {
+            $project: {
+                summary: {
+                    $ifNull: [
+                        { $arrayElemAt: ['$summary', 0] },
+                        {
+                            totalVolumeUSD: 0,
+                            totalFeesUSD: 0,
+                            tradeCount: 0,
+                            averageTradeUSD: 0,
+                            minTradeUSD: 0,
+                            maxTradeUSD: 0,
+                            distinctParticipants: 0,
+                        },
+                    ],
+                },
+                bySwapType: 1,
+                daily: 1,
+            },
+        },
+    ];
+};

--- a/src/modules/trading-contest/pipelines/participant.stats.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/participant.stats.pipeline.ts
@@ -1,10 +1,10 @@
 import mongoose, { PipelineStage } from 'mongoose';
-import { TradingContestParticipantDto } from '../dtos/contest.leaderboard.dto';
+import { TradingContestParamsDto } from '../dtos/contest.leaderboard.dto';
 
 export const participantStatsPipeline = (
     contestId: string,
     participantId: string,
-    parameters: TradingContestParticipantDto,
+    parameters: TradingContestParamsDto,
 ): PipelineStage[] => {
     const {
         startTimestamp,

--- a/src/modules/trading-contest/pipelines/token.stats.pipeline.ts
+++ b/src/modules/trading-contest/pipelines/token.stats.pipeline.ts
@@ -1,10 +1,10 @@
 import mongoose, { PipelineStage } from 'mongoose';
-import { TradingContestParticipantDto } from '../dtos/contest.leaderboard.dto';
+import { TradingContestParamsDto } from '../dtos/contest.leaderboard.dto';
 
-export const participantTokenStatsPipeline = (
+export const tokenStatsPipeline = (
     contestId: string,
-    participantId: string,
-    parameters: TradingContestParticipantDto,
+    parameters: TradingContestParamsDto,
+    participantId?: string,
 ): PipelineStage[] => {
     const {
         startTimestamp,
@@ -17,9 +17,14 @@ export const participantTokenStatsPipeline = (
     const matchStage: PipelineStage.Match = {
         $match: {
             contest: new mongoose.Types.ObjectId(contestId),
-            participant: new mongoose.Types.ObjectId(participantId),
         },
     };
+
+    if (participantId) {
+        matchStage.$match.participant = new mongoose.Types.ObjectId(
+            participantId,
+        );
+    }
 
     if (firstToken && secondToken) {
         matchStage.$match.$or = [

--- a/src/modules/trading-contest/types.ts
+++ b/src/modules/trading-contest/types.ts
@@ -10,22 +10,27 @@ export type SwapEventPairData = {
     feesUSD: string;
 };
 
-export type LeaderBoardEntry = {
+export type ContestSwapsStats = {
+    totalVolumeUSD: number;
+    totalFeesUSD?: number;
+    tradeCount?: number;
+};
+
+export type ContestParticipantStats = ContestSwapsStats & {
+    rank: number;
+};
+
+type LeaderBoardEntry = ContestParticipantStats & {
     sender: { address: string };
-    totalVolumeUSD: number;
-    tradeCount: number;
-    totalFeesUSD: number;
-    rank: number;
 };
 
-export type ContestParticipantStats = {
-    totalVolumeUSD: number;
-    tradeCount: number;
-    totalFeesUSD: number;
-    rank: number;
+export type LeaderBoardResponse = {
+    results: LeaderBoardEntry[];
+    totalCount: number;
+    currentOffset: number;
 };
 
-export type ContestParticipantTokenStats = {
+export type ContestTokenStats = {
     tokenID: string;
     buyVolumeUSD: number;
     buyAmount: string;
@@ -42,4 +47,27 @@ export type RawSwapStat = {
     tokenOutAmount: string;
     totalVolumeUSD: number;
     tradeCount?: number;
+};
+
+export type ContestSwapsExtendedStats = ContestSwapsStats & {
+    minTradeUSD: number;
+    maxTradeUSD: number;
+    averageTradeUSD?: number;
+};
+
+export type ContestStatsBySwapType = ContestSwapsExtendedStats & {
+    swapType: 'Fixed Input' | 'Fixed Output' | 'Multi Pair' | 'Smart Swap';
+};
+
+export type ContestDailyStats = ContestSwapsExtendedStats & {
+    distinctParticipants: number;
+    date: string;
+};
+
+export type ContestStats = {
+    bySwapType: ContestStatsBySwapType[];
+    daily: ContestDailyStats[];
+    summary: ContestSwapsExtendedStats & {
+        distinctParticipants: number;
+    };
 };


### PR DESCRIPTION
## Reasoning
- no way to have an insight into the general performance of a specific contest (without fetching the entire leaderboard)
- no straight forward way to paginate the leaderboard, without knowing the total participant count in advance
  
## Proposed Changes
- mongodb aggregation pipeline for contest stats; returns stats in 3 flavors using $facet: summary, bySwapType, daily
- refactor participant token stats agg. pipeline into a more generic pipeline allowing optional filtering by participant
- update leaderboard pipeline to include total participant count (to help with pagination); rely on $facet for improved performance at db level
- update types and dtos to match the new and updated pipelines
- refactor trading contest service to properly make use of the new and updated aggregation pipelines
- add `/<contest>/stats` and `<contest>/token-stats` endpoints exposing stats for a specific contest

## How to test
- `POST /trading-contests/<CONTEST_UUID>/stats` - returns an overview of the contests performance
Request body (all parameters are optional) :
```
{
    "startTimestamp": 1753649999,
    "endTimestamp": 1753833600,
    "includeTradeCount": true,
    "includeFees": true
}
```
Response : 
```
{
    "bySwapType": [
        {
            "totalVolumeUSD": 9847.252154215199,
            "minTradeUSD": 10.186634892425076,
            "maxTradeUSD": 951.4768308801154,
            "tradeCount": 167,
            "totalFeesUSD": 29.589337511133007,
            "swapType": "Fixed Input",
            "averageTradeUSD": 58.96558176176766
        },
        {
            "totalVolumeUSD": 5599.8647079741895,
            "minTradeUSD": 10.150545564862606,
            "maxTradeUSD": 419.68010244845715,
            "tradeCount": 35,
            "totalFeesUSD": 16.8273985894196,
            "swapType": "Fixed Output",
            "averageTradeUSD": 159.99613451354827
        },
        {
            "totalVolumeUSD": 2929.902264086638,
            "minTradeUSD": 10.0521477690904,
            "maxTradeUSD": 361.3591830930328,
            "tradeCount": 66,
            "totalFeesUSD": 0,
            "swapType": "Multi Pair",
            "averageTradeUSD": 44.39245854676724
        }
    ],
    "daily": [
        {
            "totalVolumeUSD": 9151.019320461026,
            "minTradeUSD": 10.23427795330066,
            "maxTradeUSD": 419.68010244845715,
            "tradeCount": 143,
            "totalFeesUSD": 22.056976983372035,
            "date": "2025-07-28T00:00:00.000Z",
            "distinctParticipants": 64,
            "averageTradeUSD": 63.993142101126054
        },
        {
            "totalVolumeUSD": 9225.999805815001,
            "minTradeUSD": 10.0521477690904,
            "maxTradeUSD": 951.4768308801154,
            "tradeCount": 125,
            "totalFeesUSD": 24.35975911718057,
            "date": "2025-07-29T00:00:00.000Z",
            "distinctParticipants": 66,
            "averageTradeUSD": 73.80799844652002
        }
    ],
    "summary": {
        "totalVolumeUSD": 18377.019126276027,
        "minTradeUSD": 10.0521477690904,
        "maxTradeUSD": 951.4768308801154,
        "tradeCount": 268,
        "totalFeesUSD": 46.416736100552605,
        "distinctParticipants": 86,
        "averageTradeUSD": 68.57096688908966
    }
}
```
-  `POST /trading-contests/<CONTEST_UUID>/token-stats` - returns a contest overview focused on token metrics
Request body (all parameters are optional, but `firstToken` and `secondToken` cannot be added separately - both / none) :
```
{
    "startTimestamp": 1753649999,
    "endTimestamp": 1753833600,
    "firstToken": "WEGLD-bd4d79",
    "secondToken": "MEX-455c57",
    "includeTradeCount": true
}
```
Response : 
```
[
    {
        "tokenID": "WEGLD-bd4d79",
        "buyVolumeUSD": 9197.646614110767,
        "buyAmount": "585.768566464805696478",
        "sellVolumeUSD": 14769.580561574829,
        "sellAmount": "939.002939604248284078",
        "buyCount": 142,
        "sellCount": 204
    },
    {
        "tokenID": "MEX-455c57",
        "buyVolumeUSD": 14769.580561574829,
        "buyAmount": "10901065661.829594324045028904",
        "sellVolumeUSD": 9197.646614110767,
        "sellAmount": "6820112618.431834723379715791",
        "buyCount": 204,
        "sellCount": 142
    }
]
```
- `POST /trading-contests/<CONTEST_UUID>/leaderboard` - updated response
```
{
    "results": [
        {
            "totalVolumeUSD": 104.66979211692255,
            "tradeCount": 1,
            "totalFeesUSD": 0.31450043189015475,
            "rank": 51,
            "sender": {
                "address": "erd1glv7kzwhj67japtghwv6qvz0usju00hsnn32x5s49h5k8mwr2h5qndakdz"
            }
        },
        {
            "totalVolumeUSD": 102.76950525330783,
            "tradeCount": 6,
            "totalFeesUSD": 0.1950791649178279,
            "rank": 52,
            "sender": {
                "address": "erd1y7ha5wasvldcu3a7t5jjlvyga5y27exxj2r6nrvpq90n2fyjkt4qxu3m62"
            }
        },
        {
            "totalVolumeUSD": 99.14254796017059,
            "tradeCount": 1,
            "totalFeesUSD": 0,
            "rank": 53,
            "sender": {
                "address": "erd1tps86etf0qd9jr2ddy9l9y8ww5dz40hg0zay32def8muv4v6n7rqvug3s7"
            }
        }
    ],
    "totalCount": 92,
    "currentOffset": 50
}
```
