### PR TITLE
[MEX-692] updated gas limit for XMEX merge transaction

### DIFF
--- a/src/config/default.json
+++ b/src/config/default.json
@@ -479,7 +479,7 @@
                 "default": 10000000
             },
             "updateTokens": 10000000,
-            "defaultMergeTokens": 8000000,
+            "defaultMergeTokens": 9000000,
             "mergeTokensMultiplier": 750000,
             "migrateOldTokens": 15000000,
             "admin": {


### PR DESCRIPTION
## Reasoning
- not enough gas
  
## Proposed Changes
- increased default gas limit for xMEX token merge transaction

## How to test
- N/A
