### PR TITLE
[MEX-966] Optional sender arg on swap query

### DIFF
--- a/src/modules/auto-router/models/auto-router.args.ts
+++ b/src/modules/auto-router/models/auto-router.args.ts
@@ -16,6 +16,9 @@ export class AutoRouterArgs {
 
     @Field()
     tolerance: number;
+
+    @Field({ nullable: true })
+    sender?: string;
 }
 
 @ArgsType()

--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -324,6 +324,7 @@ export class AutoRouterService {
                     args.tokenOutID,
                     args.amountIn,
                     args.tolerance,
+                    args.sender,
                 ),
             ]);
 
@@ -552,10 +553,17 @@ export class AutoRouterService {
                         'XOXNO smart swap selected but transaction is missing',
                     );
                 }
-                const transaction = new TransactionModel({
-                    ...parent.transactions[0],
-                    sender,
-                });
+
+                const transaction = new TransactionModel(
+                    parent.transactions[0],
+                );
+
+                if (transaction.sender !== sender) {
+                    throw new Error(
+                        'different sender on XOXNO aggregator transaction',
+                    );
+                }
+
                 await this.smartRouterEvaluationService.addFixedInputSwapComparison(
                     parent,
                     transaction,
@@ -962,6 +970,7 @@ export class AutoRouterService {
         tokenOutID: string,
         amountIn: string,
         tolerance: number,
+        sender?: string,
     ): Promise<XoxnoQuoteModel | undefined> {
         if (!this.apiConfigService.isXoxnoAggregatorEnabled()) {
             return undefined;
@@ -978,6 +987,7 @@ export class AutoRouterService {
             tokenOutID,
             amountIn,
             tolerance,
+            sender,
         );
     }
 

--- a/src/modules/auto-router/services/xoxno-aggregator.service.ts
+++ b/src/modules/auto-router/services/xoxno-aggregator.service.ts
@@ -31,12 +31,17 @@ export class XoxnoAggregatorService {
         tokenOut: string,
         amountIn: string,
         slippage: number,
+        sender?: string,
     ): Promise<XoxnoQuoteModel | undefined> {
         if (!this.baseUrl) {
             return undefined;
         }
 
         const profiler = new PerformanceProfiler(`xoxno-aggregator`);
+
+        if (sender === undefined || !Address.isValid(sender)) {
+            sender = Address.Zero().toBech32();
+        }
 
         try {
             const params: Record<string, string | number | boolean> = {
@@ -45,7 +50,7 @@ export class XoxnoAggregatorService {
                 amountIn,
                 slippage,
                 includePaths: true,
-                sender: Address.Zero().toBech32(),
+                sender,
             };
 
             if (this.referralID !== undefined) {


### PR DESCRIPTION
## Reasoning
- XOXNO aggregator needs a real sender address to best return a transaction
  
## Proposed Changes
- added real sender for XOXNO aggregator request
- reject swap transaction with XOXNO aggregator if tx sender and auth user are different

## How to test
- swap query with no sender and requested `transactions` field should fail
- swap query with sender, authenticated user and requested `transactions` field should return transaction
