### PR TITLE
[MEX-961] fixes after testing state-rpc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ IMPERSONATE_URL=â€œhttps://devnet-extras-api.multiversx.com/impersonate/allowedâ
 RABBITMQ_URL=
 RABBITMQ_EXCHANGE=all_events
 RABBITMQ_QUEUE=dex_service
+RABBITMQ_EXCHANGE_STATE=state_accesses
+RABBITMQ_STATE_QUEUE=dex_service_state
 
 # Other
 ENABLE_CACHE_GUEST_RATE_THRESHOLD=100

--- a/src/microservices/dex-state/services/compute/farm.compute.service.ts
+++ b/src/microservices/dex-state/services/compute/farm.compute.service.ts
@@ -73,7 +73,7 @@ export class FarmComputeService {
     }
 
     calculateBoostedRewardsPerWeek(farm: FarmModelV2): string {
-        const blocksInWeek = 14440 * 7;
+        const blocksInWeek = constantsConfig.BLOCKS_PER_WEEK;
         const totalRewardsPerWeek = new BigNumber(
             farm.perBlockRewards,
         ).multipliedBy(blocksInWeek);

--- a/src/microservices/dex-state/services/handlers/farms.state.handler.ts
+++ b/src/microservices/dex-state/services/handlers/farms.state.handler.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { FarmModelV2 } from 'src/modules/farm/models/farm.v2.model';
+
+const FARM_IMMUTABLE_FIELDS: ReadonlySet<keyof FarmModelV2> = new Set<
+    keyof FarmModelV2
+>(['address', 'farmedTokenId', 'farmingTokenId', 'farmTokenCollection', 'pairAddress']);
 import {
     Farms,
     UpdateFarmsRequest,
@@ -13,7 +17,7 @@ export class FarmsStateHandler {
     constructor(
         private readonly stateStore: StateStore,
         private readonly farmComputeService: FarmComputeService,
-    ) {}
+    ) { }
 
     getFarms(addresses: string[], fields: string[] = []): Farms {
         const result: Farms = {
@@ -53,14 +57,6 @@ export class FarmsStateHandler {
         const updatedFarms = new Map<string, FarmModelV2>();
         const failedAddresses: string[] = [];
 
-        const nonUpdateableFields = [
-            'address',
-            'farmedTokenId',
-            'farmingTokenId',
-            'farmTokenCollection',
-            'pairAddress',
-        ];
-
         for (const partial of partialFarms) {
             if (!partial.address) {
                 continue;
@@ -76,14 +72,13 @@ export class FarmsStateHandler {
             const updatedFarm = { ...farm };
 
             for (const field of updateMask.paths) {
-                if (partial[field] === undefined) {
+                if (!Object.prototype.hasOwnProperty.call(partial, field)) {
                     continue;
                 }
 
-                if (nonUpdateableFields.includes(field)) {
+                if (FARM_IMMUTABLE_FIELDS.has(field as keyof FarmModelV2)) {
                     continue;
                 }
-
                 updatedFarm[field] = partial[field];
             }
 

--- a/src/microservices/dex-state/services/handlers/farms.state.handler.ts
+++ b/src/microservices/dex-state/services/handlers/farms.state.handler.ts
@@ -110,6 +110,7 @@ export class FarmsStateHandler {
                 }
 
                 const updatedPair = { ...pair };
+                updatedPair.compoundedAPR = { ...updatedPair.compoundedAPR };
 
                 updatedPair.compoundedAPR.farmBaseAPR = completeFarm.baseApr;
                 updatedPair.compoundedAPR.farmBoostedAPR =

--- a/src/microservices/dex-state/services/handlers/pairs.state.handler.ts
+++ b/src/microservices/dex-state/services/handlers/pairs.state.handler.ts
@@ -23,6 +23,10 @@ import { sortKeysByField } from '../../utils/sort.utils';
 import { StateStore } from '../state.store';
 import { TokensStateHandler } from './tokens.state.handler';
 
+const PAIR_IMMUTABLE_FIELDS: ReadonlySet<keyof PairModel> = new Set<
+    keyof PairModel
+>(['address', 'firstTokenId', 'secondTokenId', 'liquidityPoolTokenId']);
+
 const PAIR_SORT_FIELD_MAP = {
     [PairSortField.PAIRS_SORT_DEPLOYED_AT]: 'deployedAt',
     [PairSortField.PAIRS_SORT_FEES]: 'feesUSD24h',
@@ -38,7 +42,7 @@ export class PairsStateHandler {
     constructor(
         private readonly stateStore: StateStore,
         private readonly tokensHandler: TokensStateHandler,
-    ) {}
+    ) { }
 
     getPairs(addresses: string[], fields: string[] = []): Pairs {
         const result: Pairs = {
@@ -359,13 +363,6 @@ export class PairsStateHandler {
         const updatedPairs = new Map<string, PairModel>();
         const failedAddresses: string[] = [];
 
-        const nonUpdateableFields = [
-            'address',
-            'firstTokenId',
-            'secondTokenId',
-            'liquidityPoolTokenId',
-        ];
-
         for (const partial of partialPairs) {
             if (!partial.address) {
                 continue;
@@ -381,11 +378,11 @@ export class PairsStateHandler {
             const updatedPair = { ...pair };
 
             for (const field of updateMask.paths) {
-                if (partial[field] === undefined) {
+                if (!Object.prototype.hasOwnProperty.call(partial, field)) {
                     continue;
                 }
 
-                if (nonUpdateableFields.includes(field)) {
+                if (PAIR_IMMUTABLE_FIELDS.has(field as keyof PairModel)) {
                     continue;
                 }
 

--- a/src/microservices/dex-state/services/handlers/staking.state.handler.ts
+++ b/src/microservices/dex-state/services/handlers/staking.state.handler.ts
@@ -228,6 +228,7 @@ export class StakingStateHandler {
                 }
 
                 const updatedPair = { ...pair };
+                updatedPair.compoundedAPR = { ...updatedPair.compoundedAPR };
 
                 updatedPair.compoundedAPR.dualFarmBaseAPR =
                     completeStakingFarm.baseApr;

--- a/src/microservices/dex-state/services/handlers/staking.state.handler.ts
+++ b/src/microservices/dex-state/services/handlers/staking.state.handler.ts
@@ -15,6 +15,10 @@ import {
 import { StakingComputeService } from '../compute/staking.compute.service';
 import { StateStore } from '../state.store';
 
+const STAKING_IMMUTABLE_FIELDS: ReadonlySet<keyof StakingModel> = new Set<
+    keyof StakingModel
+>(['address', 'rewardTokenId', 'farmingTokenId', 'farmTokenCollection']);
+
 const STAKING_FARM_SORT_FIELD_MAP = {
     [StakingFarmSortField.STAKING_SORT_PRICE]: 'farmingTokenPriceUSD',
     [StakingFarmSortField.STAKING_SORT_TVL]: 'stakedValueUSD',
@@ -27,7 +31,7 @@ export class StakingStateHandler {
     constructor(
         private readonly stateStore: StateStore,
         private readonly stakingComputeService: StakingComputeService,
-    ) {}
+    ) { }
 
     getStakingFarms(addresses: string[], fields: string[] = []): StakingFarms {
         const result: StakingFarms = {
@@ -163,13 +167,6 @@ export class StakingStateHandler {
         const updatedStakingFarms = new Map<string, StakingModel>();
         const failedAddresses: string[] = [];
 
-        const nonUpdateableFields = [
-            'address',
-            'rewardTokenId',
-            'farmingTokenId',
-            'farmTokenCollection',
-        ];
-
         for (const partial of partialStakingFarms) {
             if (!partial.address) {
                 continue;
@@ -187,11 +184,11 @@ export class StakingStateHandler {
             const updatedStakingFarm = { ...stakingFarm };
 
             for (const field of updateMask.paths) {
-                if (partial[field] === undefined) {
+                if (!Object.prototype.hasOwnProperty.call(partial, field)) {
                     continue;
                 }
 
-                if (nonUpdateableFields.includes(field)) {
+                if (STAKING_IMMUTABLE_FIELDS.has(field as keyof StakingModel)) {
                     continue;
                 }
 

--- a/src/microservices/dex-state/services/handlers/timekeeping.state.handler.ts
+++ b/src/microservices/dex-state/services/handlers/timekeeping.state.handler.ts
@@ -21,15 +21,13 @@ export class TimekeepingStateHandler {
 
         if (this.stateStore.farms.has(address)) {
             time = { ...this.stateStore.farms.get(address).time };
-        }
-
-        if (this.stateStore.stakingFarms.has(address)) {
+        } else if (this.stateStore.stakingFarms.has(address)) {
             time = { ...this.stateStore.stakingFarms.get(address).time };
-        }
-
-        const feesCollector = this.stateStore.feesCollector;
-        if (feesCollector && feesCollector.address === address) {
-            time = { ...feesCollector.time };
+        } else {
+            const feesCollector = this.stateStore.feesCollector;
+            if (feesCollector && feesCollector.address === address) {
+                time = { ...feesCollector.time };
+            }
         }
 
         if (time === undefined) {

--- a/src/microservices/dex-state/services/handlers/tokens.state.handler.ts
+++ b/src/microservices/dex-state/services/handlers/tokens.state.handler.ts
@@ -15,6 +15,10 @@ import {
 import { sortKeysByField } from '../../utils/sort.utils';
 import { StateStore } from '../state.store';
 
+const TOKEN_IMMUTABLE_FIELDS: ReadonlySet<keyof EsdtToken> = new Set<
+    keyof EsdtToken
+>(['identifier', 'decimals', 'type']);
+
 const TOKEN_SORT_FIELD_MAP = {
     [TokenSortField.TOKENS_SORT_PRICE]: 'price',
     [TokenSortField.TOKENS_SORT_VOLUME]: 'volumeUSD24h',
@@ -33,7 +37,7 @@ const TOKEN_SORT_FIELD_MAP = {
 
 @Injectable()
 export class TokensStateHandler {
-    constructor(private readonly stateStore: StateStore) {}
+    constructor(private readonly stateStore: StateStore) { }
 
     getTokens(tokenIDs: string[], fields: string[] = []): Tokens {
         const result: Tokens = {
@@ -170,8 +174,6 @@ export class TokensStateHandler {
         const updatedTokens = new Map<string, EsdtToken>();
         const failedIdentifiers: string[] = [];
 
-        const nonUpdateableFields = ['identifier', 'decimals', 'type'];
-
         for (const partial of partialTokens) {
             if (!partial.identifier) {
                 continue;
@@ -187,11 +189,11 @@ export class TokensStateHandler {
             const updatedToken = { ...token };
 
             for (const field of updateMask.paths) {
-                if (partial[field] === undefined) {
+                if (!Object.prototype.hasOwnProperty.call(partial, field)) {
                     continue;
                 }
 
-                if (nonUpdateableFields.includes(field)) {
+                if (TOKEN_IMMUTABLE_FIELDS.has(field as keyof EsdtToken)) {
                     continue;
                 }
 

--- a/src/microservices/dex-state/services/state.initialization.service.ts
+++ b/src/microservices/dex-state/services/state.initialization.service.ts
@@ -125,6 +125,7 @@ export class StateInitializationService {
 
             if (pair && completeFarm.rewardType !== FarmRewardType.DEPRECATED) {
                 const updatedPair = { ...pair };
+                updatedPair.compoundedAPR = { ...updatedPair.compoundedAPR };
                 updatedPair.hasFarms = true;
                 updatedPair.farmAddress = completeFarm.address;
                 updatedPair.farmRewardCollection =
@@ -174,6 +175,7 @@ export class StateInitializationService {
 
             if (pair && stakingFarm) {
                 const updatedPair = { ...pair };
+                updatedPair.compoundedAPR = { ...updatedPair.compoundedAPR };
                 updatedPair.hasDualFarms = true;
                 updatedPair.stakingProxyAddress = stakingProxy.address;
                 updatedPair.dualFarmRewardTokenId = stakingProxy.stakingTokenId;

--- a/src/modules/pair/services/pair.service.ts
+++ b/src/modules/pair/services/pair.service.ts
@@ -1,7 +1,9 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
 import { mxConfig } from 'src/config';
 import { BigNumber } from 'bignumber.js';
-import { LiquidityPosition, LockedTokensInfo } from '../models/pair.model';
+import { LiquidityPosition } from '../models/pair.model';
 import {
     quote,
     getAmountOut,
@@ -17,8 +19,6 @@ import {
     EsdtToken,
     EsdtTokenType,
 } from 'src/modules/tokens/models/esdtToken.model';
-import { SimpleLockModel } from 'src/modules/simple-lock/models/simple.lock.model';
-import { ContextGetterService } from 'src/services/context/context.getter.service';
 import { PairComputeService } from './pair.compute.service';
 import { RouterAbiService } from 'src/modules/router/services/router.abi.service';
 import { TokenService } from 'src/modules/tokens/services/token.service';
@@ -38,8 +38,8 @@ export class PairService {
         @Inject(forwardRef(() => TokenService))
         private readonly tokenService: TokenService,
         private readonly cachingService: CacheService,
-        private readonly contextGetter: ContextGetterService,
         private readonly pairsState: PairsStateService,
+        @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
     ) {}
 
     async getFirstToken(pairAddress: string): Promise<EsdtToken> {
@@ -274,7 +274,12 @@ export class PairService {
             if (token && token.type === EsdtTokenType.FungibleLpToken) {
                 returnedData = token.pairAddress;
             }
-        } catch (error) {}
+        } catch (error) {
+            this.logger.warn(
+                `Failed to get pair address for LP token ${tokenID}: ${error.message}`,
+                { context: PairService.name },
+            );
+        }
 
         await this.cachingService.set(
             `${tokenID}.pairAddress`,
@@ -289,37 +294,4 @@ export class PairService {
             throw new Error('You are not the owner.');
     }
 
-    // TODO : remove after adding refresh to state rpc
-    async getLockedTokensInfo(pairAddress: string): Promise<LockedTokensInfo> {
-        const [
-            lockingScAddress,
-            unlockEpoch,
-            lockingDeadlineEpoch,
-            currentEpoch,
-        ] = await Promise.all([
-            this.pairAbi.lockingScAddress(pairAddress),
-            this.pairAbi.unlockEpoch(pairAddress),
-            this.pairAbi.lockingDeadlineEpoch(pairAddress),
-            this.contextGetter.getCurrentEpoch(),
-        ]);
-
-        if (
-            lockingScAddress === undefined ||
-            unlockEpoch === undefined ||
-            lockingDeadlineEpoch === undefined
-        ) {
-            return undefined;
-        }
-
-        if (currentEpoch >= lockingDeadlineEpoch) {
-            return undefined;
-        }
-
-        return new LockedTokensInfo({
-            lockingScAddress: lockingScAddress,
-            lockingSC: new SimpleLockModel({ address: lockingScAddress }),
-            unlockEpoch,
-            lockingDeadlineEpoch,
-        });
-    }
 }

--- a/src/modules/state/controllers/state.controller.ts
+++ b/src/modules/state/controllers/state.controller.ts
@@ -2,9 +2,11 @@ import {
     Body,
     Controller,
     Post,
+    UseGuards,
     UsePipes,
     ValidationPipe,
 } from '@nestjs/common';
+import { JwtOrNativeAdminGuard } from 'src/modules/auth/jwt.or.native.admin.guard';
 import { QueueTasksRequest } from '../entities/state.tasks.entities';
 import { StateTasksService } from '../services/state.tasks.service';
 
@@ -12,6 +14,7 @@ import { StateTasksService } from '../services/state.tasks.service';
 export class StateController {
     constructor(private readonly stateTasks: StateTasksService) {}
 
+    @UseGuards(JwtOrNativeAdminGuard)
     @UsePipes(
         new ValidationPipe({
             transform: true,

--- a/src/modules/state/entities/state.tasks.entities.ts
+++ b/src/modules/state/entities/state.tasks.entities.ts
@@ -46,10 +46,11 @@ export const StateTaskPriority: Record<StateTasks, number> = {
 export const StateTasksWithArguments = [
     StateTasks.INDEX_LP_TOKEN,
     StateTasks.INDEX_PAIR,
-    StateTasks.BROADCAST_PRICE_UPDATES,
     StateTasks.REFRESH_FARM,
     StateTasks.REFRESH_STAKING_FARM,
 ];
+
+export const PENDING_PRICE_UPDATES_KEY = 'dexService.pendingPriceUpdates';
 
 export class TaskDto {
     @IsNotEmpty()

--- a/src/modules/state/services/state.grpc.client.service.ts
+++ b/src/modules/state/services/state.grpc.client.service.ts
@@ -1,10 +1,13 @@
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
+import { Observable, timeout } from 'rxjs';
 import {
     DEX_STATE_SERVICE_NAME,
     IDexStateServiceClient,
 } from 'src/microservices/dex-state/interfaces/dex_state.interfaces';
 import { DEX_STATE_CLIENT } from '../state.grpc.client.module';
+
+const GRPC_DEADLINE_MS = 10_000;
 
 @Injectable()
 export class StateGrpcClientService implements OnModuleInit {
@@ -13,8 +16,18 @@ export class StateGrpcClientService implements OnModuleInit {
     constructor(@Inject(DEX_STATE_CLIENT) private clientGrpc: ClientGrpc) {}
 
     onModuleInit() {
-        this.client = this.clientGrpc.getService<IDexStateServiceClient>(
+        const rawClient = this.clientGrpc.getService<IDexStateServiceClient>(
             DEX_STATE_SERVICE_NAME,
         );
+        this.client = new Proxy(rawClient, {
+            get(target, prop) {
+                const fn = (target as any)[prop];
+                if (typeof fn !== 'function') return fn;
+                return (...args: any[]) =>
+                    (fn.apply(target, args) as Observable<any>).pipe(
+                        timeout(GRPC_DEADLINE_MS),
+                    );
+            },
+        }) as IDexStateServiceClient;
     }
 }

--- a/src/modules/state/services/state.sync.service.ts
+++ b/src/modules/state/services/state.sync.service.ts
@@ -367,7 +367,7 @@ export class StateSyncService {
         return result;
     }
 
-    async getFeesCollectorFeesAndWeekyRewards(
+    async getFeesCollectorFeesAndWeeklyRewards(
         feesCollector: FeesCollectorModel,
     ): Promise<Partial<FeesCollectorModel>> {
         const time = await this.weeklyRewardsSync.getWeekTimekeeping(

--- a/src/modules/state/services/state.tasks.service.ts
+++ b/src/modules/state/services/state.tasks.service.ts
@@ -20,6 +20,7 @@ import { FeesCollectorStateService } from './fees.collector.state.service';
 import { StateService } from './state.service';
 import { StakingStateService } from './staking.state.service';
 import {
+    PENDING_PRICE_UPDATES_KEY,
     StateTaskPriority,
     StateTasks,
     StateTasksWithArguments,
@@ -30,8 +31,16 @@ import { FarmModelV2 } from 'src/modules/farm/models/farm.v2.model';
 import { StakingModel } from 'src/modules/staking/models/staking.model';
 
 export const STATE_TASKS_CACHE_KEY = 'dexService.stateTasks';
+const TASK_RETRY_COUNT_KEY_PREFIX = 'dexService.taskRetryCount';
+const MAX_TASK_RETRIES = 5;
+const TASK_RETRY_TTL_SECONDS = 86400;
 const INDEX_LP_MAX_ATTEMPTS = 60;
 const PAIR_REFRESH_CONCURRENCY = 50;
+
+function getTaskRetryKey(task: TaskDto): string {
+    const base = `${TASK_RETRY_COUNT_KEY_PREFIX}:${task.name}`;
+    return task.args?.length ? `${base}:${task.args.join(':')}` : base;
+}
 
 @Injectable()
 export class StateTasksService {
@@ -57,6 +66,28 @@ export class StateTasksService {
                 !task.args?.length
             ) {
                 throw new Error(`Task '${task.name}' requires an argument`);
+            }
+
+            if (task.name === StateTasks.BROADCAST_PRICE_UPDATES) {
+                if (task.args?.length) {
+                    const tokenIDs = JSON.parse(task.args[0]) as string[];
+                    await this.cacheService.addToSet(
+                        PENDING_PRICE_UPDATES_KEY,
+                        tokenIDs,
+                    );
+                }
+
+                await this.cacheService.zAdd(
+                    STATE_TASKS_CACHE_KEY,
+                    JSON.stringify({ name: StateTasks.BROADCAST_PRICE_UPDATES }),
+                    StateTaskPriority[task.name],
+                );
+
+                this.logger.info(
+                    `State task ${task.name} added to queue`,
+                    { context: StateTasksService.name },
+                );
+                continue;
             }
 
             const serializedTask = JSON.stringify(instanceToPlain(task));
@@ -113,9 +144,7 @@ export class StateTasksService {
                     await this.updateSnapshot();
                     break;
                 case StateTasks.BROADCAST_PRICE_UPDATES:
-                    await this.broadcastTokensPriceUpdates(
-                        JSON.parse(task.args[0]),
-                    );
+                    await this.broadcastTokensPriceUpdates();
                     break;
                 case StateTasks.REFRESH_PAIR_RESERVES:
                     await this.refreshPairReserves();
@@ -141,14 +170,33 @@ export class StateTasksService {
                 default:
                     break;
             }
+
+            await this.cacheService.deleteRemote(getTaskRetryKey(task));
         } catch (error) {
             this.logger.error(`Failed processing task "${task.name}"`, error);
 
-            await this.cacheService.zAdd(
-                STATE_TASKS_CACHE_KEY,
-                JSON.stringify(instanceToPlain(task)),
-                StateTaskPriority[task.name],
+            const retryCount = await this.cacheService.incrementRemote(
+                getTaskRetryKey(task),
+                TASK_RETRY_TTL_SECONDS,
             );
+
+            if (retryCount >= MAX_TASK_RETRIES) {
+                this.logger.error(
+                    `Task "${task.name}" dead-lettered after ${MAX_TASK_RETRIES} failed attempts`,
+                    { task: instanceToPlain(task), context: StateTasksService.name },
+                );
+                await this.cacheService.deleteRemote(getTaskRetryKey(task));
+            } else {
+                this.logger.warn(
+                    `Re-queuing task "${task.name}" (attempt ${retryCount}/${MAX_TASK_RETRIES})`,
+                    { context: StateTasksService.name },
+                );
+                await this.cacheService.zAdd(
+                    STATE_TASKS_CACHE_KEY,
+                    JSON.stringify(instanceToPlain(task)),
+                    StateTaskPriority[task.name],
+                );
+            }
         } finally {
             profiler.stop(`Finished processing task "${task.name}" in`, true);
         }
@@ -314,7 +362,17 @@ export class StateTasksService {
         });
     }
 
-    async broadcastTokensPriceUpdates(tokenIDs: string[]): Promise<void> {
+    async broadcastTokensPriceUpdates(): Promise<void> {
+        const tokenIDs = await this.cacheService.getSetMembers(
+            PENDING_PRICE_UPDATES_KEY,
+        );
+
+        if (tokenIDs.length === 0) {
+            return;
+        }
+
+        await this.cacheService.deleteRemote(PENDING_PRICE_UPDATES_KEY);
+
         const tokens = await this.tokensState.getTokens(tokenIDs, [
             'identifier',
             'price',

--- a/src/modules/state/services/state.tasks.service.ts
+++ b/src/modules/state/services/state.tasks.service.ts
@@ -315,12 +315,16 @@ export class StateTasksService {
     }
 
     async broadcastTokensPriceUpdates(tokenIDs: string[]): Promise<void> {
-        const priceUpdates: string[][] = [];
-        const tokens = await this.tokensState.getTokens(tokenIDs, ['price']);
+        const tokens = await this.tokensState.getTokens(tokenIDs, [
+            'identifier',
+            'price',
+        ]);
 
-        tokenIDs.forEach((tokenID, index) =>
-            priceUpdates.push([tokenID, tokens[index].price]),
-        );
+        const priceByID = new Map(tokens.map((t) => [t.identifier, t.price]));
+
+        const priceUpdates: string[][] = tokenIDs
+            .filter((id) => priceByID.has(id))
+            .map((id) => [id, priceByID.get(id)]);
 
         await this.pubSub.publish(TOKENS_PRICE_UPDATE_EVENT, {
             priceUpdates,
@@ -481,7 +485,7 @@ export class StateTasksService {
         ]);
 
         const feesCollectorUpdates =
-            await this.syncService.getFeesCollectorFeesAndWeekyRewards(
+            await this.syncService.getFeesCollectorFeesAndWeeklyRewards(
                 feesCollector,
             );
 

--- a/src/modules/state/utils/state.task.utils.ts
+++ b/src/modules/state/utils/state.task.utils.ts
@@ -1,7 +1,9 @@
 import { instanceToPlain } from 'class-transformer';
 import { CacheService } from 'src/services/caching/cache.service';
 import {
+    PENDING_PRICE_UPDATES_KEY,
     StateTaskPriority,
+    StateTasks,
     StateTasksWithArguments,
     TaskDto,
 } from '../entities/state.tasks.entities';
@@ -14,6 +16,20 @@ export async function queueStateTasks(
     for (const task of tasks) {
         if (StateTasksWithArguments.includes(task.name) && !task.args?.length) {
             throw new Error(`Task '${task.name}' requires an argument`);
+        }
+
+        if (task.name === StateTasks.BROADCAST_PRICE_UPDATES) {
+            if (task.args?.length) {
+                const tokenIDs = JSON.parse(task.args[0]) as string[];
+                await cacheService.addToSet(PENDING_PRICE_UPDATES_KEY, tokenIDs);
+            }
+
+            await cacheService.zAdd(
+                STATE_TASKS_CACHE_KEY,
+                JSON.stringify({ name: StateTasks.BROADCAST_PRICE_UPDATES }),
+                StateTaskPriority[task.name],
+            );
+            continue;
         }
 
         const serializedTask = JSON.stringify(instanceToPlain(task));


### PR DESCRIPTION
## Reasoning
- Several correctness bugs were found during testing of the state-rpc architecture
- Security hardening was required on the admin endpoint exposed by `StateController`
- The task queue had no retry limit, meaning failed tasks would be re-queued indefinitely causing potential queue storms

## Proposed Changes
- Fix blocksInWeek magic number: replace 14440 * 7 with constantsConfig.BLOCKS_PER_WEEK
- Fix shallow copy mutation of compoundedAPR in farms handler, staking handler, and state initialization to prevent shared-object corruption across updates
- Fix TimekeepingStateHandler sequential if blocks converted to else if chain to prevent staking farm values silently overwriting farm values
- Fix index-based token price mapping in broadcastTokensPriceUpdates replaced with a Map keyed by identifier to prevent price misalignment when tokens are missing or reordered
- Add @UseGuards(JwtOrNativeAdminGuard) to POST /state/queue-tasks — endpoint was publicly accessible without authentication
- Replace per-handler nonUpdateableFields string arrays with module-level *_IMMUTABLE_FIELDS: ReadonlySet<keyof Model> typed against the model — typos produce compile errors, new fields are updateable automatically
- Add 10-second gRPC call deadline via a Proxy on StateGrpcClientService that pipes timeout(10_000) onto every method's Observable — covers all ~30 call sites automatically
- Add task retry limit (max 5 attempts) with dead-letter logging: retry count stored in a separate Redis key (dexService.taskRetryCount:<name>[:<args>]) so queue member strings remain unchanged and Redis sorted set deduplication is preserved for all task types
- Extract BROADCAST_PRICE_UPDATES deduplication logic into the shared queueStateTasks util and add PENDING_PRICE_UPDATES_KEY constant to state.tasks.entities.ts
- Add RABBITMQ_EXCHANGE_STATE and RABBITMQ_STATE_QUEUE to .env.example

## How to test
- Run the full unit test suite (npm run test) — 345 tests across 46 suites must pass
- Start the state microservice and public API, trigger a pair reserve update via RabbitMQ and verify prices update correctly in GraphQL
- Call POST /state/queue-tasks without a valid JWT/native auth token and verify a 401 is returned
- Trigger a task that consistently fails (e.g. point REFRESH_FARM at a non-existent address) and verify it is dead-lettered after 5 attempts with an error log, and not re-queued further
- Verify a hung gRPC server causes calls to fail with TimeoutError after ~10 seconds rather than blocking indefinitely