### PR TITLE
[MEX-879] Prevent timescaledb ingesting for non numeric values

### DIFF
--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -410,6 +410,17 @@ export class RabbitMqConsumer {
                 this.data[series] = {};
             }
             for (const measure of Object.keys(eventData[series])) {
+                const measureValue = new BigNumber(eventData[series][measure]);
+
+                if (measureValue.isNaN() || !measureValue.isFinite()) {
+                    this.logger.warn('Skipping ingest for non numeric value', {
+                        series,
+                        measure,
+                        value: eventData[series][measure],
+                    });
+                    continue;
+                }
+
                 if (
                     measure.toLowerCase().includes('volume') ||
                     measure.toLowerCase().includes('fees')
@@ -422,6 +433,10 @@ export class RabbitMqConsumer {
                 } else {
                     this.data[series][measure] = eventData[series][measure];
                 }
+            }
+
+            if (Object.keys(this.data[series]).length === 0) {
+                delete this.data[series];
             }
         }
     }

--- a/src/modules/rabbitmq/rabbitmq.consumer.ts
+++ b/src/modules/rabbitmq/rabbitmq.consumer.ts
@@ -104,7 +104,6 @@ export class RabbitMqConsumer {
         exchange: process.env.RABBITMQ_EXCHANGE,
     })
     async consumeEvents(rawEvents: any) {
-        this.logger.info('Start Processing events...');
         if (!rawEvents.events) {
             return;
         }
@@ -367,7 +366,6 @@ export class RabbitMqConsumer {
                 Time: timestamp,
             });
         }
-        this.logger.info('Finish Processing events...');
     }
 
     async getFilterAddresses(): Promise<void> {


### PR DESCRIPTION
## Reasoning
- `NaN` values being persisted in the `hyper_dex_analytics` table leads to data corruption across all continuous aggregates sitting on top of it
  
## Proposed Changes
- add a check for `NaN` or infinite values before updating the object used for ingesting data in event notifier instances

## How to test
- N/A
