### PR TITLE
[MEX-888] Endpoint for custom push notifications

### DIFF
--- a/src/modules/push-notifications/models/custom.push.notification.payload.ts
+++ b/src/modules/push-notifications/models/custom.push.notification.payload.ts
@@ -1,0 +1,52 @@
+import {
+    ArrayMaxSize,
+    ArrayMinSize,
+    IsArray,
+    IsInt,
+    IsNotEmptyObject,
+    IsOptional,
+    IsString,
+    Min,
+    ValidateIf,
+    ValidateNested,
+} from 'class-validator';
+import { pushNotificationsConfig } from 'src/config';
+import { NotificationConfig } from './push.notifications.types';
+
+export class NotificationContent implements NotificationConfig {
+    @IsString()
+    title: string;
+
+    @IsString()
+    body: string;
+
+    @IsOptional()
+    @IsString()
+    route: string;
+
+    @IsString()
+    iconUrl =
+        'https://xexchange.com/assets/imgs/mx-logos/xexchange-logo@2x.webp';
+}
+
+export class CustomPushNotificationPayload {
+    @IsNotEmptyObject()
+    @ValidateNested()
+    content: NotificationContent;
+
+    @IsString()
+    notificationKey: string;
+
+    @ValidateIf((o) => !o.addresses || o.addresses.length === 0)
+    @IsInt()
+    @Min(1)
+    targetEpoch?: number;
+
+    @ValidateIf((o) => !o.targetEpoch)
+    @IsOptional()
+    @IsArray()
+    @ArrayMinSize(1)
+    @IsString({ each: true })
+    @ArrayMaxSize(pushNotificationsConfig.options.batchSize)
+    addresses?: string[];
+}


### PR DESCRIPTION
## Reasoning
- allow custom push notifications to be sent besides
  
## Proposed Changes
- add method for sending a custom notification to all users with energy
- expose endpoint (private API) that allows sending custom notifications to specific addresses / all users with energy

## How to test
`POST <PRIVATE_API>/push-notifications/send-custom`
- request body for notification to specific addresses (max 100)
```
  {
      "notificationKey": "customAnnouncement",
      "addresses": ["erd19xm2msh5sfvs5je9axp3jhzm2r5dpez8qfh88wxvcv97z24msqwqm2xn56"],
      "content": {
          "title": "xExchange: Custom Announcement",
          "body": "This is the body of the notification",
          "route": "/portfolio",
          "iconUrl": "https://xexchange.com/assets/imgs/mx-logos/xexchange-logo@2x.webp"
      }
  }
```
- request body for notification to all users with energy in a specific past epoch
```
  {
      "notificationKey": "customMexAnnouncement",
      "targetEpoch": 4351,
      "content": {
          "title": "xExchange: Custom MEX Announcement",
          "body": "This is the body of the notification"
      }
  }
```
## Notes 
- `notificationKey` parameter is used internally to identify and track potential failed notifications
- at least one of  `addresses` or `targetEpoch` is required. `addresses` takes precedence when both are present
- `content.iconUrl` and `content.route` are optional

