### PR TITLE
[MEX-966] Default sender in xoxno aggregator

### DIFF
--- a/src/modules/auto-router/services/auto-router.service.ts
+++ b/src/modules/auto-router/services/auto-router.service.ts
@@ -50,6 +50,7 @@ import {
     XoxnoQuoteModel,
     XoxnoPathModel,
 } from '../models/xoxno-aggregator.model';
+import { Address } from '@multiversx/sdk-core/out';
 
 @Injectable()
 export class AutoRouterService {
@@ -548,9 +549,9 @@ export class AutoRouterService {
     ): Promise<TransactionModel[]> {
         if (parent.smartSwap !== undefined) {
             if (parent.smartSwap.source === SmartSwapSource.XOXNO) {
-                if (!parent.transactions?.[0]) {
+                if (!parent.transactions?.[0] || !Address.isValid(sender)) {
                     throw new Error(
-                        'XOXNO smart swap selected but transaction is missing',
+                        'XOXNO smart swap selected but transaction or sender is missing',
                     );
                 }
 

--- a/src/modules/auto-router/services/xoxno-aggregator.service.ts
+++ b/src/modules/auto-router/services/xoxno-aggregator.service.ts
@@ -39,10 +39,6 @@ export class XoxnoAggregatorService {
 
         const profiler = new PerformanceProfiler(`xoxno-aggregator`);
 
-        if (sender === undefined || !Address.isValid(sender)) {
-            sender = Address.Zero().toBech32();
-        }
-
         try {
             const params: Record<string, string | number | boolean> = {
                 from: tokenIn,
@@ -50,8 +46,11 @@ export class XoxnoAggregatorService {
                 amountIn,
                 slippage,
                 includePaths: true,
-                sender,
             };
+
+            if (sender !== undefined && Address.isValid(sender)) {
+                params.sender = sender;
+            }
 
             if (this.referralID !== undefined) {
                 params.referralId = this.referralID;

--- a/src/modules/auto-router/specs/xoxno-aggregator.service.spec.ts
+++ b/src/modules/auto-router/specs/xoxno-aggregator.service.spec.ts
@@ -50,6 +50,8 @@ describe('XoxnoAggregatorService', () => {
         const tokenOut = 'USDC-123456';
         const amountIn = '1000000000000000000';
         const slippage = 0.01;
+        const sender =
+            'erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu';
 
         it('should return undefined if base URL is not configured', async () => {
             apiConfigServiceMock.getXoxnoApiUrl.mockReturnValue(
@@ -74,7 +76,13 @@ describe('XoxnoAggregatorService', () => {
                 data: { amountOut: '2000' },
             });
 
-            await service.getQuote(tokenIn, tokenOut, amountIn, slippage);
+            await service.getQuote(
+                tokenIn,
+                tokenOut,
+                amountIn,
+                slippage,
+                sender,
+            );
 
             expect(mockedAxios.get).toHaveBeenCalledWith(
                 `${mockBaseUrl}/quote`,


### PR DESCRIPTION
## Reasoning
- using a default sender in xoxno quote would add response time because of transaction compute and return
- using a sender without actual balance amounts to execute the transaction just add more load on the response time
  
## Proposed Changes
- use a valid sender only when the client graphql query provides one

## How to test
- omit sender from query; response should not return a transaction
